### PR TITLE
Introduced Node and xpath-like selector API.

### DIFF
--- a/src/main/java/walkingkooka/naming/Names.java
+++ b/src/main/java/walkingkooka/naming/Names.java
@@ -31,7 +31,7 @@ final public class Names implements PublicStaticHelper {
     /**
      * {@see StringName}
      */
-    public static Name string(final String name) {
+    public static StringName string(final String name) {
         return StringName.with(name);
     }
 

--- a/src/main/java/walkingkooka/test/HashCodeEqualsDefinedTestCase.java
+++ b/src/main/java/walkingkooka/test/HashCodeEqualsDefinedTestCase.java
@@ -78,5 +78,15 @@ abstract public class HashCodeEqualsDefinedTestCase<T extends HashCodeEqualsDefi
         this.checkToStringOverridden(this.type());
     }
 
+    protected void checkEquals(final T first, final Object second) {
+        assertEquals(first, second);
+        assertEquals(second, first);
+    }
+
+    protected void checkNotEquals(final T first, final Object second) {
+        assertNotEquals(first, second);
+        assertNotEquals(second, first);
+    }
+
     abstract protected Class<? extends T> type();
 }

--- a/src/main/java/walkingkooka/text/CharSequences.java
+++ b/src/main/java/walkingkooka/text/CharSequences.java
@@ -204,10 +204,16 @@ final public class CharSequences implements PublicStaticHelper {
     }
 
     /**
-     * Helper that combines {@link #escape} and adds double quotes.
+     * Helper that combines {@link #escape} and adds double quotes if required and escapes.
      */
     private static CharSequence quoteAndEscape2(final CharSequence chars) {
-        return "\"" + CharSequences.escape(chars) + '"';
+        final boolean quoted = startsWith(chars, "\"") && endsWith(chars, "\"");
+
+        return new StringBuilder()
+                .append('"')
+                .append(CharSequences.escape(quoted ? chars.subSequence(1, chars.length() -1) : chars))
+                .append('"')
+                .toString();
     }
 
     /**
@@ -227,9 +233,7 @@ final public class CharSequences implements PublicStaticHelper {
 
         if (null != chars) {
             if (Whitespace.has(chars)) {
-                result = new StringBuilder(chars.length() + 2).append('"')
-                        .append(chars)
-                        .append('"');
+                result = quoteIfChars(chars);
             }
         }
 

--- a/src/main/java/walkingkooka/tree/FakeNode.java
+++ b/src/main/java/walkingkooka/tree/FakeNode.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree;
+
+import walkingkooka.naming.Name;
+import walkingkooka.test.Fake;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeNode<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        implements Node<N, NAME, ANAME, AVALUE>, Fake {
+
+    @Override public NAME name() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override public int index() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override public Optional<N> parent() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override public N setParent(Optional<N> parent) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override public boolean isRoot() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override public List<N> children() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override public N setChildren(List<N> children) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override public Map<ANAME, AVALUE> attributes() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override public N setAttributes(Map<ANAME, AVALUE> attributes) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override public N create(NAME name) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/walkingkooka/tree/Node.java
+++ b/src/main/java/walkingkooka/tree/Node.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.naming.HasName;
+import walkingkooka.naming.Name;
+import walkingkooka.test.HashCodeEqualsDefined;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A node is part of a tree holding branches and leaves all of which are nodes.
+ */
+public interface Node<N extends Node<N, NAME, ANAME, AVALUE>,
+        NAME extends Name,
+        ANAME extends Name,
+        AVALUE>
+        extends HasName<NAME>, HashCodeEqualsDefined {
+
+    /**
+     * Returns the name of this node, or null if one is not present.
+     */
+    NAME name();
+
+    /**
+     * If not the root returns the index of this node, or -1 for root.
+     */
+    default int index() {
+        int index = -1;
+
+        final Optional<N> parent = this.parent();
+        if (parent.isPresent()) {
+            index = parent.get().children().indexOf(this);
+            if (-1 == index) {
+                throw new NodeException("Child not present in children of parent=" + this);
+            }
+        }
+
+        return index;
+    }
+
+    /**
+     * Returns the parent {@Link Node}.
+     */
+    Optional<N> parent();
+
+    /**
+     * Sets or replaces the parent of this node.
+     * If the new parent is the same as the original, the original Node is returned.
+     */
+    N setParent(Optional<N> parent);
+
+    default N removeParent() {
+        return this.setParent(Optional.empty());
+    }
+
+    default N setParent(final N parent) {
+        return this.setParent(Optional.of(parent));
+    }
+
+    /**
+     * Returns true if this node is the root.
+     */
+    default boolean isRoot() {
+        return !this.parent().isPresent();
+    }
+
+    /**
+     * Returns the children of this node.
+     */
+    List<N> children();
+
+    /**
+     * Sets new children.
+     */
+    N setChildren(final List<N> children);
+
+    /**
+     * Appends a new child.
+     */
+    default N appendChild(final N child) {
+        Objects.requireNonNull(child, "child");
+
+        final List<N> newChildren = Lists.array();
+        newChildren.addAll(this.children());
+        newChildren.add(child);
+        return this.setChildren(newChildren);
+    }
+
+    /**
+     * Replaces an existing child with a new one.
+     */
+    default N replaceChild(final N oldChild, final N newChild) {
+        Objects.requireNonNull(oldChild, "oldChild");
+        Objects.requireNonNull(newChild, "newChild");
+
+        final Optional<N> parent = oldChild.parent();
+        if (!parent.isPresent()) {
+            throw new IllegalArgumentException("Old child has no parent=" + oldChild);
+        }
+        if (!parent.get().equals(this)) {
+            throw new IllegalArgumentException("Old child has different parent=" + oldChild);
+        }
+
+        // replace
+        final List<N> newChildren = Lists.array();
+        newChildren.addAll(this.children());
+        newChildren.set(oldChild.index(), newChild);
+
+        return this.setChildren(newChildren);
+    }
+
+    /**
+     * Removes an existing child.
+     */
+    default N removeChild(final N child) {
+        Objects.requireNonNull(child, "child");
+
+        final Optional<N> parent = child.parent();
+        if (!parent.isPresent()) {
+            throw new IllegalArgumentException("Child has no parent=" + child);
+        }
+        if (!parent.get().equals(this)) {
+            throw new IllegalArgumentException("Child has different parent=" + child);
+        }
+
+        // replace
+        final List<N> newChildren = Lists.array();
+        newChildren.addAll(this.children());
+        newChildren.remove(child.index());
+
+        return this.setChildren(newChildren);
+    }
+
+    /**
+     * Returns the attributes of this node.
+     */
+    Map<ANAME, AVALUE> attributes();
+
+    /**
+     * Sets or replaces the attributes.
+     */
+    N setAttributes(final Map<ANAME, AVALUE> attributes);
+
+    /**
+     * Creates a new node.
+     */
+    N create(NAME name);
+
+    /**
+     * Returns the previous sibling if one exists.
+     */
+    default Optional<N> previousSibling() {
+        Optional<N> result = Optional.empty();
+
+        final Optional<N> parent = this.parent();
+        if (parent.isPresent()) {
+            final List<N> children = parent.get().children();
+            final int index = this.index();
+            if (index > 0) {
+                result = Optional.of(children.get(index - 1));
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Returns the next sibling if one exists.
+     */
+    default Optional<N> nextSibling() {
+        Optional<N> result = Optional.empty();
+
+        final Optional<N> parent = this.parent();
+        if (parent.isPresent()) {
+            final List<N> children = parent.get().children();
+            final int index = this.index();
+            if (index + 1 < children.size()) {
+                result = Optional.of(children.get(index + 1));
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/walkingkooka/tree/NodeEqualityTestCase.java
+++ b/src/main/java/walkingkooka/tree/NodeEqualityTestCase.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree;
+
+import org.junit.Test;
+import walkingkooka.naming.Name;
+import walkingkooka.test.HashCodeEqualsDefinedTestCase;
+
+import java.util.Map;
+
+abstract public class NodeEqualityTestCase<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> extends HashCodeEqualsDefinedTestCase<N> {
+
+    @Test
+    public void testNoChildren(){
+        final N node1 = this.createNode(0);
+        final N node2 = this.createNode(0);
+        this.checkEquals(node1, node2);
+    }
+
+    @Test
+    public void testExtraChildDifferent(){
+        final N node1 = this.createNode(0);
+        final N node2 = this.createNode(0).appendChild(this.createNode(1));
+        this.checkNotEquals(node1, node2);
+    }
+
+    @Test
+    public void testSameChildren() {
+        final N child = this.createNode(1);
+
+        final N node1 = this.createNode(0).appendChild(child);
+        final N node2 = this.createNode(0).appendChild(child);
+        this.checkEquals(node1, node2);
+    }
+
+    @Test
+    public void testDifferentChildren() {
+        final N node1 = this.createNode(0).appendChild(this.createNode(1));
+        final N node2 = this.createNode(0).appendChild(this.createNode(99));
+        this.checkNotEquals(node1, node2);
+    }
+
+    @Test
+    public void testDifferentChildrenSameGrandChild() {
+        final N node1 = this.createNode(0).appendChild(this.createNode(100).appendChild(this.createNode(200)));
+        final N node2 = this.createNode(0).appendChild(this.createNode(199).appendChild(this.createNode(200)));
+        this.checkNotEquals(node1, node2);
+    }
+
+    @Test
+    public void testDifferentChildren2() {
+        final N node1 = this.createNode(0).appendChild(this.createNode(100)).appendChild(this.createNode(200));
+        final N node2 = this.createNode(0).appendChild(this.createNode(199)).appendChild(this.createNode(200));
+        this.checkNotEquals(node1, node2);
+    }
+
+    @Test
+    public void testDifferentGrandChildren() {
+        final N node1 = this.createNode(0).appendChild(this.createNode(100).appendChild(this.createNode(200)));
+        final N node2 = this.createNode(0).appendChild(this.createNode(100).appendChild(this.createNode(299)));
+        this.checkNotEquals(node1, node2);
+    }
+
+    @Test
+    public void testSameAttributes() {
+        final Map<ANAME, AVALUE> attributes = this.createAttributes(0);
+        final N node1 = this.createNode(0).setAttributes(attributes);
+        final N node2 = this.createNode(0).setAttributes(attributes);
+        this.checkEquals(node1, node2);
+    }
+
+    @Test
+    public void testDifferentAttributes() {
+        final N node1 = this.createNode(0).setAttributes(this.createAttributes(0));
+        final N node2 = this.createNode(0).setAttributes(this.createAttributes(1));
+        this.checkNotEquals(node1, node2);
+    }
+
+    @Test
+    public void testChildWithDifferentAttributes() {
+        final N node1 = this.createNode(0).appendChild(this.createNode(100)).setAttributes(this.createAttributes(0));
+        final N node2 = this.createNode(0).appendChild(this.createNode(100)).setAttributes(this.createAttributes(1));
+        this.checkNotEquals(node1, node2);
+    }
+
+    protected abstract N createNode(int i);
+
+    protected abstract Map<ANAME, AVALUE> createAttributes(int i);
+}

--- a/src/main/java/walkingkooka/tree/NodeException.java
+++ b/src/main/java/walkingkooka/tree/NodeException.java
@@ -15,37 +15,21 @@
  *
  */
 
-package walkingkooka.naming;
+package walkingkooka.tree;
 
-import walkingkooka.type.PublicStaticHelper;
+import walkingkooka.SystemException;
 
-final public class Paths implements PublicStaticHelper {
+public class NodeException extends SystemException {
 
-    /**
-     * {@see FakePath}
-     */
-    public static Path fake() {
-        return FakePath.create();
+    protected NodeException() {
+        super();
     }
 
-    /**
-     * {@see PropertiesPath}
-     */
-    public static PropertiesPath properties(final String path) {
-        return PropertiesPath.parse(path);
+    public NodeException(final String message) {
+        super(message);
     }
 
-    /**
-     * {@see StringPath}
-     */
-    public static StringPath string(final String path) {
-        return StringPath.parse(path);
-    }
-
-    /**
-     * stop creation
-     */
-    private Paths() {
-        throw new UnsupportedOperationException();
+    public NodeException(final String message, final Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/main/java/walkingkooka/tree/NodeTestCase.java
+++ b/src/main/java/walkingkooka/tree/NodeTestCase.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree;
+
+import org.junit.Test;
+import walkingkooka.naming.Name;
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertNotSame;
+
+abstract public class NodeTestCase<N extends Node<N, NAME, ANAME, AVALUE>,
+        NAME extends Name,
+        ANAME extends Name,
+        AVALUE extends Object>
+        extends
+        PackagePrivateClassTestCase<N> {
+
+    protected NodeTestCase() {
+        super();
+    }
+
+    @Test final public void testNameCached() {
+        final N node = this.createNode();
+        this.checkCached(node, "name", node.name(), node.name());
+    }
+
+    @Test final public void testParentCached() {
+        final N node = this.createNode();
+        this.checkCached(node, "parent", node.parent(), node.parent());
+    }
+
+    @Test final public void testChildrenCached() {
+        final N node = this.createNode();
+        this.checkCached(node, "children", node.children(), node.children());
+    }
+
+    @Test
+    public void testAppendChild() {
+        final N parent = this.createNode();
+
+        final N child1 = this.createNode();
+        final N parent1 = this.appendChildAndCheck(parent, child1);
+
+        this.checkChildren(parent1, child1.setParent(parent1));
+    }
+
+    @Test
+    public void testAppendChild2() {
+        final N parent = this.createNode();
+
+        final N child1 = this.createNode();
+        final N parent1 = this.appendChildAndCheck(parent, child1);
+
+        final N child2 = this.createNode();
+        final N parent2 = this.appendChildAndCheck(parent1, child2);
+
+        this.checkChildren(parent2, child1.setParent(parent2), child2.setParent(parent2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRemoveChildWithoutParent() {
+        final N parent = this.createNode();
+        final N child = this.createNode();
+
+        parent.removeChild(child);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRemoveChildDifferentParent() {
+        final N parent1 = this.createNode();
+
+        final N parent2 = this.createNode().appendChild(this.createNode());
+        final N childOf2 = parent2.children().get(0);
+
+        parent1.removeChild(childOf2);
+    }
+
+    @Test
+    public void testRemoveChild() {
+        final N parent = this.createNode();
+
+        final N child1 = this.createNode();
+        final N parent1 = this.appendChildAndCheck(parent, child1);
+
+        final N removed1 = this.removeChildAndCheck(parent1, parent1.children().get(0));
+
+        this.checkChildren(removed1);
+    }
+
+    @Test
+    public void testRemoveChildFirst() {
+        this.appendTwoChildrenAndRemove(0);
+    }
+
+    @Test
+    public void testRemoveChildLast() {
+       this.appendTwoChildrenAndRemove(1);
+    }
+
+    private void appendTwoChildrenAndRemove(final int remove) {
+        final N parent = this.createNode();
+
+        final N child1 = this.createNode();
+        final N parent1 = this.appendChildAndCheck(parent, child1);
+
+        final N child2 = this.createNode();
+        final N parent2 = this.appendChildAndCheck(parent1, child2);
+
+        final N removed = parent2.children().get(remove);
+        final N parent3 = this.removeChildAndCheck(parent2, removed);
+
+        this.checkChildren(parent3, removed.setParent(parent3));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testReplaceChildWithoutParent() {
+        final N parent = this.createNode();
+        final N child = this.createNode();
+
+        parent.replaceChild(child, this.createNode());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testReplaceChildDifferentParent() {
+        final N parent1 = this.createNode();
+
+        final N parent2 = this.createNode().appendChild(this.createNode());
+        final N childOf2 = parent2.children().get(0);
+
+        parent1.replaceChild(childOf2, this.createNode());
+    }
+
+    @Test
+    public void testReplaceChild() {
+        final N parent = this.createNode();
+
+        final N child1 = this.createNode();
+        final N child2 = this.createNode();
+
+        final N set = this.setChildrenAndCheck(parent, child1, child2);
+
+        this.checkChildren(set, child1.setParent(set), child1.setParent(set));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setChildrenWithNullFails() {
+        final N parent = this.createNode();
+        parent.setChildren(null);
+    }
+
+    @Test
+    public void testSameChildren() {
+        final N parentBefore = this.appendChildAndCheck(this.createNode(), this.createNode());
+
+        final N parentAfter = parentBefore.setChildren(parentBefore.children());
+        assertSame(parentAfter, parentBefore);
+    }
+
+    @Test
+    public void testSetDifferentChildren() {
+        final N parent = this.createNode();
+
+        final N child1 = this.createNode();
+        final N child2 = this.createNode();
+
+        final N parent1 = this.setChildrenAndCheck(parent, child1, child2);
+
+        final N child3 = this.createNode();
+        final N parent2 = this.setChildrenAndCheck(parent1, child3);
+
+        this.checkChildren(parent2, child3.setParent(parent2));
+    }
+
+    @Test final public void testAttributesCached() {
+        final N node = this.createNode();
+        this.checkCached(node, "attributes", node.attributes(), node.attributes());
+    }
+
+    @Test
+    public void testSetSameAttributes() {
+        final N node = this.createNode();
+        assertSame(node, node.setAttributes(node.attributes()));
+    }
+
+    private <T> void checkCached(final N node, final String property, final T value, final T value2) {
+        if (value != value2) {
+            failNotSame(node + " did not cache " + property, value, value2);
+        }
+    }
+
+    abstract protected N createNode();
+
+    protected void checkParent(final N node, final N parent) {
+        assertSame("parent of " + node, parent, node.parent());
+    }
+
+    protected N appendChildAndCheck(final N parent, final N child) {
+        final N newParent = parent.appendChild(child);
+        assertNotSame("appendChild must not return the same node", newParent, parent);
+
+        final List<N> children = newParent.children();
+        assertNotEquals("children must have at least 1 child", 0, children.size());
+        assertEquals("last child must be the added child", child.name(), children.get(children.size() - 1).name());
+
+        this.checkParentOfChildren(newParent);
+
+        return newParent;
+    }
+
+    protected N removeChildAndCheck(final N parent, final N child) {
+        final N newParent = parent.removeChild(child);
+        assertNotSame("removeChild must not return the same node", newParent, parent);
+
+        final List<N> oldChildren = parent.children();
+        final List<N> newChildren = newParent.children();
+        assertEquals("new children must have 1 less child than old", oldChildren.size(), 1 + newChildren.size());
+
+        this.checkParentOfChildren(newParent);
+
+        return newParent;
+    }
+
+    protected N setChildrenAndCheck(final N parent, final N... children) {
+        final N newParent = parent.setChildren(Arrays.asList(children));
+
+        this.checkParentOfChildren(newParent);
+        this.checkChildren(newParent, children);
+
+        return newParent;
+    }
+
+    protected void checkParentOfChildren(final N parent) {
+        int i = 0;
+        for (N child : parent.children()) {
+            assertSame("parent of child[" + i + "]=" + child, parent, child.parent().get());
+        }
+    }
+
+    protected void checkChildren(final N parent, final N... children) {
+        assertEquals("children of parent", parent.children().size(), children.length);
+        this.checkParentOfChildren(parent);
+    }
+}

--- a/src/main/java/walkingkooka/tree/Nodes.java
+++ b/src/main/java/walkingkooka/tree/Nodes.java
@@ -15,37 +15,22 @@
  *
  */
 
-package walkingkooka.naming;
+package walkingkooka.tree;
 
+import walkingkooka.naming.Name;
 import walkingkooka.type.PublicStaticHelper;
 
-final public class Paths implements PublicStaticHelper {
+final public class Nodes implements PublicStaticHelper {
 
-    /**
-     * {@see FakePath}
-     */
-    public static Path fake() {
-        return FakePath.create();
+    public static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+    Node<N, NAME, ANAME, AVALUE> fake() {
+        return new FakeNode<>();
     }
 
     /**
-     * {@see PropertiesPath}
+     * Stop creation
      */
-    public static PropertiesPath properties(final String path) {
-        return PropertiesPath.parse(path);
-    }
-
-    /**
-     * {@see StringPath}
-     */
-    public static StringPath string(final String path) {
-        return StringPath.parse(path);
-    }
-
-    /**
-     * stop creation
-     */
-    private Paths() {
+    private Nodes() {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/tree/select/AncestorNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/AncestorNodeSelector.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+/**
+ * A {@link NodeSelector} that selects all the ancestors of a given {@link Node} until the root of the graph is reached.
+ */
+final class AncestorNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link AncestorNodeSelector} getter
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> AncestorNodeSelector<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(INSTANCE);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private final static AncestorNodeSelector INSTANCE = new AncestorNodeSelector();
+
+    /**
+     * Private constructor use type safe getter
+     */
+    private AncestorNodeSelector() {
+        super();
+    }
+
+    /**
+     * Private constructor
+     */
+    private AncestorNodeSelector(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        super(selector);
+    }
+
+    // NodeSelector
+
+    NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+         // no point appending a ancestor to another...
+        return selector instanceof AncestorNodeSelector ?
+                this :
+                new AncestorNodeSelector(selector);
+    }
+
+    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        this.matchParent(node, context);
+    }
+
+    @Override
+    void match(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        super.match(node, context);
+
+        this.matchParent(node, context);
+    }
+
+    @Override
+    void toString0(final StringBuilder b, String separator){
+        b.append(separator).append("ancestor");
+        this.toStringNext(b, DEFAULT_AXIS_SEPARATOR);
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof AncestorNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/AndNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/AndNodeSelector.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.collect.set.Sets;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A {@link NodeSelector} that continues to walking the tree, continuously trying the next selector.
+ */
+final class AndNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        LogicalNodeSelector<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link AndNodeSelector} creator
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>,
+            NAME extends Name,
+            ANAME extends Name,
+            AVALUE> NodeSelector<N, NAME, ANAME, AVALUE> with(
+            final List<NodeSelector<N, NAME, ANAME, AVALUE>> selectors) {
+        Objects.requireNonNull(selectors, "selectors");
+
+        final Collection<NodeSelector<N, NAME, ANAME, AVALUE>> unique = gatherUniques(selectors);
+        return unique.size() == 1 ? unique.iterator().next() : new AndNodeSelector<N, NAME, ANAME, AVALUE>(unique);
+    }
+
+    /**
+     * Private constructor called by factory
+     */
+    private AndNodeSelector(final Collection<NodeSelector<N, NAME, ANAME, AVALUE>> selectors) {
+        super(selectors);
+    }
+
+    @Override public Set<N> accept(final N node) {
+        Set<N> all = null;
+
+        for(NodeSelector<N, NAME, ANAME, AVALUE> selector : this.selectors) {
+            final Set<N> current = Sets.ordered();
+            selector.accept(node, new NodeSelectorNodeSelectorContext<>(current));
+
+            if(null==all) {
+                all = current;
+            } else {
+                all.retainAll(current);
+            }
+            if(all.isEmpty()) {
+                break;
+            }
+        }
+
+        return all;
+    }
+
+    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        for(N match : this.accept(node)) {
+            context.match(match);
+        }
+    }
+
+    @Override
+    String operatorToString(){
+        return "&";
+    }
+
+    boolean canBeEqual(final Object other){
+        return other instanceof AndNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/ChildrenNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/ChildrenNodeSelector.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+/**
+ * A {@link NodeSelector} that selects all the direct children of a given {@link Node}.
+ */
+final class ChildrenNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link ChildrenNodeSelector} getter
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> ChildrenNodeSelector<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(ChildrenNodeSelector.INSTANCE);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private final static ChildrenNodeSelector INSTANCE = new ChildrenNodeSelector();
+
+    /**
+     * Private constructor use type safe getter
+     */
+    private ChildrenNodeSelector() {
+        super();
+    }
+
+    /**
+     * Private constructor
+     */
+    private ChildrenNodeSelector(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        super(selector);
+    }
+
+    // NodeSelector
+
+    NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        return new ChildrenNodeSelector(selector);
+    }
+
+    // NodeSelector
+
+    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        this.matchChildren(node, context);
+    }
+
+    // Object
+
+    @Override
+    void toString0(final StringBuilder b, String separator) {
+        b.append(separator).append("child");
+        this.toStringNext(b, DEFAULT_AXIS_SEPARATOR);
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof ChildrenNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/ContainsNodeAttributeValuePredicate.java
+++ b/src/main/java/walkingkooka/tree/select/ContainsNodeAttributeValuePredicate.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.Name;
+import walkingkooka.text.CharSequences;
+import walkingkooka.tree.Node;
+
+/**
+ * A {@link java.util.function.Predicate} that returns true if the attribute contains the value in string form.
+ */
+final class ContainsNodeAttributeValuePredicate<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends NodeAttributeValuePredicate<N, NAME, ANAME, AVALUE> {
+
+    ContainsNodeAttributeValuePredicate(ANAME name, AVALUE value) {
+        super(name, value);
+    }
+
+    @Override
+    boolean test0(final AVALUE value, final AVALUE current) {
+        return current.toString().contains(value.toString());
+    }
+
+    @Override boolean isSameType(final Object other) {
+        return other instanceof ContainsNodeAttributeValuePredicate;
+    }
+
+    @Override String toString0(final ANAME name, final AVALUE value) {
+        // //a[contains(@href, '://')]
+        return "[contains(@" + name + "," + CharSequences.quoteIfChars(value) + ")]";
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/DescendantNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/DescendantNodeSelector.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.Name;
+import walkingkooka.naming.PathSeparator;
+import walkingkooka.tree.Node;
+
+import java.util.Objects;
+
+
+/**
+ * A {@link NodeSelector} that selects all the descendants of a given {@link Node} until all are visited.
+ */
+final class DescendantNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link DescendantNodeSelector} getter
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> DescendantNodeSelector<N, NAME, ANAME, AVALUE> with(final PathSeparator separator) {
+        Objects.requireNonNull(separator, "separator");
+        return new DescendantNodeSelector(separator);
+    }
+
+    /**
+     * Private constructor use type safe getter
+     */
+    private DescendantNodeSelector(final PathSeparator separator) {
+        super();
+        this.separator = separator;
+    }
+
+    /**
+     * Private constructor
+     */
+    private DescendantNodeSelector(final PathSeparator separator, final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        super(selector);
+        this.separator = separator;
+    }
+
+    // NodeSelector
+
+    NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        // no point appending a descending to another...
+        return selector instanceof DescendantNodeSelector ?
+                this :
+                new DescendantNodeSelector(this.separator, selector);
+    }
+
+    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        this.matchChildren(node, context);
+    }
+
+    @Override
+    void match(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        super.match(node, context);
+        this.matchChildren(node, context);
+    }
+
+    @Override
+    void toString0(final StringBuilder b, String separator) {
+        b.append(this.separator).append(this.separator);
+        this.toStringNext(b, "");
+    }
+
+    // ignore in hashcode / equals...
+    private final PathSeparator separator;
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof DescendantNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/EndsWithNodeAttributeValuePredicate.java
+++ b/src/main/java/walkingkooka/tree/select/EndsWithNodeAttributeValuePredicate.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.Name;
+import walkingkooka.text.CharSequences;
+import walkingkooka.tree.Node;
+
+/**
+ * A {@link java.util.function.Predicate} that returns true if an attribute value ends with the given test value.
+ */
+final class EndsWithNodeAttributeValuePredicate<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends NodeAttributeValuePredicate<N, NAME, ANAME, AVALUE> {
+
+    EndsWithNodeAttributeValuePredicate(ANAME name, AVALUE value) {
+        super(name, value);
+    }
+
+    @Override boolean test0(final AVALUE value, final AVALUE currentValue) {
+        return currentValue.toString().endsWith(value.toString());
+    }
+
+    @Override boolean isSameType(final Object other) {
+        return other instanceof EndsWithNodeAttributeValuePredicate;
+    }
+
+    @Override String toString0(final ANAME name, final AVALUE value) {
+        //[ends-with(@href, '/')]
+        return "[ends-with(@" + name + "," + CharSequences.quoteIfChars(value) + ")]";
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/EqualNodeAttributeValuePredicate.java
+++ b/src/main/java/walkingkooka/tree/select/EqualNodeAttributeValuePredicate.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.Name;
+import walkingkooka.text.CharSequences;
+import walkingkooka.tree.Node;
+
+/**
+ * A {@link java.util.function.Predicate} that matches nodes that contain an attribute with a value.
+ */
+final class EqualNodeAttributeValuePredicate<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends NodeAttributeValuePredicate<N, NAME, ANAME, AVALUE> {
+
+    EqualNodeAttributeValuePredicate(ANAME name, AVALUE value) {
+        super(name, value);
+    }
+
+    @Override boolean test0(final AVALUE value, final AVALUE current) {
+        return current.equals(value);
+    }
+
+    @Override boolean isSameType(final Object other) {
+        return other instanceof EqualNodeAttributeValuePredicate;
+    }
+
+    @Override String toString0(final ANAME name, final AVALUE value) {
+        //[@for="xyz"]
+        return "[@" + name + "=" + CharSequences.quoteIfChars(value) + "]";
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/FollowingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/FollowingNodeSelector.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Optional;
+
+/**
+ * A {@link NodeSelector} that selects all the preceding nodes of a given {@link Node}. It does this by asking all ancestors to process their following
+ * siblings and their ancestors.
+ */
+final class FollowingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link FollowingNodeSelector} getter
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> FollowingNodeSelector<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(FollowingNodeSelector.INSTANCE);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private final static FollowingNodeSelector INSTANCE = new FollowingNodeSelector();
+
+    /**
+     * Private constructor use type safe getter
+     */
+    private FollowingNodeSelector() {
+        super();
+    }
+
+    /**
+     * Private constructor
+     */
+    private FollowingNodeSelector(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        super(selector);
+    }
+
+    // NodeSelector
+
+    NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        // no point appending a following to another...
+        return selector instanceof FollowingNodeSelector ?
+                this :
+                new FollowingNodeSelector(selector);
+    }
+
+    @Override
+    void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        this.matchChildren(node, context);
+        this.matchFollowingSiblings(node, context);
+
+        final Optional<N> parent = node.parent();
+        if (parent.isPresent()) {
+            this.matchFollowingSiblings(parent.get(), context);
+        }
+    }
+
+    @Override
+    void match(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        super.match(node, context);
+        this.matchChildren(node, context);
+    }
+
+    @Override
+    void toString0(final StringBuilder b, String separator){
+        b.append(separator).append("following");
+        this.toStringNext(b, DEFAULT_AXIS_SEPARATOR);
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof FollowingNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/FollowingSiblingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/FollowingSiblingNodeSelector.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+/**
+ * A {@link NodeSelector} that selects all the following siblings of a given {@link Node}.
+ */
+final class FollowingSiblingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link FollowingSiblingNodeSelector} getter
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> FollowingSiblingNodeSelector<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(FollowingSiblingNodeSelector.INSTANCE);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private final static FollowingSiblingNodeSelector INSTANCE = new FollowingSiblingNodeSelector();
+
+    /**
+     * Package private constructor use type safe getter
+     */
+    FollowingSiblingNodeSelector() {
+        super();
+    }
+
+    /**
+     * Private constructor
+     */
+    private FollowingSiblingNodeSelector(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        super(selector);
+    }
+
+    // NodeSelector
+
+    NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        // no point appending a followingSibling to another...
+        return selector instanceof FollowingSiblingNodeSelector ?
+                this :
+                new FollowingSiblingNodeSelector(selector);
+    }
+
+    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        this.matchFollowingSiblings(node, context);
+    }
+
+    @Override
+    void toString0(final StringBuilder b, String separator){
+        b.append(separator).append("following-sibling");
+        this.toStringNext(b, DEFAULT_AXIS_SEPARATOR);
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof FollowingSiblingNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/IndexedChildNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/IndexedChildNodeSelector.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.List;
+
+/**
+ * A {@link NodeSelector} that pushes the child at the index from the {@link Node#children()}. Note that index begins
+ * at 1.
+ */
+final class IndexedChildNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+
+    private final static int INDEX_BIAS = 1;
+
+    /**
+     * Creates a {@link IndexedChildNodeSelector}
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> IndexedChildNodeSelector<N, NAME, ANAME, AVALUE> with(
+            final int index) {
+        if (index < INDEX_BIAS) {
+            throw new IllegalArgumentException("Invalid index " + index + " must begin at " + INDEX_BIAS);
+        }
+        return new IndexedChildNodeSelector<>(index);
+    }
+
+    /**
+     * Private constructor use factory
+     */
+    private IndexedChildNodeSelector(final int index) {
+        super();
+        this.index = index;
+    }
+
+    /**
+     * Private constructor
+     */
+    private IndexedChildNodeSelector(final int index, final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        super(selector);
+        this.index = index;
+    }
+
+    // NodeSelector
+
+    NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        return new IndexedChildNodeSelector(this.index, selector);
+    }
+
+    @Override
+    void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        final List<N> children = node.children();
+        final int index = this.index-INDEX_BIAS;
+        if (index < children.size()) {
+            this.match(children.get(index), context);
+        }
+    }
+
+    private final int index;
+
+    @Override
+    void toString0(final StringBuilder b, String separator){
+        b.append(separator).append("[" + this.index + "]");
+        this.toStringNext(b, "");
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof IndexedChildNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/LogicalNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/LogicalNodeSelector.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.ShouldNeverHappenError;
+import walkingkooka.collect.set.Sets;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A {@link NodeSelector} that continues combines the results of at least two selectors in with some logical operation.
+ */
+abstract class LogicalNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        NodeSelector<N, NAME, ANAME, AVALUE> {
+
+    static <N extends Node<N, NAME, ANAME, AVALUE>,
+            NAME extends Name,
+            ANAME extends Name,
+            AVALUE> Collection<NodeSelector<N, NAME, ANAME, AVALUE>> gatherUniques(
+            final List<NodeSelector<N, NAME, ANAME, AVALUE>> selectors) {
+        final Set<NodeSelector<N, NAME, ANAME, AVALUE>> uniques = Sets.ordered();
+        for(NodeSelector<N, NAME, ANAME, AVALUE> selector : selectors) {
+            Objects.requireNonNull(selector, "selectors must not contain null");
+            uniques.add(selector);
+        }
+        return uniques;
+    }
+
+    final Collection<NodeSelector<N, NAME, ANAME, AVALUE>> selectors;
+
+    LogicalNodeSelector(final Collection<NodeSelector<N, NAME, ANAME, AVALUE>> selectors) {
+        super();
+        this.selectors = selectors;
+    }
+
+    @Override
+    NodeSelector<N, NAME, ANAME, AVALUE> append0(final NodeSelector<N, NAME, ANAME, AVALUE> selector){
+        throw new UnsupportedOperationException();
+    }
+
+    @Override void match(N node, NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        throw new ShouldNeverHappenError(this.getClass().getName() + ".match(Node, NodeSelectorContext)");
+    }
+
+    @Override void toString0(final StringBuilder b, final String separator) {
+        String between = separator;
+        for(NodeSelector<N, NAME, ANAME, AVALUE> selector : this.selectors) {
+            selector.toString0(b, between);
+            between = this.operatorToString();
+        }
+    }
+
+    abstract String operatorToString();
+
+    @Override
+    void toStringNext(final StringBuilder b, final String separator) {
+        // there is no next.
+    }
+
+    // Object
+
+    public final int hashCode() {
+        return this.selectors.hashCode();
+    }
+
+    public final boolean equals(final Object other) {
+        return this == other || this.canBeEqual(other) && this.equals0((LogicalNodeSelector<N, NAME, ANAME, AVALUE>)other);
+    }
+
+    abstract boolean canBeEqual(final Object other);
+
+    private boolean equals0(final LogicalNodeSelector<N, NAME, ANAME, AVALUE>other){
+        return this.selectors.equals(other.selectors);
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/NamedNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/NamedNodeSelector.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.Name;
+import walkingkooka.naming.PathSeparator;
+import walkingkooka.tree.Node;
+
+import java.util.Objects;
+
+/**
+ * A {@link NodeSelector} that selects all the ancestors of a given {@link Node} until the root of the graph is reached.
+ */
+final class NamedNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        UnaryNodeSelector<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link NamedNodeSelector} getter
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>,
+            NAME extends Name,
+            ANAME extends Name,
+            AVALUE> NamedNodeSelector<N, NAME, ANAME, AVALUE> with(final NAME name, final PathSeparator separator) {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(separator, "separator");
+
+        return new NamedNodeSelector<>(name, separator);
+    }
+
+    /**
+     * Private constructor use type safe getter
+     */
+    private NamedNodeSelector(final NAME name, final PathSeparator separator) {
+        super();
+        this.name = name;
+        this.separator = separator;
+    }
+
+    /**
+     * Private constructor
+     */
+    private NamedNodeSelector(final NAME name, final PathSeparator separator, final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        super(selector);
+        this.name = name;
+        this.separator = separator;
+    }
+
+    // NodeSelector
+
+    NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        return new NamedNodeSelector(this.name, this.separator, selector);
+    }
+
+    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        if (this.name.equals(node.name())) {
+            this.match(node, context);
+        }
+    }
+
+    private final NAME name;
+
+    @Override
+    void toString0(final StringBuilder b, String separator) {
+        b.append(this.separator.character()).append(separator).append(this.name.value());
+
+        this.toStringNext(b, this.separator.string());
+    }
+
+    private final PathSeparator separator;
+
+    @Override int hashCode0(final NodeSelector<N, NAME, ANAME, AVALUE> next) {
+        return Objects.hash(next, this.name);
+    }
+
+    @Override boolean canBeEqual(final Object other) {
+        return other instanceof NamedNodeSelector;
+    }
+
+    @Override boolean equals1(final UnaryNodeSelector<N, NAME, ANAME, AVALUE> other) {
+        return other instanceof NamedNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/NodeAttributeValuePredicate.java
+++ b/src/main/java/walkingkooka/tree/select/NodeAttributeValuePredicate.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Objects;
+
+/**
+ * A base attribute that tests an existing attribute value with an expected value.
+ */
+abstract class NodeAttributeValuePredicate<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        implements java.util.function.Predicate<N> {
+
+    NodeAttributeValuePredicate(final ANAME name, final AVALUE value) {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(value, "value");
+
+        this.name = name;
+        this.value = value;
+    }
+
+    private final ANAME name;
+    private final AVALUE value;
+
+    public final boolean test(final N node) {
+        final AVALUE current = node.attributes().get(this.name);
+        return null != current && this.test0(this.value, current);
+    }
+
+    abstract boolean test0(final AVALUE value, final AVALUE current);
+
+    public final int hashCode() {
+        return Objects.hash(this.name, this.value);
+    }
+
+    public final boolean equals(final Object other) {
+        return this == other || this.isSameType(other) && this.equals0(Cast.to(other));
+    }
+
+    abstract boolean isSameType(final Object other);
+
+    final boolean equals0(final NodeAttributeValuePredicate<?, ?, ?, ?> predicate) {
+        return this.name.equals(predicate.name) && this.value.equals(predicate.value);
+    }
+
+    public final String toString() {
+        return this.toString0(this.name, this.value);
+    }
+
+    abstract String toString0(final ANAME name, final AVALUE value);
+}

--- a/src/main/java/walkingkooka/tree/select/NodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelector.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A selector maybe used to select zero or more nodes within a tree given a {@link Node}.
+ */
+public abstract class NodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> {
+
+    /**
+     * Package private to limit sub classing.
+     */
+    NodeSelector(){
+    }
+
+    // NodeSelector
+
+    final NodeSelector<N, NAME, ANAME, AVALUE> append(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        Objects.requireNonNull(selector, "selector");
+
+        return this.append0(selector);
+    }
+
+    abstract NodeSelector<N, NAME, ANAME, AVALUE> append0(final NodeSelector<N, NAME, ANAME, AVALUE> selector);
+
+    /**
+     * Accepts a starting {@link Node} anywhere in a tree returning all matching nodes.
+     */
+    abstract public Set<N> accept(final N node);
+
+    /**
+     * Sub classes must implement this to contain the core logic in testing if a node is match or unmatched.
+     */
+    abstract void accept(N node, NodeSelectorContext<N, NAME, ANAME, AVALUE> context);
+
+    /**
+     * Pushes all siblings {@link Node nodes} until itself is reached.
+     */
+    final void matchPrecedingSiblings(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        final Optional<N> parent = node.parent();
+
+        if (parent.isPresent()) {
+            N current = node;
+            for (; ; ) {
+                final Optional<N> next = current.previousSibling();
+                if (!next.isPresent()) {
+                    break;
+                }
+                current = next.get();
+                this.match(current, context);
+            }
+        }
+    }
+
+    /**
+     * Pushes all siblings {@link Node nodes} after itself.
+     */
+    final void matchFollowingSiblings(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        final Optional<N> parent = node.parent();
+        if (parent.isPresent()) {
+
+            N current = node;
+            for (; ; ) {
+                final Optional<N> next = current.nextSibling();
+                if (!next.isPresent()) {
+                    break;
+                }
+                current = next.get();
+                this.match(current, context);
+            }
+        }
+    }
+
+    /**
+     * Pushes all direct children of the {@link Node node}.`
+     */
+    final void matchChildren(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        for (final N child : node.children()) {
+            this.match(child, context);
+        }
+    }
+
+    /**
+     * Matches the parent only if one is present.
+     */
+    final void matchParent(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        final Optional<N> parent = node.parent();
+        if (parent.isPresent()) {
+            this.match(parent.get(), context);
+        }
+    }
+
+    /**
+     * Handles a matched {@link Node}
+     */
+    abstract void match(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context);
+
+    final static String DEFAULT_AXIS_SEPARATOR = "::";
+
+    /**
+     * Force sub classes to implement.
+     */
+    @Override
+    public final String toString() {
+        final StringBuilder b = new StringBuilder();
+        this.toString0(b, "");
+        return b.toString();
+    }
+
+    abstract void toString0(final StringBuilder b, final String separator);
+
+    abstract void toStringNext(final StringBuilder b, final String separator);
+}

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorBuilder.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorBuilder.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.build.Builder;
+import walkingkooka.build.BuilderException;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.naming.Name;
+import walkingkooka.naming.PathSeparator;
+import walkingkooka.tree.Node;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Build that supports complex assembly / concatenation of one or more selectors.
+ */
+public class NodeSelectorBuilder<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> implements Builder<NodeSelector<N, NAME, ANAME, AVALUE>> {
+
+    public static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodeSelectorBuilder<N, NAME, ANAME, AVALUE> create(final PathSeparator separator) {
+        Objects.requireNonNull(separator, "separator");
+        return new NodeSelectorBuilder<>(separator);
+    }
+
+    private final PathSeparator separator;
+
+    private NodeSelectorBuilder(final PathSeparator separator) {
+        super();
+        this.separator = separator;
+    }
+
+    /**
+     * {@see AncestorNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> ancestor() {
+        return this.append(AncestorNodeSelector.<N, NAME, ANAME, AVALUE>get());
+    }
+
+    /**
+     * {@see AndNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> and(final NodeSelector<N, NAME, ANAME, AVALUE> ...selectors) {
+        return this.append(AndNodeSelector.with(Lists.of(selectors)));
+    }
+
+    /**
+     * {@see ContainsNodeAttributeValuePredicate}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> attributeValueContains(final ANAME name, final AVALUE value) {
+        return this.predicate(new ContainsNodeAttributeValuePredicate<N, NAME, ANAME, AVALUE>(name, value));
+    }
+
+    /**
+     * {@see EndsWithNodeAttributeValuePredicate}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> attributeValueEndsWith(final ANAME name, final AVALUE value) {
+        return this.predicate(new EndsWithNodeAttributeValuePredicate<N, NAME, ANAME, AVALUE>(name, value));
+    }
+
+    /**
+     * {@see EqualNodeAttributeValuePredicate}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> attributeValueEquals(final ANAME name, final AVALUE value) {
+        return this.predicate(new EqualNodeAttributeValuePredicate<N, NAME, ANAME, AVALUE>(name, value));
+    }
+
+    /**
+     * {@see StartsWithNodeAttributeValuePredicate}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> attributeValueStartsWith(final ANAME name, final AVALUE value) {
+        return this.predicate(new StartsWithNodeAttributeValuePredicate<N, NAME, ANAME, AVALUE>(name, value));
+    }
+
+    /**
+     * {@see IndexedChildNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> child(final int index) {
+        return this.append(IndexedChildNodeSelector.with(index));
+    }
+
+    /**
+     * {@see ChildrenNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> children() {
+        return this.append(ChildrenNodeSelector.<N, NAME, ANAME, AVALUE>get());
+    }
+
+    /**
+     * {@see DescendantNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> descendant() {
+        return this.append(DescendantNodeSelector.<N, NAME, ANAME, AVALUE>with(this.separator));
+    }
+
+    /**
+     * {@see FollowingNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> following() {
+        return this.append(FollowingNodeSelector.<N, NAME, ANAME, AVALUE>get());
+    }
+
+    /**
+     * {@see FollowingSiblingNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> followingSibling() {
+        return this.append(FollowingSiblingNodeSelector.<N, NAME, ANAME, AVALUE>get());
+    }
+
+    /**
+     * {@see NamedNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> named(final NAME name) {
+        return this.append(NamedNodeSelector.with(name, this.separator));
+    }
+
+    /**
+     * {@see OrNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> or(final NodeSelector<N, NAME, ANAME, AVALUE>...selectors) {
+        return this.append(OrNodeSelector.with(Lists.of(selectors)));
+    }
+
+    /**
+     * {@see ParentNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> parent() {
+        return this.append(ParentNodeSelector.<N, NAME, ANAME, AVALUE>get());
+    }
+
+    /**
+     * {@see PrecedingNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> preceding() {
+        return this.append(PrecedingNodeSelector.<N, NAME, ANAME, AVALUE>get());
+    }
+
+    /**
+     * {@see PrecedingSiblingNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> precedingSibling() {
+        return this.append(PrecedingSiblingNodeSelector.<N, NAME, ANAME, AVALUE>get());
+    }
+
+    /**
+     * {@see PredicateNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> predicate(final Predicate<N> predicate) {
+        return this.append(PredicateNodeSelector.<N, NAME, ANAME, AVALUE>with(predicate));
+    }
+
+    /**
+     * {@see SelfNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> self() {
+        return this.append(SelfNodeSelector.<N, NAME, ANAME, AVALUE>get());
+    }
+
+    private NodeSelectorBuilder<N, NAME, ANAME, AVALUE> append(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        this.selector = null != this.selector ? this.selector.append(selector) : selector;
+        return this;
+    }
+
+    private NodeSelector<N, NAME, ANAME, AVALUE> selector;
+
+    @Override public NodeSelector<N, NAME, ANAME, AVALUE> build() throws BuilderException {
+        if (null == this.selector) {
+            throw new BuilderException("Builder is empty!");
+        }
+        return this.selector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorContext.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorContext.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+abstract class NodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> {
+
+    abstract void match(final N node);
+}

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorNodeSelectorContext.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorNodeSelectorContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Set;
+
+class NodeSelectorNodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends NodeSelectorContext<N, NAME, ANAME, AVALUE> {
+
+    NodeSelectorNodeSelectorContext(final Set<N> matched) {
+        this.matched = matched;
+    }
+
+    @Override void match(final N node) {
+        this.matched.add(node);
+    }
+
+    private final Set<N> matched;
+
+    public String toString() {
+        return this.matched.toString();
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/OrNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/OrNodeSelector.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.collect.set.Sets;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A {@link NodeSelector} that continues to walking the tree, continuously trying the next selector.
+ */
+final class OrNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        LogicalNodeSelector<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link OrNodeSelector} creator
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>,
+            NAME extends Name,
+            ANAME extends Name,
+            AVALUE> NodeSelector<N, NAME, ANAME, AVALUE> with(
+            final List<NodeSelector<N, NAME, ANAME, AVALUE>> selectors) {
+        Objects.requireNonNull(selectors, "selectors");
+
+        final Collection<NodeSelector<N, NAME, ANAME, AVALUE>> unique = gatherUniques(selectors);
+        return unique.size() == 1 ? unique.iterator().next() : new OrNodeSelector<N, NAME, ANAME, AVALUE>(unique);
+    }
+
+    /**
+     * Private constructor called by factory
+     */
+    private OrNodeSelector(final Collection<NodeSelector<N, NAME, ANAME, AVALUE>> selectors) {
+        super(selectors);
+    }
+
+    // LogicalNodeSelector
+
+    @Override public Set<N> accept(final N node) {
+        final Set<N> matches = Sets.ordered();
+        this.accept(node, new NodeSelectorNodeSelectorContext<>(matches));
+        return matches;
+    }
+
+    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        for(NodeSelector<N, NAME, ANAME, AVALUE> selector : this.selectors) {
+            selector.accept(node, context);
+        }
+    }
+
+    @Override
+    String operatorToString(){
+        return "|";
+    }
+
+    boolean canBeEqual(final Object other){
+        return other instanceof OrNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/ParentNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/ParentNodeSelector.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+/**
+ * A {@link NodeSelector} that selects any non <code>null</code> parent of any given {@link Node}.
+ */
+final class ParentNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link ParentNodeSelector} getter
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> ParentNodeSelector<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(ParentNodeSelector.INSTANCE);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private final static ParentNodeSelector INSTANCE = new ParentNodeSelector();
+
+    /**
+     * Private constructor use type safe getter
+     */
+    private ParentNodeSelector() {
+        super();
+    }
+
+    /**
+     * Private constructor
+     */
+    private ParentNodeSelector(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        super(selector);
+    }
+
+    // NodeSelector
+
+    NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        return new ParentNodeSelector(selector);
+    }
+
+    @Override
+    public void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        this.matchParent(node, context);
+    }
+
+    @Override
+    void toString0(final StringBuilder b, String separator){
+        b.append(separator).append("..");
+        this.toStringNext(b, "");
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof ParentNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/PrecedingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PrecedingNodeSelector.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Optional;
+
+/**
+ * A {@link NodeSelector} that selects all the preceding nodes of a given {@link Node}. It does this by asking all ancestors to process their previous
+ * siblings and their ancestors.
+ */
+final class PrecedingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link PrecedingNodeSelector} getter
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> PrecedingNodeSelector<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(PrecedingNodeSelector.INSTANCE);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private final static PrecedingNodeSelector INSTANCE = new PrecedingNodeSelector();
+
+    /**
+     * Private constructor use type safe getter
+     */
+    private PrecedingNodeSelector() {
+        super();
+    }
+
+    /**
+     * Private constructor
+     */
+    private PrecedingNodeSelector(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        super(selector);
+    }
+
+    // NodeSelector
+
+    NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        // no point appending a preceeding to another...
+        return selector instanceof PrecedingNodeSelector ?
+                this :
+                new PrecedingNodeSelector(selector);
+    }
+
+    @Override
+    void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        this.matchChildren(node, context);
+        this.matchPrecedingSiblings(node, context);
+
+        final Optional<N> parent = node.parent();
+        if (parent.isPresent()) {
+            this.matchPrecedingSiblings(parent.get(), context);
+        }
+    }
+
+    @Override
+    void match(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        super.match(node, context);
+        this.matchChildren(node, context);
+    }
+
+    @Override
+    void toString0(final StringBuilder b, String separator){
+        b.append(separator).append("preceding");
+        this.toStringNext(b, DEFAULT_AXIS_SEPARATOR);
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof PrecedingNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/PrecedingSiblingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PrecedingSiblingNodeSelector.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+/**
+ * A {@link NodeSelector} that selects all the preceding siblings of a given {@link Node}.
+ */
+final class PrecedingSiblingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link PrecedingSiblingNodeSelector} getter
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> PrecedingSiblingNodeSelector<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(PrecedingSiblingNodeSelector.INSTANCE);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private final static PrecedingSiblingNodeSelector INSTANCE = new PrecedingSiblingNodeSelector();
+
+    /**
+     * Package private constructor use type safe getter
+     */
+    PrecedingSiblingNodeSelector() {
+        super();
+    }
+
+    /**
+     * Private constructor
+     */
+    private PrecedingSiblingNodeSelector(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        super(selector);
+    }
+
+    // NodeSelector
+
+    NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        // no point appending a preceedingSibling to another...
+        return selector instanceof PrecedingSiblingNodeSelector ?
+                this :
+                new PrecedingSiblingNodeSelector(selector);
+    }
+
+    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        this.matchPrecedingSiblings(node, context);
+    }
+
+    @Override
+    void toString0(final StringBuilder b, String separator){
+        b.append(separator).append("preceding-sibling");
+        this.toStringNext(b, DEFAULT_AXIS_SEPARATOR);
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof PrecedingSiblingNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/PredicateNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PredicateNodeSelector.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * A {@link NodeSelector} that matches {@link Node nodes} whose attributes match the provided {@link Predicate}.
+ */
+final class PredicateNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        UnaryNodeSelector<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link PredicateNodeSelector} getter
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> PredicateNodeSelector<N, NAME, ANAME, AVALUE> with(final Predicate<N> predicate) {
+        Objects.requireNonNull(predicate, "predicate");
+        return new PredicateNodeSelector(predicate);
+    }
+
+    /**
+     * Private constructor use type safe getter
+     */
+    private PredicateNodeSelector(final Predicate<N> predicate) {
+        super();
+        this.predicate = predicate;
+    }
+
+    /**
+     * Private constructor
+     */
+    private PredicateNodeSelector(final Predicate<N> predicate, final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        super(selector);
+        this.predicate = predicate;
+    }
+
+    // NodeSelector
+
+    NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        return new PredicateNodeSelector(this.predicate, selector);
+    }
+
+    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        if(this.predicate.test(node)){
+            context.match(node);
+        }
+    }
+
+    private final Predicate<N> predicate;
+
+    // Object
+
+
+    @Override int hashCode0(final NodeSelector<N, NAME, ANAME, AVALUE> next) {
+        return Objects.hash(next, this.predicate);
+    }
+
+    @Override boolean canBeEqual(final Object other) {
+        return other instanceof PredicateNodeSelector;
+    }
+
+    @Override boolean equals1(final UnaryNodeSelector<N, NAME, ANAME, AVALUE> other) {
+        return this.equals2(Cast.to(other));
+    }
+
+    private boolean equals2(final PredicateNodeSelector<?, ?, ?, ?> other) {
+        return this.predicate.equals(other.predicate);
+    }
+
+    @Override
+    void toString0(final StringBuilder b, final String separator){
+        b.append(this.predicate.toString());
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/SelfNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/SelfNodeSelector.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.List;
+
+/**
+ * A {@link NodeSelector} that pushes any given {@link Node} to the {@link List}.
+ */
+final class SelfNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link ChildrenNodeSelector} getter
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> SelfNodeSelector<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(SelfNodeSelector.INSTANCE);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private final static SelfNodeSelector INSTANCE = new SelfNodeSelector();
+
+    /**
+     * Private constructor use type safe getter
+     */
+    private SelfNodeSelector() {
+        super();
+    }
+
+    /**
+     * Private constructor
+     */
+    private SelfNodeSelector(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        super(selector);
+    }
+
+    // NodeSelector
+
+    NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+        // no point appending a self to another...
+        return selector instanceof SelfNodeSelector ?
+                this :
+                new SelfNodeSelector(selector);
+    }
+
+    @Override
+    void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        this.match(node, context);
+    }
+
+    @Override
+    void toString0(final StringBuilder b, final String separator){
+        b.append(separator).append(".");
+        this.toStringNext(b, DEFAULT_AXIS_SEPARATOR);
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof SelfNodeSelector;
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/StartsWithNodeAttributeValuePredicate.java
+++ b/src/main/java/walkingkooka/tree/select/StartsWithNodeAttributeValuePredicate.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.Name;
+import walkingkooka.text.CharSequences;
+import walkingkooka.tree.Node;
+
+/**
+ * A {@link java.util.function.Predicate} that returns true if an attribute value starts with the given test value.
+ */
+final class StartsWithNodeAttributeValuePredicate<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends NodeAttributeValuePredicate<N, NAME, ANAME, AVALUE> {
+
+    StartsWithNodeAttributeValuePredicate(ANAME name, AVALUE value) {
+        super(name, value);
+    }
+
+    @Override
+    boolean test0(final AVALUE value, final AVALUE current) {
+        return current.toString().startsWith(value.toString());
+    }
+
+    @Override boolean isSameType(final Object other) {
+        return other instanceof StartsWithNodeAttributeValuePredicate;
+    }
+
+    @Override String toString0(final ANAME name, final AVALUE value) {
+        //[starts-with(@href, '/')]
+        return "[starts-with(@" + name + "," + CharSequences.quoteIfChars(value) + ")]";
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/TerminalNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/TerminalNodeSelector.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.ShouldNeverHappenError;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Set;
+
+/**
+ * A {@link NodeSelector} that selects and does nothing.
+ */
+final class TerminalNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+        extends
+        NodeSelector<N, NAME, ANAME, AVALUE> {
+
+    /**
+     * Type safe {@link TerminalNodeSelector} getter
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> TerminalNodeSelector<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(TerminalNodeSelector.INSTANCE);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private final static TerminalNodeSelector INSTANCE = new TerminalNodeSelector();
+
+    /**
+     * Package private constructor use type safe getter
+     */
+    TerminalNodeSelector() {
+        super();
+    }
+
+    // NodeSelector
+
+    @Override
+    NodeSelector<N, NAME, ANAME, AVALUE> append0(final NodeSelector<N, NAME, ANAME, AVALUE> selector){
+        return selector;
+    }
+
+    @Override public Set<N> accept(N node) {
+        throw new ShouldNeverHappenError(this.getClass() + ".accept(Node)");
+    }
+
+    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        context.match(node);
+    }
+
+    @Override void match(N node, NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        throw new ShouldNeverHappenError(this.getClass() + ".match(Node, NodeSelectorContext)");
+    }
+
+    @Override
+    void toString0(final StringBuilder b, final String separator){
+        //nop
+    }
+
+    @Override void toStringNext(final StringBuilder b, final String separator) {
+        throw new ShouldNeverHappenError(this.getClass() + ".toStringNext(StringBuilder, String)");
+    }
+}

--- a/src/main/java/walkingkooka/tree/select/UnaryNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/UnaryNodeSelector.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.collect.set.Sets;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Set;
+
+/**
+ * Base class for all non logical (binary) selectors.
+ */
+abstract class UnaryNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+    extends NodeSelector<N, NAME, ANAME, AVALUE> {
+
+    UnaryNodeSelector() {
+        this(TerminalNodeSelector.get());
+    }
+
+    UnaryNodeSelector(final NodeSelector<N, NAME, ANAME, AVALUE> next) {
+        super();
+        this.next = next;
+    }
+
+    @Override
+    NodeSelector<N, NAME, ANAME, AVALUE> append0(final NodeSelector<N, NAME, ANAME, AVALUE> selector){
+        return this.append1(null == this.next ?
+            selector : // we are the last append!
+            this.next.append0(selector));
+    }
+    
+    abstract NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector);
+
+    @Override
+    public final Set<N> accept(final N node) {
+        final Set<N> matches = Sets.ordered();
+        this.accept(node, new NodeSelectorNodeSelectorContext<>(matches));
+        return matches;
+    }
+
+    /**
+     * The default simply records the {@link Node} to the {@link NodeSelectorContext}.
+     */
+    void match(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        this.next.accept(node, context);
+    }
+
+    @Override
+    final void toStringNext(final StringBuilder b, final String separator){
+        if(null!=this.next) {
+            this.next.toString0(b, separator);
+        }
+    }
+
+    final NodeSelector<N, NAME, ANAME, AVALUE> next;
+
+    // Object
+
+    public final int hashCode(){
+        return this.hashCode0(this.next);
+    }
+
+    abstract int hashCode0(final NodeSelector<N, NAME, ANAME, AVALUE> next);
+
+    public final boolean equals(final Object other) {
+        return this == other || this.canBeEqual(other) && this.equals0(Cast.to(other));
+    }
+
+    abstract boolean canBeEqual(final Object other);
+
+    private boolean equals0(final UnaryNodeSelector<N, NAME, ANAME, AVALUE> other) {
+        return this.equals1(other) && this.next.equals(other.next);
+    }
+
+    abstract boolean equals1(final UnaryNodeSelector<N, NAME, ANAME, AVALUE> other);
+}

--- a/src/main/java/walkingkooka/tree/select/UnaryNodeSelector2.java
+++ b/src/main/java/walkingkooka/tree/select/UnaryNodeSelector2.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+/**
+ * Base class for all non logical (binary) selectors without any additional properties.
+ */
+abstract class UnaryNodeSelector2<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+    extends UnaryNodeSelector<N, NAME, ANAME, AVALUE> {
+
+    UnaryNodeSelector2() {
+        super();
+    }
+
+    UnaryNodeSelector2(final NodeSelector<N, NAME, ANAME, AVALUE> next) {
+        super(next);
+    }
+
+    final int hashCode0(final NodeSelector<N, NAME, ANAME, AVALUE> next) {
+        return next.hashCode();
+    }
+
+    final boolean equals1(final UnaryNodeSelector<N, NAME, ANAME, AVALUE> other) {
+        return true; // no extra properties...
+    }
+}

--- a/src/test/java/walkingkooka/text/CharSequencesQuoteIfCharsTest.java
+++ b/src/test/java/walkingkooka/text/CharSequencesQuoteIfCharsTest.java
@@ -33,13 +33,23 @@ final public class CharSequencesQuoteIfCharsTest extends StaticMethodTestCase {
     }
 
     @Test
-    public void testCharSequence() {
-        assertEquals("\"quoted\\n\"", CharSequences.quoteIfChars("quoted\n"));
+    public void testCharSequenceRequiresQuotes() {
+        assertEquals("\"abc\\n\"", CharSequences.quoteIfChars("abc\n"));
     }
 
     @Test
-    public void testCharArray() {
-        assertEquals("\"quoted\\n\"", CharSequences.quoteIfChars("quoted\n".toCharArray()));
+    public void testCharSequenceAlreadyQuoted() {
+        assertEquals("\"abc\\n\"", CharSequences.quoteIfChars("\"abc\n\""));
+    }
+
+    @Test
+    public void testCharArrayRequiredQuotes() {
+        assertEquals("\"abc\\n\"", CharSequences.quoteIfChars("\"abc\n\"".toCharArray()));
+    }
+
+    @Test
+    public void testCharArrayAlreadyQuoted() {
+        assertEquals("\"abc\\n\"", CharSequences.quoteIfChars("\"abc\n\"".toCharArray()));
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/CharSequencesQuoteIfNecessaryTest.java
+++ b/src/test/java/walkingkooka/text/CharSequencesQuoteIfNecessaryTest.java
@@ -41,4 +41,10 @@ final public class CharSequencesQuoteIfNecessaryTest extends StaticMethodTestCas
         Assert.assertEquals('"' + chars.toString() + '"',
                 CharSequences.quoteIfNecessary(chars).toString());
     }
+
+    @Test
+    public void testAlreadyQuoted() {
+        final String already = "\"abc\"";
+        assertEquals(already, CharSequences.quoteIfNecessary(already));
+    }
 }

--- a/src/test/java/walkingkooka/tree/select/AncestorNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/AncestorNodeSelectorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+final public class AncestorNodeSelectorTest extends
+        UnaryNodeSelectorTestCase<AncestorNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test
+    public void testRoot() {
+        this.acceptAndCheck(TestFakeNode.node("root"));
+    }
+
+    @Test
+    public void testAllAncestorsFromGrandChild() {
+        final TestFakeNode grandChild = TestFakeNode.node("grandChild");
+        final TestFakeNode child = TestFakeNode.node("child", grandChild);
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent.child(0).child(0), child, parent);
+    }
+
+    @Test
+    public void testAllAncestorsFromParent() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent);
+    }
+
+    @Test
+    public void testIgnoresDescendants() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent);
+    }
+
+    @Test
+    public void testIgnoresSiblings() {
+        final TestFakeNode child1 = TestFakeNode.node("child1");
+        final TestFakeNode child2 = TestFakeNode.node("child2");
+        final TestFakeNode parent = TestFakeNode.node("parent", child1, child2);
+
+        this.acceptAndCheck(parent.child(0), parent);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("ancestor", this.createSelector().toString());
+    }
+
+    @Override
+    protected AncestorNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return AncestorNodeSelector.get();
+    }
+
+    @Override
+    protected Class<AncestorNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(AncestorNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/AndNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/AndNodeSelectorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.naming.Names;
+import walkingkooka.naming.StringName;
+
+public final class AndNodeSelectorTest extends
+        LogicalNodeSelectorTestCase<AndNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test
+    public void testNothingMatched() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+        final TestFakeNode sibling = TestFakeNode.node("sibling");
+        final TestFakeNode root = TestFakeNode.node("root", parent, sibling);
+
+        this.acceptAndCheck(this.createSelector0(NamedNodeSelector.with(Names.string("unknown1"), SEPARATOR),
+                NamedNodeSelector.with(Names.string("unknown1"), SEPARATOR)),
+                root.child(0));
+    }
+
+    @Test
+    public void testDifferentSelectors() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+        final TestFakeNode sibling = TestFakeNode.node("sibling");
+        final TestFakeNode root = TestFakeNode.node("root", parent, sibling);
+
+        this.acceptAndCheck(this.createSelector0(ChildrenNodeSelector.get(), AncestorNodeSelector.get()),
+                root.child(0));
+    }
+
+    @Test
+    public void testOverlappingSelectors() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+        final TestFakeNode sibling = TestFakeNode.node("sibling");
+        final TestFakeNode root = TestFakeNode.node("root", parent, sibling);
+
+        this.acceptAndCheck(this.createSelector0(ChildrenNodeSelector.get(), DescendantNodeSelector.with(SEPARATOR)),
+                root.child(0),
+                child);
+    }
+
+    @Override
+    NodeSelector<TestFakeNode, StringName, StringName, Object> createSelector0(
+            final NodeSelector<TestFakeNode, StringName, StringName, Object>...selectors) {
+        return AndNodeSelector.with(Lists.of(selectors));
+    }
+
+    @Override protected Class<AndNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(AndNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/ChildrenNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/ChildrenNodeSelectorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.naming.StringName;
+
+final public class ChildrenNodeSelectorTest
+        extends UnaryNodeSelectorTestCase<ChildrenNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test
+    public void testChildless() {
+        this.acceptAndCheck(TestFakeNode.node("childless"));
+    }
+
+    @Test
+    public void testChildWithParent() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent").setChildren(Lists.of(child));
+
+        this.acceptAndCheck(parent.child(0));
+    }
+
+    @Test
+    public void testParentWithChild() {
+        final TestFakeNode child = TestFakeNode.node("child");
+
+        this.acceptAndCheck(TestFakeNode.node("parent of one", child), child);
+    }
+
+    @Test
+    public void testManyChildren() {
+        final TestFakeNode child1 = TestFakeNode.node("child1");
+        final TestFakeNode child2 = TestFakeNode.node("child2");
+
+        this.acceptAndCheck(TestFakeNode.node("parent of many children", child1, child2), child1, child2);
+    }
+
+    @Test
+    public void testIgnoresGrandChild() {
+        final TestFakeNode grandChild = TestFakeNode.node("grandchild");
+        final TestFakeNode child = TestFakeNode.node("child", grandChild);
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent, child);
+    }
+
+    @Test
+    public void testIgnoresSiblings() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+        final TestFakeNode siblingOfParent = TestFakeNode.node("siblingOfParent", child);
+        final TestFakeNode grandParent = TestFakeNode.node("grandParent", parent, siblingOfParent);
+
+        this.acceptAndCheck(parent, child);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("child", this.createSelector().toString());
+    }
+
+    @Override
+    protected ChildrenNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return ChildrenNodeSelector.get();
+    }
+
+    @Override
+    protected Class<ChildrenNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(ChildrenNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/ContainsNodeAttributeValuePredicateTest.java
+++ b/src/test/java/walkingkooka/tree/select/ContainsNodeAttributeValuePredicateTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+import java.util.Collections;
+
+public class ContainsNodeAttributeValuePredicateTest
+        extends NodeAttributeValuePredicateTestCase<ContainsNodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test
+    public void testContains() {
+        this.testTrue(new TestFakeNode("node").setAttributes(Collections.singletonMap(ATTRIBUTE_NAME1, "!!!" + VALUE + "@@@")));
+    }
+
+    @Test
+    public void testDoesntContain() {
+        this.testFalse(new TestFakeNode("node").setAttributes(Collections.singletonMap(ATTRIBUTE_NAME1, "different")));
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("[contains(@\"attribute-1\",\"123\")]", this.createPredicate().toString());
+    }
+
+    @Override
+    ContainsNodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object> createPredicate(final StringName name, final Object value) {
+        return new ContainsNodeAttributeValuePredicate(name, value);
+    }
+
+    @Override
+    protected Class<ContainsNodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(ContainsNodeAttributeValuePredicate.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/DescendantNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/DescendantNodeSelectorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+final public class DescendantNodeSelectorTest extends
+        UnaryNodeSelectorTestCase<DescendantNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullPathSeparatorFails() {
+        DescendantNodeSelector.with(null);
+    }
+
+    @Test
+    public void testChildless() {
+        this.acceptAndCheck(TestFakeNode.node("only"));
+    }
+
+    @Test
+    public void testIgnoresParent() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(child);
+    }
+
+    @Test
+    public void testParentWithChildren() {
+        final TestFakeNode child1 = TestFakeNode.node("child1");
+        final TestFakeNode child2 = TestFakeNode.node("child2");
+
+        this.acceptAndCheck(TestFakeNode.node("parent", child1, child2), child1, child2);
+    }
+
+    @Test
+    public void testParentWithGrandChildren() {
+        final TestFakeNode grandChild1 = TestFakeNode.node("grandChild1");
+        final TestFakeNode grandChild2 = TestFakeNode.node("grandChild2");
+
+        final TestFakeNode child1 = TestFakeNode.node("child1", grandChild1);
+        final TestFakeNode child2 = TestFakeNode.node("child2", grandChild2);
+
+        this.acceptAndCheck(TestFakeNode.node("parent", child1, child2), child1, grandChild1, child2, grandChild2);
+    }
+
+    @Test
+    public void testChildrenWithChildren2() {
+        final TestFakeNode grandChild1 = TestFakeNode.node("grandChild1");
+        final TestFakeNode grandChild2 = TestFakeNode.node("grandChild2");
+
+        final TestFakeNode child1 = TestFakeNode.node("child1", grandChild1, grandChild2);
+        final TestFakeNode child2 = TestFakeNode.node("child2");
+
+        this.acceptAndCheck(TestFakeNode.node("parent", child1, child2), child1, grandChild1, grandChild2, child2);
+    }
+
+    @Test
+    public void testIgnoresSiblings() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+        final TestFakeNode siblingOfParent = TestFakeNode.node("siblingOfParent", child);
+        final TestFakeNode grandParent = TestFakeNode.node("grandParent", parent, siblingOfParent);
+
+        this.acceptAndCheck(parent, child);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("//", this.createSelector().toString());
+    }
+
+    @Override
+    protected DescendantNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return DescendantNodeSelector.with(SEPARATOR);
+    }
+
+    @Override
+    protected Class<DescendantNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(DescendantNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/EndsWithNodeAttributeValuePredicateTest.java
+++ b/src/test/java/walkingkooka/tree/select/EndsWithNodeAttributeValuePredicateTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+import java.util.Collections;
+
+public class EndsWithNodeAttributeValuePredicateTest
+        extends NodeAttributeValuePredicateTestCase<EndsWithNodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test
+    public void tesEndsWith() {
+        this.testTrue(new TestFakeNode("node").setAttributes(Collections.singletonMap(ATTRIBUTE_NAME1, "!!!" + VALUE)));
+    }
+
+    @Test
+    public void testWrongEndsWith() {
+        this.testFalse(new TestFakeNode("node").setAttributes(Collections.singletonMap(ATTRIBUTE_NAME1, VALUE + "!!!")));
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("[ends-with(@\"attribute-1\",\"123\")]", this.createPredicate().toString());
+    }
+
+    @Override
+    EndsWithNodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object> createPredicate(final StringName name, final Object value) {
+        return new EndsWithNodeAttributeValuePredicate(name, value);
+    }
+
+    @Override
+    protected Class<EndsWithNodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(EndsWithNodeAttributeValuePredicate.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/EqualNodeAttributeValuePredicateTest.java
+++ b/src/test/java/walkingkooka/tree/select/EqualNodeAttributeValuePredicateTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+import java.util.Collections;
+
+public class EqualNodeAttributeValuePredicateTest
+        extends NodeAttributeValuePredicateTestCase<EqualNodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test
+    public void testEquals() {
+        this.testTrue(new TestFakeNode("node").setAttributes(Collections.singletonMap(ATTRIBUTE_NAME1, VALUE)));
+    }
+
+    @Test
+    public void testUnequalValue() {
+        this.testFalse(new TestFakeNode("node").setAttributes(Collections.singletonMap(ATTRIBUTE_NAME1, "!!!" + VALUE)));
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("[@\"attribute-1\"=\"123\"]", this.createPredicate().toString());
+    }
+
+    @Override
+    EqualNodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object> createPredicate(final StringName name, final Object value) {
+        return new EqualNodeAttributeValuePredicate(name, value);
+    }
+
+    @Override protected Class<EqualNodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(EqualNodeAttributeValuePredicate.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/FakeNodeSelector.java
+++ b/src/test/java/walkingkooka/tree/select/FakeNodeSelector.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.StringName;
+import walkingkooka.test.Fake;
+
+import java.util.Set;
+
+class FakeNodeSelector extends NodeSelector<TestFakeNode, StringName, StringName, Object> implements Fake {
+
+    @Override
+    NodeSelector<TestFakeNode, StringName, StringName, Object> append0(final NodeSelector<TestFakeNode, StringName, StringName, Object> selector){
+        throw new UnsupportedOperationException();
+    }
+
+    @Override public Set<TestFakeNode> accept(TestFakeNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void accept(TestFakeNode node, NodeSelectorContext<TestFakeNode, StringName, StringName, Object> context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void match(TestFakeNode node, NodeSelectorContext<TestFakeNode, StringName, StringName, Object> context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void toString0(final StringBuilder b, final String separator){
+        b.append(separator).append("Fake");
+    }
+
+    @Override
+    void toStringNext(final StringBuilder b, final String separator) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/FollowingNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/FollowingNodeSelectorTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+final public class FollowingNodeSelectorTest extends
+        UnaryNodeSelectorTestCase<FollowingNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test final public void testRoot() {
+        this.acceptAndCheck(TestFakeNode.node("root"));
+    }
+
+    @Test final public void testOnlyChildIgnoresParent() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent.child(0));
+    }
+
+    @Test final public void testChild() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent, child);
+    }
+
+    @Test final public void testFirstChild() {
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following = TestFakeNode.node("following");
+        final TestFakeNode parent = TestFakeNode.node("parent", self, following);
+
+        this.acceptAndCheck(parent.child(0), following);
+    }
+
+    @Test final public void testFirstChild2() {
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following1 = TestFakeNode.node("following1");
+        final TestFakeNode following2 = TestFakeNode.node("following2");
+        final TestFakeNode parent = TestFakeNode.node("parent", self, following1, following2);
+
+        this.acceptAndCheck(parent.child(0), following1, following2);
+    }
+
+    @Test final public void testLastChild() {
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode parent = TestFakeNode.node("parent", TestFakeNode.node("before"), self);
+
+        this.acceptAndCheck(parent.child(1));
+    }
+
+    @Test final public void testParentFollowingSibling() {
+        final TestFakeNode parent = TestFakeNode.node("parent");
+
+        final TestFakeNode parentFollowingSibling = TestFakeNode.node("parentFollowingSibling");
+
+        final TestFakeNode grandParent = TestFakeNode.node("grandParent", parent, parentFollowingSibling);
+
+        this.acceptAndCheck(grandParent.child(0), parentFollowingSibling);
+    }
+
+    @Test final public void testChildrenAndParentFollowingSibling() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        final TestFakeNode parentFollowingSiblingChild = TestFakeNode.node("parentFollowingSiblingChild");
+        final TestFakeNode parentFollowingSibling = TestFakeNode.node("parentFollowingSibling", parentFollowingSiblingChild);
+
+        final TestFakeNode grandParent = TestFakeNode.node("grandParent", parent, parentFollowingSibling);
+
+        this.acceptAndCheck(grandParent.child(0), child, parentFollowingSibling, parentFollowingSiblingChild);
+    }
+
+    @Test final public void testIgnoresPreceding() {
+        final TestFakeNode preceding = TestFakeNode.node("preceding");
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following = TestFakeNode.node("following");
+
+        final TestFakeNode parent = TestFakeNode.node("parent", preceding, self, following);
+
+        this.acceptAndCheck(parent.child(1), following);
+    }
+
+    @Test final public void testIgnoresPreceding2() {
+        final TestFakeNode preceding1 = TestFakeNode.node("preceding1");
+        final TestFakeNode preceding2 = TestFakeNode.node("preceding2");
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following1 = TestFakeNode.node("following1");
+        final TestFakeNode following2 = TestFakeNode.node("following2");
+
+        final TestFakeNode parent = TestFakeNode.node("parent", preceding1, preceding2, self, following1, following2);
+
+        this.acceptAndCheck(parent.child(2), following1, following2);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("following", this.createSelector().toString());
+    }
+
+    @Override
+    protected FollowingNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return FollowingNodeSelector.get();
+    }
+
+    @Override
+    protected Class<FollowingNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(FollowingNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/FollowingSiblingNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/FollowingSiblingNodeSelectorTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+final public class FollowingSiblingNodeSelectorTest extends
+        UnaryNodeSelectorTestCase<FollowingSiblingNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test final public void testRoot() {
+        this.acceptAndCheck(TestFakeNode.node("root"));
+    }
+
+    @Test final public void testChildIgnoresParent() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent.child(0));
+    }
+
+    @Test final public void testFirstChildWithFollowingSibling() {
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following = TestFakeNode.node("following");
+        final TestFakeNode parent = TestFakeNode.node("parent", self, following);
+
+        this.acceptAndCheck(parent.child(0), following);
+    }
+
+    @Test final public void testFirstChildWithFollowingSiblings2() {
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following1 = TestFakeNode.node("following1");
+        final TestFakeNode following2 = TestFakeNode.node("following2");
+        final TestFakeNode parent = TestFakeNode.node("parent", self, following1, following2);
+
+        this.acceptAndCheck(parent.child(0), following1, following2);
+    }
+
+    @Test final public void testLastChild() {
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode parent = TestFakeNode.node("parent", TestFakeNode.node("before"), self);
+
+        this.acceptAndCheck(parent.child(1));
+    }
+
+    @Test final public void testIgnoresPreceeding() {
+        final TestFakeNode preceeding = TestFakeNode.node("preceeding");
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following = TestFakeNode.node("following");
+
+        final TestFakeNode parent = TestFakeNode.node("parent", preceeding, self, following);
+
+        this.acceptAndCheck(parent.child(1), following);
+    }
+
+    @Test final public void testIgnoresPreceeding2() {
+        final TestFakeNode preceeding1 = TestFakeNode.node("preceeding1");
+        final TestFakeNode preceeding2 = TestFakeNode.node("preceeding2");
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following1 = TestFakeNode.node("following1");
+        final TestFakeNode following2 = TestFakeNode.node("following2");
+
+        final TestFakeNode parent = TestFakeNode.node("parent", preceeding1, preceeding2, self, following1, following2);
+
+        this.acceptAndCheck(parent.child(2), following1, following2);
+    }
+
+    @Test final public void testIgnoresChildren() {
+        this.acceptAndCheck(TestFakeNode.node("parent", TestFakeNode.node("child")));
+    }
+
+    @Test
+    public void testGrandChildrenIgnored() {
+        final TestFakeNode preceeding = TestFakeNode.node("preceeding");
+        final TestFakeNode self = TestFakeNode.node("self");
+
+        final TestFakeNode followingGrandChild = TestFakeNode.node("followingGrandChild");
+        final TestFakeNode following = TestFakeNode.node("following", followingGrandChild);
+
+        final TestFakeNode parent = TestFakeNode.node("parent", preceeding, self, following);
+
+        this.acceptAndCheck(parent.child(1), following);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("following-sibling", this.createSelector().toString());
+    }
+
+    @Override
+    protected FollowingSiblingNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return FollowingSiblingNodeSelector.get();
+    }
+
+    @Override
+    protected Class<FollowingSiblingNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(FollowingSiblingNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/IndexedChildNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/IndexedChildNodeSelectorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+
+final public class IndexedChildNodeSelectorTest extends
+        NodeSelectorTestCase2<IndexedChildNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    // constants
+
+    private final static int INDEX = 2;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeIndexFails() {
+        IndexedChildNodeSelector.with(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testZeroIndexFails() {
+        IndexedChildNodeSelector.with(0);
+    }
+
+    @Test
+    public void testChildless() {
+        this.acceptAndCheck(TestFakeNode.node("childless"));
+    }
+
+    @Test
+    public void testFewerChild() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        this.acceptAndCheck(TestFakeNode.node("parent", child));
+    }
+
+    @Test
+    public void testChildPresent() {
+        final TestFakeNode child1 = TestFakeNode.node("child1");
+        final TestFakeNode child2 = TestFakeNode.node("child2");
+        this.acceptAndCheck(TestFakeNode.node("parent", child1, child2), child2);
+    }
+
+    @Test
+    public void testExtraChildrenIgnored() {
+        final TestFakeNode child1 = TestFakeNode.node("child1");
+        final TestFakeNode child2 = TestFakeNode.node("child2");
+        final TestFakeNode child3 = TestFakeNode.node("child3");
+
+        this.acceptAndCheck(TestFakeNode.node("parent", child1, child2, child3), child2);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("INDEX", 2, IndexedChildNodeSelectorTest.INDEX);
+        Assert.assertEquals("[2]", this.createSelector().toString());
+    }
+
+    @Override
+    protected IndexedChildNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return IndexedChildNodeSelector.with(IndexedChildNodeSelectorTest.INDEX);
+    }
+
+    @Override
+    protected Class<IndexedChildNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(IndexedChildNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/LogicalNodeSelectorTestCase.java
+++ b/src/test/java/walkingkooka/tree/select/LogicalNodeSelectorTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+public abstract class LogicalNodeSelectorTestCase<S extends LogicalNodeSelector<TestFakeNode, StringName, StringName, Object>>
+extends NodeSelectorTestCase<S>{
+
+    private final static NodeSelector<TestFakeNode, StringName, StringName, Object> SELECTOR = new FakeNodeSelector();
+
+    LogicalNodeSelectorTestCase(){
+        super();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public final void testWithNullFirstFails() {
+        this.createSelector(null, SELECTOR);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public final void testWithNullSecondFails() {
+        this.createSelector(SELECTOR, null);
+    }
+
+    @Test
+    public final void testWithEqualFirstAndSecond() {
+        assertSame(SELECTOR, this.createSelector0(SELECTOR, SELECTOR));
+    }
+
+    @Override S createSelector() {
+        return this.createSelector(SELECTOR, new FakeNodeSelector());
+    }
+
+    final S createSelector(final NodeSelector<TestFakeNode, StringName, StringName, Object>...selectors) {
+        return Cast.to(this.createSelector0(selectors));
+    }
+
+    abstract NodeSelector<TestFakeNode, StringName, StringName, Object> createSelector0(final NodeSelector<TestFakeNode, StringName, StringName, Object>...selectors);
+
+    final void acceptAndCheck0(final NodeSelector<TestFakeNode, StringName, StringName, Object> selector,
+                               final TestFakeNode start,
+                               final String... nodes) {
+        this.acceptAndCheckUsingContext(selector, start, nodes);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/NamedNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NamedNodeSelectorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.Names;
+import walkingkooka.naming.PathSeparator;
+import walkingkooka.naming.StringName;
+
+final public class NamedNodeSelectorTest extends
+        UnaryNodeSelectorTestCase<NamedNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    private final static StringName NAME = Names.string("never");
+    private final static PathSeparator SEPARATOR = PathSeparator.requiredAtStart('/');
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullPathSeparatorFails() {
+        NamedNodeSelector.with(NAME, null);
+    }
+
+    @Test
+    public void testRootDifferentName() {
+        this.acceptAndCheck(TestFakeNode.node("root"));
+    }
+
+    @Test
+    public void testRoot() {
+        final TestFakeNode node = TestFakeNode.node("root");
+        this.acceptAndCheck(node.name(), node, node);
+    }
+
+    @Test
+    public void testChild() {
+        final TestFakeNode grandChild = TestFakeNode.node("grandChild");
+        final TestFakeNode child = TestFakeNode.node("child", grandChild);
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(child.name(), parent);
+    }
+
+    @Test
+    public void testAllAncestorsFromParent() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent.name(), child);
+    }
+
+    @Test
+    public void testIgnoresSiblings() {
+        final TestFakeNode child1 = TestFakeNode.node("child1");
+        final TestFakeNode child2 = TestFakeNode.node("child2");
+        final TestFakeNode parent = TestFakeNode.node("parent", child1, child2);
+
+        this.acceptAndCheck(child2.name(), parent.child(0));
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("/" + NAME.value(), this.createSelector().toString());
+    }
+
+    @Test
+    public void testToString2() {
+        Assert.assertEquals("!" + NAME.value(),  this.createSelector(PathSeparator.requiredAtStart('!')).toString());
+    }
+
+    @Test
+    public void testToStringPathSeparatorNotRequiredAtStart() {
+        Assert.assertEquals("/" + NAME.value(),  this.createSelector(PathSeparator.notRequiredAtStart('/')).toString());
+    }
+
+    @Override
+    protected NamedNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return createSelector(NAME);
+    }
+
+    private NamedNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector(final StringName name) {
+        return NamedNodeSelector.with(name, SEPARATOR);
+    }
+
+    private NamedNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector(final PathSeparator separator) {
+        return NamedNodeSelector.with(NAME, separator);
+    }
+
+    final void acceptAndCheck(final StringName match, final TestFakeNode start, final TestFakeNode... nodes) {
+        this.acceptAndCheck(this.createSelector(match), start, nodes);
+    }
+
+    @Override
+    protected Class<NamedNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(NamedNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/NodeAttributeValuePredicateTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeAttributeValuePredicateTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class NodeAttributeValuePredicateTest extends PackagePrivateClassTestCase<NodeAttributeValuePredicate> {
+    @Override protected Class<NodeAttributeValuePredicate> type() {
+        return NodeAttributeValuePredicate.class;
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/NodeAttributeValuePredicateTestCase.java
+++ b/src/test/java/walkingkooka/tree/select/NodeAttributeValuePredicateTestCase.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Test;
+import walkingkooka.naming.Names;
+import walkingkooka.naming.StringName;
+import walkingkooka.predicate.PredicateTestCase;
+
+import java.util.Collections;
+
+public abstract class NodeAttributeValuePredicateTestCase<N extends NodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object>>
+        extends PredicateTestCase<N, TestFakeNode> {
+
+    final static StringName ATTRIBUTE_NAME1 = Names.string("attribute-1");
+    final static StringName ATTRIBUTE_NAME2 = Names.string("attribute-2");
+    final static String VALUE = "123";
+
+    NodeAttributeValuePredicateTestCase() {
+        super();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullValueFails() {
+        this.createPredicate(ATTRIBUTE_NAME1, null);
+    }
+
+    @Test
+    public final void testAttributeMissing() {
+        this.testFalse(new TestFakeNode("nodeName").setAttributes(Collections.singletonMap(ATTRIBUTE_NAME2, "value")));
+    }
+
+    @Test
+    public final void testAttributeDifferentValue() {
+        this.testFalse(new TestFakeNode("nodeName").setAttributes(Collections.singletonMap(ATTRIBUTE_NAME1, "*DIFFERENT*")));
+    }
+
+    protected N createPredicate() {
+        return this.createPredicate(ATTRIBUTE_NAME1);
+    }
+
+    final N createPredicate(final StringName name) {
+        return this.createPredicate(name, VALUE);
+    }
+
+    abstract N createPredicate(final StringName name, final Object value);
+
+
+}

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorBuilderTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorBuilderTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Before;
+import org.junit.Test;
+import walkingkooka.build.BuilderTestCase;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.naming.Names;
+import walkingkooka.naming.PathSeparator;
+import walkingkooka.naming.StringName;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class NodeSelectorBuilderTest extends BuilderTestCase<NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object>, NodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    private final static StringName ATTRIBUTE = Names.string("attribute");
+    private final static String VALUE = "*VALUE*";
+
+    private static final String ROOT = "root";
+    private static final String GRAND_PARENT = "grandParent";
+    private static final String PARENT_SIBLING_BEFORE = "parentSiblingBefore";
+    private static final String PARENT = "parent";
+    private static final String CHILD1 = "child1";
+    private static final String CHILD2 = "child2";
+    private static final String CHILD3 = "child3";
+    private static final String GRAND_CHILD = "grandChild";
+    private static final String PARENT_SIBLING_AFTER = "parentSiblingAfter";
+
+    @Before
+    public void beforeEachTest() {
+        TestFakeNode.names.clear();
+    }
+
+    @Test
+    public void testNamedUnmatched() {
+        final TestFakeNode root = TestFakeNode.node(ROOT);
+
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .named(Names.string("not-found"));
+
+        this.acceptAndCheck(b, root);
+    }
+
+    @Test
+    public void testNamedMatch() {
+        final TestFakeNode root = TestFakeNode.node(ROOT);
+
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .named(Names.string(ROOT));
+
+        this.acceptAndCheck(b, root, root);
+    }
+
+    @Test
+    public void testDeepPathName() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node(PARENT, child);
+        final TestFakeNode root = TestFakeNode.node(ROOT, parent);
+
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .named(Names.string("child"));
+
+        this.acceptAndCheck(b, root, child);
+    }
+
+    @Test
+    public void testNameAndAttribute() {
+        final TestFakeNode child1 = TestFakeNode.node(CHILD1).setAttributes(Maps.one(ATTRIBUTE, VALUE));
+        final TestFakeNode child2 = TestFakeNode.node(CHILD2).setAttributes(Maps.one(ATTRIBUTE, "different"));
+        final TestFakeNode parent = TestFakeNode.node(PARENT, child1, child2);
+        
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .named(Names.string(CHILD1))
+                .attributeValueEquals(ATTRIBUTE, VALUE);
+
+        this.acceptAndCheck(b, parent, child1);
+    }
+
+    @Test
+    public void testDeepPathNameAndAttribute() {
+        final TestFakeNode child1 = TestFakeNode.node(CHILD1).setAttributes(Maps.one(ATTRIBUTE, VALUE));
+        final TestFakeNode child2 = TestFakeNode.node(CHILD2).setAttributes(Maps.one(ATTRIBUTE, "different"));
+        final TestFakeNode parent = TestFakeNode.node(PARENT, child1, child2);
+        final TestFakeNode root = TestFakeNode.node(ROOT, parent);
+
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .named(Names.string(CHILD1))
+                .attributeValueEquals(ATTRIBUTE, VALUE);
+
+        this.acceptAndCheck(b, root, child1);
+    }
+
+    @Test
+    public void testMultipleAttribute() {
+        final TestFakeNode child1 = TestFakeNode.node(CHILD1).setAttributes(Maps.one(ATTRIBUTE, VALUE));
+        final TestFakeNode child2 = TestFakeNode.node(CHILD2).setAttributes(Maps.one(ATTRIBUTE, "different"));
+        final TestFakeNode child3 = TestFakeNode.node(CHILD3).setAttributes(Maps.one(ATTRIBUTE, VALUE));
+        final TestFakeNode parent = TestFakeNode.node(PARENT, child1, child2, child3);
+        final TestFakeNode root = TestFakeNode.node(ROOT, parent);
+
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .attributeValueEquals(ATTRIBUTE, VALUE);
+
+        this.acceptAndCheck(b, root, child1, child3);
+    }
+
+    @Test
+    public void testOr() {
+        final TestFakeNode child1 = TestFakeNode.node(CHILD1).setAttributes(Maps.one(ATTRIBUTE, "123"));
+        final TestFakeNode child2 = TestFakeNode.node(CHILD2).setAttributes(Maps.one(ATTRIBUTE, "456"));
+        final TestFakeNode parent1 = TestFakeNode.node("parent1", child1, child2);
+        final TestFakeNode parent2 = TestFakeNode.node("parent2").setAttributes(Maps.one(ATTRIBUTE, "789"));
+        final TestFakeNode root = TestFakeNode.node(ROOT, parent1, parent2);
+
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .or(this.createBuilder().attributeValueEquals(ATTRIBUTE, "123").build(),
+                        this.createBuilder().attributeValueEquals(ATTRIBUTE, "789").build());
+
+        this.acceptAndCheck(b, root, child1, parent2);
+    }
+
+    @Test
+    public void testAnd() {
+        final TestFakeNode child1 = TestFakeNode.node(CHILD1).setAttributes(Maps.one(ATTRIBUTE, "123"));
+        final TestFakeNode child2 = TestFakeNode.node(CHILD2).setAttributes(Maps.one(ATTRIBUTE, "222"));
+        final TestFakeNode parent1 = TestFakeNode.node("parent1", child1, child2);
+        final TestFakeNode parent2 = TestFakeNode.node("parent2").setAttributes(Maps.one(ATTRIBUTE, "111"));
+        final TestFakeNode parent3 = TestFakeNode.node("parent3").setAttributes(Maps.one(ATTRIBUTE, "12345"));
+        final TestFakeNode root = TestFakeNode.node(ROOT, parent1, parent2, parent3);
+
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .and(this.createBuilder().attributeValueContains(ATTRIBUTE, "1").build(),
+                        this.createBuilder().attributeValueContains(ATTRIBUTE, "2").build());
+
+        this.acceptAndCheck(b, root, child1, parent3);
+    }
+
+    @Test
+    public void testDeepPathNameAndSelf() {
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .named(Names.string(PARENT))
+                .self();
+
+        this.acceptTreeAndCheck(b, PARENT);
+    }
+
+    @Test
+    public void testDeepPathNameAndParent() {
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .named(Names.string(PARENT))
+                .parent();
+
+        this.acceptTreeAndCheck(b, GRAND_PARENT);
+    }
+
+    @Test
+    public void testDeepPathNameAndAncestor() {
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .named(Names.string(PARENT))
+                .ancestor();
+
+        this.acceptTreeAndCheck(b, GRAND_PARENT, ROOT);
+    }
+
+    @Test
+    public void testDeepPathNameAndChildren() {
+
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .named(Names.string(PARENT))
+                .children();
+
+        this.acceptTreeAndCheck(b, CHILD1, CHILD2, CHILD3);
+    }
+
+    @Test
+    public void testDeepPathNameAndChild() {
+
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .named(Names.string(PARENT))
+                .child(2);
+
+        this.acceptTreeAndCheck(b, CHILD2);
+    }
+
+    @Test
+    public void testDeepPathNameAndPrecedingSibling() {
+
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .named(Names.string(PARENT))
+                .precedingSibling();
+
+        this.acceptTreeAndCheck(b, PARENT_SIBLING_BEFORE);
+    }
+
+    @Test
+    public void testDeepPathNameAndFollowingSibling() {
+
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .named(Names.string(PARENT))
+                .followingSibling();
+
+        this.acceptTreeAndCheck(b, PARENT_SIBLING_AFTER);
+    }
+
+    @Test
+    public void testDeepPathNameAndDescendants() {
+
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder()
+                .descendant()
+                .named(Names.string(PARENT))
+                .descendant();
+
+        this.acceptTreeAndCheck(b, CHILD1, GRAND_CHILD, CHILD2, CHILD3);
+    }
+
+    private void acceptTreeAndCheck(final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b, final String...nodes) {
+        final TestFakeNode parentSiblingBefore = TestFakeNode.node(PARENT_SIBLING_BEFORE);
+        final TestFakeNode child1 = TestFakeNode.node(CHILD1, TestFakeNode.node(GRAND_CHILD));
+        final TestFakeNode parent = TestFakeNode.node(PARENT, child1, TestFakeNode.node(CHILD2), TestFakeNode.node(CHILD3));
+        final TestFakeNode parentSiblingAfter = TestFakeNode.node(PARENT_SIBLING_AFTER);
+        final TestFakeNode grandParent = TestFakeNode.node(GRAND_PARENT, parentSiblingBefore, parent, parentSiblingAfter);
+
+        this.acceptAndCheck0(b, TestFakeNode.node(ROOT, grandParent), nodes);
+    }
+
+    private void acceptAndCheck(final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> builder,
+                                final TestFakeNode start,
+                                final TestFakeNode... nodes) {
+        this.acceptAndCheck0(builder,
+                start,
+                Arrays.stream(nodes)
+                        .map( n  -> n.name().value())
+                        .toArray(size  -> new String[ size]));
+    }
+
+    private void acceptAndCheck0(final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> builder,
+                                          final TestFakeNode start,
+                                          final String... nodes) {
+        final NodeSelector<TestFakeNode, StringName, StringName, Object> selector = builder.build();
+        final Set<TestFakeNode> matched = selector.accept(start);
+        final List<String> matchedNodes = matched.stream()
+                .map(n -> n.name().value())
+                .collect(Collectors.toList());
+        assertEquals("Selector.accept=" + selector + "\n" + start, Lists.of(nodes), matchedNodes);
+    }
+
+    @Test
+    public void testToStringNodeAndAttributeSelector() {
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder();
+        b.named(Names.string(PARENT))
+                .attributeValueContains(Names.string("attribute-name"), "attribute-value");
+
+        assertEquals("/parent[contains(@\"attribute-name\",\"attribute-value\")]", b.build().toString());
+    }
+
+    @Test
+    public void testToStringManySelectors() {
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder();
+        b.precedingSibling()
+                .self()
+                .followingSibling();
+
+        assertEquals("preceding-sibling::.::following-sibling", b.build().toString());
+    }
+
+    @Test
+    public void testToStringManySelectors2() {
+        final NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> b= this.createBuilder();
+        b.preceding()
+                .self()
+                .following();
+
+        assertEquals("preceding::.::following", b.build().toString());
+    }
+
+    @Override protected NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> createBuilder() {
+        return NodeSelectorBuilder.create(PathSeparator.requiredAtStart('/'));
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.test.PublicClassTestCase;
+
+public final class NodeSelectorTest extends PublicClassTestCase<NodeSelector<?, ?, ?, ?>> {
+    @Override protected Class<NodeSelector<?, ?, ?, ?>> type() {
+        return Cast.to(NodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Before;
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.naming.PathSeparator;
+import walkingkooka.naming.StringName;
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+abstract public class NodeSelectorTestCase<S extends NodeSelector<TestFakeNode, StringName, StringName, Object>> extends PackagePrivateClassTestCase<S> {
+
+    final static PathSeparator SEPARATOR = PathSeparator.requiredAtStart('/');
+
+    @Before
+    public void beforeEachTest() {
+        TestFakeNode.names.clear();
+    }
+
+    NodeSelectorTestCase() {
+        super();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testAppendNullFails() {
+        this.createSelector().append(null);
+    }
+
+    abstract S createSelector();
+
+    final void acceptAndCheck(final TestFakeNode start) {
+        this.acceptAndCheck0(this.createSelector(), start, new String[0]);
+    }
+
+    final void acceptAndCheck(final TestFakeNode start, final String... nodes) {
+        this.acceptAndCheck0(this.createSelector(), start, nodes);
+    }
+
+    final void acceptAndCheck(final TestFakeNode start, final TestFakeNode... nodes) {
+        this.acceptAndCheck(this.createSelector(), start, nodes);
+    }
+
+    final void acceptAndCheck(final NodeSelector<TestFakeNode, StringName, StringName, Object> selector,
+                               final TestFakeNode start,
+                               final TestFakeNode... nodes) {
+        this.acceptAndCheck0(selector,
+                start,
+                Arrays.stream(nodes)
+                        .map( n  -> n.name().value())
+                        .toArray(size  -> new String[ size]));
+    }
+
+    abstract void acceptAndCheck0(final NodeSelector<TestFakeNode, StringName, StringName, Object> selector,
+                               final TestFakeNode start,
+                               final String... nodes);
+
+    final void acceptAndCheckUsingContext(final NodeSelector<TestFakeNode, StringName, StringName, Object> selector,
+                                          final TestFakeNode start,
+                                          final String... nodes) {
+        final Set<TestFakeNode> matched = selector.accept(start);
+        final List<String> matchedNodes = matched.stream()
+                .map(n -> n.name().value())
+                .collect(Collectors.toList());
+        assertEquals("Selector.accept\n" + start, Lists.of(nodes), matchedNodes);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase2.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase2.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.naming.StringName;
+
+import java.util.List;
+
+public abstract class NodeSelectorTestCase2<S extends NodeSelector<TestFakeNode, StringName, StringName, Object>>
+extends NodeSelectorTestCase<S>{
+
+    NodeSelectorTestCase2(){
+        super();
+    }
+
+    final void acceptAndCheck0(final NodeSelector<TestFakeNode, StringName, StringName, Object> selector,
+                               final TestFakeNode start,
+                               final String... nodes) {
+        this.acceptAndCheckRequiringOrder(selector, start, nodes);
+        this.acceptAndCheckUsingContext(selector, start, nodes);
+    }
+
+    final void acceptAndCheckRequiringOrder(NodeSelector<TestFakeNode, StringName, StringName, Object> selector, TestFakeNode start, String[] nodes) {
+        final List<String> expected = Lists.array();
+        expected.addAll(Lists.of(nodes));
+
+        selector.accept(start, new NodeSelectorContext<TestFakeNode, StringName, StringName, Object>() {
+
+            int i = 0;
+
+            @Override void match(final TestFakeNode node) {
+                if(i == nodes.length) {
+                    Assert.fail("Unexpected matching node: " + node);
+                }
+
+                if(!nodes[i].equals(node.name().value())){
+                    Assert.fail("Unexpected node " + node + " expected "+ nodes[i]);
+                }
+                expected.remove(0);
+                i++;
+            }
+        });
+
+        assertEquals("Finished processing contains unmatched nodes", Lists.empty(), expected);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/OrNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/OrNodeSelectorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.naming.Names;
+import walkingkooka.naming.StringName;
+
+public final class OrNodeSelectorTest extends
+        LogicalNodeSelectorTestCase<OrNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test
+    public void testNothingMatched() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+        final TestFakeNode sibling = TestFakeNode.node("sibling");
+        final TestFakeNode root = TestFakeNode.node("root", parent, sibling);
+
+        this.acceptAndCheck(this.createSelector0(NamedNodeSelector.with(Names.string("unknown1"), SEPARATOR),
+                NamedNodeSelector.with(Names.string("unknown1"), SEPARATOR)),
+                root.child(0));
+    }
+
+    @Test
+    public void testDifferentSelectors() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+        final TestFakeNode sibling = TestFakeNode.node("sibling");
+        final TestFakeNode root = TestFakeNode.node("root", parent, sibling);
+
+        this.acceptAndCheck(this.createSelector0(
+                ChildrenNodeSelector.get(),
+                SelfNodeSelector.get()),
+                root.child(0),
+                child, parent);
+    }
+
+    @Test
+    public void testOverlappingSelectors() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+        final TestFakeNode sibling = TestFakeNode.node("sibling");
+        final TestFakeNode root = TestFakeNode.node("root", parent, sibling);
+
+        this.acceptAndCheck(this.createSelector0(ChildrenNodeSelector.get(),
+                AncestorNodeSelector.get()),
+                root.child(0),
+                child, root);
+    }
+
+    @Override
+    NodeSelector<TestFakeNode, StringName, StringName, Object> createSelector0(
+            final NodeSelector<TestFakeNode, StringName, StringName, Object> ...selectors) {
+        return OrNodeSelector.with(Lists.of(selectors));
+    }
+
+    @Override protected Class<OrNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(OrNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/ParentNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/ParentNodeSelectorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+final public class ParentNodeSelectorTest
+        extends UnaryNodeSelectorTestCase<ParentNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test
+    public void testRoot() {
+        this.acceptAndCheck(TestFakeNode.node("root"));
+    }
+
+    @Test
+    public void testParentIsRoot() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent.child(0), parent);
+    }
+
+    @Test
+    public void testIgnoresDescendants() {
+        final TestFakeNode grandChild = TestFakeNode.node("grandChild");
+        final TestFakeNode child = TestFakeNode.node("child", grandChild); //
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent.child(0), parent);
+    }
+
+    @Test
+    public void testIgnoresSiblings() {
+        final TestFakeNode grandChild = TestFakeNode.node("grandChild");
+        final TestFakeNode child1 = TestFakeNode.node("child1", grandChild); //
+        final TestFakeNode child2 = TestFakeNode.node("child2"); //
+        final TestFakeNode parent = TestFakeNode.node("parent", child1, child2);
+
+        this.acceptAndCheck(parent.child(1), parent);
+    }
+
+    @Test
+    public void testIgnoresGrandParent() {
+        final TestFakeNode grandChild = TestFakeNode.node("grandChild");
+        final TestFakeNode child = TestFakeNode.node("child", grandChild); //
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(child.child(0), child);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("..", this.createSelector().toString());
+    }
+
+    @Override
+    protected ParentNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return ParentNodeSelector.get();
+    }
+
+    @Override
+    protected Class<ParentNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(ParentNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/PrecedingNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/PrecedingNodeSelectorTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+final public class PrecedingNodeSelectorTest extends
+        UnaryNodeSelectorTestCase<PrecedingNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test final public void testRoot() {
+        this.acceptAndCheck(TestFakeNode.node("root"));
+    }
+
+    @Test final public void testOnlyChildIgnoresParent() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent.child(0));
+    }
+
+    @Test final public void testChild() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent, child);
+    }
+
+    @Test final public void testPrecedingSibling() {
+        final TestFakeNode preceding1 = TestFakeNode.node("preceding1");
+        final TestFakeNode preceding2 = TestFakeNode.node("preceding2");
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode parent = TestFakeNode.node("parent", preceding1, preceding2, self);
+
+        this.acceptAndCheck(parent.child(2), preceding2, preceding1);
+    }
+
+    @Test final public void testIgnoresFollowingSibling() {
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following = TestFakeNode.node("following");
+        final TestFakeNode parent = TestFakeNode.node("parent", self, following);
+
+        this.acceptAndCheck(parent.child(0));
+    }
+
+    @Test final public void testIgnoresFollowingSibling2() {
+        final TestFakeNode preceding1 = TestFakeNode.node("preceding1");
+        final TestFakeNode preceding2 = TestFakeNode.node("preceding2");
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following = TestFakeNode.node("following");
+
+        final TestFakeNode parent = TestFakeNode.node("parent", preceding1, preceding2, self, following);
+
+        this.acceptAndCheck(parent.child(2), preceding2, preceding1);
+    }
+
+    @Test final public void testParentPrecedingSibling() {
+        final TestFakeNode parent = TestFakeNode.node("parent");
+
+        final TestFakeNode parentProcedingSibling = TestFakeNode.node("parentProcedingSibling");
+
+        final TestFakeNode grandParent = TestFakeNode.node("grandParent", parentProcedingSibling, parent);
+
+        this.acceptAndCheck(grandParent.child(1), parentProcedingSibling);
+    }
+
+    @Test final public void testParentPrecedingSiblingWithChild() {
+        final TestFakeNode parent = TestFakeNode.node("parent");
+
+        final TestFakeNode parentProcedingSiblingChild = TestFakeNode.node("parentProcedingSiblingChild");
+        final TestFakeNode parentProcedingSibling = TestFakeNode.node("parentProcedingSibling", parentProcedingSiblingChild);
+
+        final TestFakeNode grandParent = TestFakeNode.node("grandParent", parentProcedingSibling, parent);
+
+        this.acceptAndCheck(grandParent.child(1), parentProcedingSibling, parentProcedingSiblingChild);
+    }
+
+    @Test final public void testIgnoresParentFollowingSibling() {
+        final TestFakeNode parent = TestFakeNode.node("parent");
+
+        final TestFakeNode parentFollowingSibling = TestFakeNode.node("parentFollowingSibling");
+
+        final TestFakeNode grandParent = TestFakeNode.node("grandParent", parent, parentFollowingSibling);
+
+        this.acceptAndCheck(grandParent.child(0));
+    }
+
+    @Test final public void testIgnoresFollowing() {
+        final TestFakeNode preceding = TestFakeNode.node("preceding");
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following = TestFakeNode.node("following");
+
+        final TestFakeNode parent = TestFakeNode.node("parent", preceding, self, following);
+
+        this.acceptAndCheck(parent.child(1), preceding);
+    }
+
+    @Test final public void testIgnoresFollowing2() {
+        final TestFakeNode preceding1 = TestFakeNode.node("preceding1");
+        final TestFakeNode preceding2 = TestFakeNode.node("preceding2");
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following1 = TestFakeNode.node("following1");
+        final TestFakeNode following2 = TestFakeNode.node("following2");
+
+        final TestFakeNode parent = TestFakeNode.node("parent", preceding1, preceding2, self, following1, following2);
+
+        this.acceptAndCheck(parent.child(2), preceding2, preceding1);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("preceding", this.createSelector().toString());
+    }
+
+    @Override
+    protected PrecedingNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return PrecedingNodeSelector.get();
+    }
+
+    @Override
+    protected Class<PrecedingNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(PrecedingNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/PrecedingSiblingNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/PrecedingSiblingNodeSelectorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+final public class PrecedingSiblingNodeSelectorTest extends
+        UnaryNodeSelectorTestCase<PrecedingSiblingNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test final public void testRoot() {
+        this.acceptAndCheck(TestFakeNode.node("root"));
+    }
+
+    @Test final public void testOnlyChild() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(parent.child(0));
+    }
+
+    @Test final public void testFirstChild() {
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following = TestFakeNode.node("following");
+        final TestFakeNode parent = TestFakeNode.node("parent", self, following);
+
+        this.acceptAndCheck(parent.child(0));
+    }
+
+    @Test final public void testLastChild() {
+        final TestFakeNode preceding = TestFakeNode.node("preceding");
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode parent = TestFakeNode.node("parent", preceding, self);
+
+        this.acceptAndCheck(parent.child(1), preceding);
+    }
+
+    @Test final public void testIgnoresGrandChildren() {
+        final TestFakeNode preceding = TestFakeNode.node("preceding", TestFakeNode.node("grandchild-of-preceding"));
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode parent = TestFakeNode.node("parent", preceding, self);
+
+        this.acceptAndCheck(parent.child(1), preceding);
+    }
+
+    @Test final public void testMiddleChildIgnoresFollowing() {
+        final TestFakeNode preceding = TestFakeNode.node("preceding");
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following = TestFakeNode.node("following");
+
+        final TestFakeNode parent = TestFakeNode.node("parent", preceding, self, following);
+
+        this.acceptAndCheck(parent.child(1), preceding);
+    }
+
+    @Test final public void testMiddleChild2() {
+        final TestFakeNode preceding1 = TestFakeNode.node("preceding1");
+        final TestFakeNode preceding2 = TestFakeNode.node("preceding2");
+        final TestFakeNode self = TestFakeNode.node("self");
+        final TestFakeNode following1 = TestFakeNode.node("following1");
+        final TestFakeNode following2 = TestFakeNode.node("following2");
+
+        final TestFakeNode parent = TestFakeNode.node("parent", preceding1, preceding2, self, following1, following2);
+
+        this.acceptAndCheck(parent.child(2), preceding2, preceding1);
+    }
+
+    @Test final public void testIgnoresChildren() {
+        this.acceptAndCheck(TestFakeNode.node("parent", TestFakeNode.node("child")));
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("preceding-sibling", this.createSelector().toString());
+    }
+
+    @Override
+    protected PrecedingSiblingNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return PrecedingSiblingNodeSelector.get();
+    }
+
+    @Override
+    protected Class<PrecedingSiblingNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(PrecedingSiblingNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/PredicateNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/PredicateNodeSelectorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+import java.util.function.Predicate;
+
+
+final public class PredicateNodeSelectorTest extends
+        UnaryNodeSelectorTestCase<PredicateNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    // constants
+
+    private final static Predicate<TestFakeNode> PREDICATE = (n)-> n.name().value().equals("self");
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullPredicateFails() {
+        PredicateNodeSelector.with(null);
+    }
+
+    @Test
+    public void testMatch() {
+        final TestFakeNode self = TestFakeNode.node("self");
+        this.acceptAndCheck(self, self);
+    }
+
+    @Test
+    public void testIgnoresNonSelfNodes() {
+        final TestFakeNode siblingBefore = TestFakeNode.node("siblingBefore");
+        final TestFakeNode self = TestFakeNode.node("self", TestFakeNode.node("child"));
+        final TestFakeNode siblingAfter = TestFakeNode.node("siblingAfter");
+        final TestFakeNode parent = TestFakeNode.node("parent", siblingBefore, self, siblingAfter);
+
+        this.acceptAndCheck(parent.child(1), self);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals(PREDICATE.toString(), this.createSelector().toString());
+    }
+
+    @Override
+    protected PredicateNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return PredicateNodeSelector.with(PREDICATE);
+    }
+
+    @Override
+    protected Class<PredicateNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(PredicateNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/SelfNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/SelfNodeSelectorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+final public class SelfNodeSelectorTest
+        extends UnaryNodeSelectorTestCase<SelfNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test
+    public void testSelf() {
+        final TestFakeNode node = TestFakeNode.node("self");
+        this.acceptAndCheck(node, node);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals(".", this.createSelector().toString());
+    }
+
+    @Override
+    protected SelfNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return SelfNodeSelector.get();
+    }
+
+    @Override
+    protected Class<SelfNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(SelfNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/StartsWithNodeAttributeValuePredicateTest.java
+++ b/src/test/java/walkingkooka/tree/select/StartsWithNodeAttributeValuePredicateTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+import java.util.Collections;
+
+public class StartsWithNodeAttributeValuePredicateTest
+        extends NodeAttributeValuePredicateTestCase<StartsWithNodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test
+    public void testStartsWith() {
+        this.testTrue(new TestFakeNode("node").setAttributes(Collections.singletonMap(ATTRIBUTE_NAME1, VALUE + "!!!")));
+    }
+
+    @Test
+    public void testWrongStartsWith() {
+        this.testFalse(new TestFakeNode("node").setAttributes(Collections.singletonMap(ATTRIBUTE_NAME1, "!!!" + VALUE)));
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("[starts-with(@\"attribute-1\",\"123\")]", this.createPredicate().toString());
+    }
+
+    @Override
+    StartsWithNodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object> createPredicate(final StringName name, final Object value) {
+        return new StartsWithNodeAttributeValuePredicate(name, value);
+    }
+
+    @Override
+    protected Class<StartsWithNodeAttributeValuePredicate<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(StartsWithNodeAttributeValuePredicate.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/TerminalNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/TerminalNodeSelectorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.StringName;
+
+final public class TerminalNodeSelectorTest
+        extends NodeSelectorTestCase2<TerminalNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("", this.createSelector().toString());
+    }
+
+    @Override
+    protected TerminalNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return TerminalNodeSelector.get();
+    }
+
+    @Override
+    protected Class<TerminalNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(TerminalNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/TestFakeNode.java
+++ b/src/test/java/walkingkooka/tree/select/TestFakeNode.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+
+import org.junit.Assert;
+import walkingkooka.build.tostring.ToStringBuilder;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.collect.set.Sets;
+import walkingkooka.naming.Names;
+import walkingkooka.naming.StringName;
+import walkingkooka.text.CharSequences;
+import walkingkooka.tree.Node;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+final class TestFakeNode implements Node<TestFakeNode, StringName, StringName, Object> {
+
+    final static Optional<TestFakeNode> NO_PARENT = Optional.empty();
+
+    static TestFakeNode node(final String name, final TestFakeNode... nodes) {
+        if(!names.add(name)) {
+            Assert.fail("Name " + CharSequences.quote(name)+ " must be unique per test");
+        }
+
+        return new TestFakeNode(name).setChildren(Lists.of(nodes));
+    }
+
+    static Set<String> names = Sets.sorted();
+
+    TestFakeNode(final String name)
+    {
+        this(Names.string(name), NO_PARENT, Lists.empty(), Maps.empty());
+    }
+
+    private TestFakeNode(final StringName name, final Optional<TestFakeNode> parent, final List<TestFakeNode> children, final Map<StringName, Object> attributes) {
+        this.name = name;
+        this.parent = parent;
+        this.attributes = attributes;
+        this.children = children;
+    }
+
+    public StringName name() {
+        return this.name;
+    }
+
+    private final StringName name;
+
+    @Override
+    public Optional<TestFakeNode> parent() {
+        return this.parent;
+    }
+
+    @Override public TestFakeNode setParent(final Optional<TestFakeNode> parent) {
+        return this.parent().equals(parent) ?
+                this :
+                new TestFakeNode(this.name, parent, this.children, this.attributes).adopt();
+    }
+
+    private Optional<TestFakeNode> parent;
+
+    @Override
+    public List<TestFakeNode> children() {
+        return this.children;
+    }
+
+    @Override public TestFakeNode setChildren(final List<TestFakeNode> children) {
+        Objects.requireNonNull(children, "children");
+
+        return this.children.equals(children) ?
+                this :
+                new TestFakeNode(this.name, NO_PARENT, children, this.attributes).adopt();
+    }
+
+    TestFakeNode child(final int i){
+        return this.children().get(i);
+    }
+
+    private List<TestFakeNode> children;
+
+    @Override
+    public Map<StringName, Object> attributes() {
+        return this.attributes;
+    }
+
+    @Override public TestFakeNode setAttributes(final Map<StringName, Object> attributes) {
+        Objects.requireNonNull(attributes, "attributes");
+
+        final Map<StringName, Object> copy = Maps.ordered();
+        copy.putAll(attributes);
+        return this.attributes.equals(copy) ?
+                this :
+                new TestFakeNode(this.name, NO_PARENT, this.children, copy).adopt();
+    }
+
+    private final Map<StringName, Object> attributes;
+
+    private TestFakeNode adopt() {
+        final Optional<TestFakeNode> parentOfChildren = Optional.of(this);
+
+        this.children = this.children().stream()
+                .map(c -> new TestFakeNode(c.name, parentOfChildren, c.children, c.attributes).adopt())
+                .collect(Collectors.toList());
+
+        return this;
+    }
+
+    @Override public TestFakeNode create(StringName name) {
+        return new TestFakeNode(name, NO_PARENT, Lists.empty(), Maps.empty());
+    }
+
+    public int hashCode() {
+        return Objects.hash(this.name(), this.attributes());
+    }
+
+    public boolean equals(final Object other){
+        return this == other || other instanceof TestFakeNode && equals0((TestFakeNode)other);
+    }
+
+    private boolean equals0(final TestFakeNode other) {
+        return this.name().equals(other.name()) &&
+                this.equalsParent(other.parent()) &&
+                this.equalsChildren(other.children()) &&
+                this.attributes().equals(other.attributes());
+    }
+
+    // check all properties, except for children of parent...
+    private boolean equalsParent(final Optional<TestFakeNode> other) {
+        boolean equals = false;
+
+        final Optional<TestFakeNode> maybeParent = this.parent();
+        if(parent.isPresent()) {
+            if(other.isPresent()){
+                final TestFakeNode parent = maybeParent.get();
+                final TestFakeNode otherParent = other.get();
+
+                // skip checking children...
+                equals = parent.name().equals(otherParent.name()) &&
+                        parent.equalsParent(otherParent.parent()) &&
+                        parent.attributes().equals(otherParent.attributes());
+            }
+        } else {
+            // both should have no parent.
+            equals = !other.isPresent();
+        }
+
+        return equals;
+    }
+
+    // check all properties of children except for parent.
+    private boolean equalsChildren(final List<TestFakeNode> otherChildren) {
+        boolean equals = false;
+
+        final List<TestFakeNode> children = this.children();
+        if(children.size() == otherChildren.size()) {
+            final Iterator<TestFakeNode> i = children.iterator();
+            final Iterator<TestFakeNode> j = otherChildren.iterator();
+            equals = true;
+
+            while(equals && i.hasNext()){
+                equals &= i.next().equalsChild(j.next());
+            }
+        }
+
+        return equals;
+    }
+
+    // check all properties of children except for parent.
+    private boolean equalsChild(final TestFakeNode other) {
+        return this.name().equals(other.name()) &&
+                this.equalsChildren(other.children()) &&
+                this.attributes().equals(other.attributes());
+    }
+
+    @Override
+    public String toString() {
+        final ToStringBuilder b = ToStringBuilder.create();
+        b.value(this.name());
+        b.surroundValues("[", "]").value(this.children());
+        b.surroundValues("{", "}").value(this.attributes());
+        return b.build();
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/TestFakeNodeEqualityTest.java
+++ b/src/test/java/walkingkooka/tree/select/TestFakeNodeEqualityTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.naming.Names;
+import walkingkooka.naming.StringName;
+import walkingkooka.tree.NodeEqualityTestCase;
+
+import java.util.Map;
+
+public class TestFakeNodeEqualityTest extends NodeEqualityTestCase<TestFakeNode, StringName, StringName, Object> {
+
+    @Override protected TestFakeNode createNode(int i) {
+        return new TestFakeNode("test-" + i);
+    }
+
+    @Override protected Map<StringName, Object> createAttributes(int i) {
+        final Map<StringName, Object> attributes = Maps.ordered();
+        for(int j = 0; j < i; j++) {
+            attributes.put(Names.string("attribute-" + i), i);
+        }
+        return attributes;
+    }
+
+    @Override protected Class<? extends TestFakeNode> type() {
+        return Cast.to(TestFakeNode.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/TestFakeNodeTest.java
+++ b/src/test/java/walkingkooka/tree/select/TestFakeNodeTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
+import walkingkooka.naming.StringName;
+import walkingkooka.tree.NodeTestCase;
+
+public class TestFakeNodeTest extends NodeTestCase<TestFakeNode, StringName, StringName, Object> {
+
+    @Rule
+    public TestName name = new TestName();
+    private int n = 0;
+
+    @Before
+    public void reset() {
+        this.n = 0;
+    }
+
+
+    @Override protected TestFakeNode createNode() {
+        return new TestFakeNode(this.name.getMethodName() + "-" + this.n++);
+    }
+
+    @Override protected Class<TestFakeNode> type() {
+        return TestFakeNode.class;
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/UnaryNodeSelector2Test.java
+++ b/src/test/java/walkingkooka/tree/select/UnaryNodeSelector2Test.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class UnaryNodeSelector2Test extends PackagePrivateClassTestCase<UnaryNodeSelector2<?, ?, ?, ?>> {
+    @Override protected Class<UnaryNodeSelector2<?, ?, ?, ?>> type() {
+        return Cast.to(UnaryNodeSelector2.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/UnaryNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/UnaryNodeSelectorTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class UnaryNodeSelectorTest extends PackagePrivateClassTestCase<UnaryNodeSelector<?, ?, ?, ?>> {
+    @Override protected Class<UnaryNodeSelector<?, ?, ?, ?>> type() {
+        return Cast.to(UnaryNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/UnaryNodeSelectorTestCase.java
+++ b/src/test/java/walkingkooka/tree/select/UnaryNodeSelectorTestCase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.naming.StringName;
+
+import java.util.List;
+
+public abstract class UnaryNodeSelectorTestCase<S extends NodeSelector<TestFakeNode, StringName, StringName, Object>>
+extends NodeSelectorTestCase<S>{
+
+    UnaryNodeSelectorTestCase(){
+        super();
+    }
+
+    final void acceptAndCheck0(final NodeSelector<TestFakeNode, StringName, StringName, Object> selector,
+                               final TestFakeNode start,
+                               final String... nodes) {
+        this.acceptAndCheckRequiringOrder(selector, start, nodes);
+        this.acceptAndCheckUsingContext(selector, start, nodes);
+    }
+
+    final void acceptAndCheckRequiringOrder(NodeSelector<TestFakeNode, StringName, StringName, Object> selector, TestFakeNode start, String[] nodes) {
+        final List<String> expected = Lists.array();
+        expected.addAll(Lists.of(nodes));
+        System.out.println("---------" + expected);
+
+        selector.accept(start, new NodeSelectorContext<TestFakeNode, StringName, StringName, Object>() {
+
+            int i = 0;
+
+            @Override void match(final TestFakeNode node) {
+                System.out.println("\t" + node);
+                if(i == nodes.length) {
+                    Assert.fail("Unexpected matching node: " + node);
+                }
+
+                if(!nodes[i].equals(node.name().value())){
+                    Assert.fail("Unexpected node " + node + " expected "+ nodes[i]);
+                }
+                expected.remove(0);
+                i++;
+            }
+        });
+
+        assertEquals("Finished processing contains unmatched nodes", Lists.empty(), expected);
+    }
+}


### PR DESCRIPTION
- Defined Node interface.
- NodeSelectorBuilder contains methods to build a selector.
- Fixed CharSequences.quoteIfChars and quoteAndEscape to not add extra
quotes if input already has surrounding quotes.
- Fixed return types of Names.stringName and Paths.stringPath