### PR TITLE
A few absolute/relative path fixes.

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokenNode.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokenNode.java
@@ -37,10 +37,17 @@ public abstract class ParserTokenNode implements Node<ParserTokenNode, ParserTok
         Value<ParserToken> {
 
     /**
-     * {@see NodeSelectorBuilder}
+     * Absolute {@see NodeSelectorBuilder}
      */
-    public static NodeSelectorBuilder<ParserTokenNode, ParserTokenNodeName, ParserTokenNodeAttributeName, String> nodeSelectorBuilder() {
-        return NodeSelectorBuilder.create(PathSeparator.requiredAtStart('/'));
+    public static NodeSelectorBuilder<ParserTokenNode, ParserTokenNodeName, ParserTokenNodeAttributeName, String> absoluteNodeSelectorBuilder() {
+        return NodeSelectorBuilder.absolute(PathSeparator.requiredAtStart('/'));
+    }
+
+    /**
+     * Relative {@see NodeSelectorBuilder}
+     */
+    public static NodeSelectorBuilder<ParserTokenNode, ParserTokenNodeName, ParserTokenNodeAttributeName, String> relativeNodeSelectorBuilder() {
+        return NodeSelectorBuilder.relative(PathSeparator.requiredAtStart('/'));
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/pojo/PojoNode.java
+++ b/src/main/java/walkingkooka/tree/pojo/PojoNode.java
@@ -44,12 +44,18 @@ public abstract class PojoNode implements Node<PojoNode, PojoName, PojoNodeAttri
         HasChildrenValues<Object, PojoNode>,
         Value<Object>,
         Comparable<PojoNode>{
+    /**
+     * Absolute {@see NodeSelectorBuilder}
+     */
+    public static NodeSelectorBuilder<PojoNode, PojoName, PojoNodeAttributeName, Object> absoluteNodeSelectorBuilder() {
+        return NodeSelectorBuilder.relative(PathSeparator.requiredAtStart('/'));
+    }
 
     /**
-     * {@see NodeSelectorBuilder}
+     * Relative {@see NodeSelectorBuilder}
      */
-    public static NodeSelectorBuilder<PojoNode, PojoName, PojoNodeAttributeName, Object> nodeSelectorBuilder() {
-        return NodeSelectorBuilder.create(PathSeparator.requiredAtStart('/'));
+    public static NodeSelectorBuilder<PojoNode, PojoName, PojoNodeAttributeName, Object> relativeNodeSelectorBuilder() {
+        return NodeSelectorBuilder.relative(PathSeparator.requiredAtStart('/'));
     }
 
     final static Optional<PojoNode> NO_PARENT = Optional.empty();

--- a/src/main/java/walkingkooka/tree/select/AbsoluteNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/AbsoluteNodeSelector.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  */
-
 package walkingkooka.tree.select;
 
 import walkingkooka.naming.Name;
@@ -26,24 +25,24 @@ import java.util.Set;
 
 
 /**
- * A {@link NodeSelector} that selects all the descendants of a given {@link Node} until all are visited.
+ * A {@link NodeSelector} that begins the search at the root of the graph.
  */
-final class DescendantNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+final class AbsoluteNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends
         UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
 
     /**
-     * Type safe {@link DescendantNodeSelector} getter
+     * Type safe {@link AbsoluteNodeSelector} getter
      */
-    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> DescendantNodeSelector<N, NAME, ANAME, AVALUE> with(final PathSeparator separator) {
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> AbsoluteNodeSelector<N, NAME, ANAME, AVALUE> with(final PathSeparator separator) {
         Objects.requireNonNull(separator, "separator");
-        return new DescendantNodeSelector(separator);
+        return new AbsoluteNodeSelector(separator);
     }
 
     /**
      * Private constructor use type safe getter
      */
-    private DescendantNodeSelector(final PathSeparator separator) {
+    private AbsoluteNodeSelector(final PathSeparator separator) {
         super();
         this.separator = separator;
     }
@@ -51,7 +50,7 @@ final class DescendantNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
     /**
      * Private constructor
      */
-    private DescendantNodeSelector(final PathSeparator separator, final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+    private AbsoluteNodeSelector(final PathSeparator separator, final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
         super(selector);
         this.separator = separator;
     }
@@ -59,10 +58,12 @@ final class DescendantNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
     // NodeSelector
 
     NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
-        // no point appending a descending to another...
-        return selector instanceof DescendantNodeSelector ?
-                this :
-                new DescendantNodeSelector(this.separator, selector);
+        // no point appending a descending to a absolute, as it already is a absolute search start...
+        return selector instanceof AbsoluteNodeSelector ?
+                this:
+                selector instanceof DescendantNodeSelector ?
+                        selector :
+                new AbsoluteNodeSelector(this.separator, selector);
     }
 
     @Override
@@ -72,18 +73,15 @@ final class DescendantNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
 
     @Override
     final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.matchChildren(node, context);
-    }
-
-    @Override
-    void match(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        super.match(node, context);
-        this.matchChildren(node, context);
+        this.match(node, context);
     }
 
     @Override
     void toString0(final StringBuilder b, String separator) {
-        b.append(this.separator).append(this.separator);
+        // must be first can never be next
+        if(this.separator.isRequiredAtStart()) {
+            b.append(this.separator);
+        }
         this.toStringNext(b, "");
     }
 
@@ -92,6 +90,6 @@ final class DescendantNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
 
     @Override
     boolean canBeEqual(final Object other) {
-        return other instanceof DescendantNodeSelector;
+        return other instanceof AbsoluteNodeSelector;
     }
 }

--- a/src/main/java/walkingkooka/tree/select/AncestorNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/AncestorNodeSelector.java
@@ -26,7 +26,7 @@ import walkingkooka.tree.Node;
  */
 final class AncestorNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends
-        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+        UnaryRelativeNodeSelector2<N, NAME, ANAME, AVALUE> {
 
     /**
      * Type safe {@link AncestorNodeSelector} getter

--- a/src/main/java/walkingkooka/tree/select/ChildrenNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/ChildrenNodeSelector.java
@@ -26,7 +26,7 @@ import walkingkooka.tree.Node;
  */
 final class ChildrenNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends
-        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+        UnaryRelativeNodeSelector2<N, NAME, ANAME, AVALUE> {
 
     /**
      * Type safe {@link ChildrenNodeSelector} getter

--- a/src/main/java/walkingkooka/tree/select/FirstChildNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/FirstChildNodeSelector.java
@@ -28,7 +28,7 @@ import walkingkooka.tree.Node;
  */
 final class FirstChildNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends
-        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+        UnaryRelativeNodeSelector2<N, NAME, ANAME, AVALUE> {
 
     /**
      * Type safe {@link FirstChildNodeSelector} getter

--- a/src/main/java/walkingkooka/tree/select/FollowingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/FollowingNodeSelector.java
@@ -29,7 +29,7 @@ import java.util.Optional;
  */
 final class FollowingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends
-        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+        UnaryRelativeNodeSelector2<N, NAME, ANAME, AVALUE> {
 
     /**
      * Type safe {@link FollowingNodeSelector} getter

--- a/src/main/java/walkingkooka/tree/select/FollowingSiblingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/FollowingSiblingNodeSelector.java
@@ -26,7 +26,7 @@ import walkingkooka.tree.Node;
  */
 final class FollowingSiblingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends
-        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+        UnaryRelativeNodeSelector2<N, NAME, ANAME, AVALUE> {
 
     /**
      * Type safe {@link FollowingSiblingNodeSelector} getter

--- a/src/main/java/walkingkooka/tree/select/IndexedChildNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/IndexedChildNodeSelector.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 final class IndexedChildNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends
-        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+        UnaryRelativeNodeSelector2<N, NAME, ANAME, AVALUE> {
 
     private final static int INDEX_BIAS = 1;
 

--- a/src/main/java/walkingkooka/tree/select/LastChildNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/LastChildNodeSelector.java
@@ -28,7 +28,7 @@ import walkingkooka.tree.Node;
  */
 final class LastChildNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends
-        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+        UnaryRelativeNodeSelector2<N, NAME, ANAME, AVALUE> {
 
     /**
      * Type safe {@link LastChildNodeSelector} getter

--- a/src/main/java/walkingkooka/tree/select/NamedNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/NamedNodeSelector.java
@@ -22,13 +22,14 @@ import walkingkooka.naming.PathSeparator;
 import walkingkooka.tree.Node;
 
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * A {@link NodeSelector} that selects all the ancestors of a given {@link Node} until the root of the graph is reached.
  */
 final class NamedNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends
-        UnaryNodeSelector<N, NAME, ANAME, AVALUE> {
+        UnaryRelativeNodeSelector<N, NAME, ANAME, AVALUE> {
 
     /**
      * Type safe {@link NamedNodeSelector} getter
@@ -67,7 +68,8 @@ final class NamedNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME exten
         return new NamedNodeSelector(this.name, this.separator, selector);
     }
 
-    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    @Override
+    final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         if (this.name.equals(node.name())) {
             this.match(node, context);
         }
@@ -76,8 +78,8 @@ final class NamedNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME exten
     private final NAME name;
 
     @Override
-    void toString0(final StringBuilder b, String separator) {
-        b.append(this.separator.character()).append(separator).append(this.name.value());
+    void toString0(final StringBuilder b, final String separator) {
+        b.append(separator).append(this.name.value());
 
         this.toStringNext(b, this.separator.string());
     }

--- a/src/main/java/walkingkooka/tree/select/NodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelector.java
@@ -33,7 +33,7 @@ public abstract class NodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
      * This method is only ever called by {@link Node#selector()}
      */
     public static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodeSelector<N, NAME, ANAME, AVALUE> path(final N node) {
-        return AbsolutePathNodeSelector.with(node);
+        return PathNodeSelector.with(node);
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorBuilder.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorBuilder.java
@@ -32,7 +32,18 @@ import java.util.function.Predicate;
  */
 public class NodeSelectorBuilder<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> implements Builder<NodeSelector<N, NAME, ANAME, AVALUE>> {
 
-    public static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodeSelectorBuilder<N, NAME, ANAME, AVALUE> create(final PathSeparator separator) {
+    /**
+     * Creates an selector that begins its search from the root of the graph.
+     */
+    public static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodeSelectorBuilder<N, NAME, ANAME, AVALUE> absolute(final PathSeparator separator) {
+        Objects.requireNonNull(separator, "separator");
+        return new NodeSelectorBuilder<>(separator);
+    }
+
+    /**
+     * Creates a selector that begins its search with the given node.
+     */
+    public static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodeSelectorBuilder<N, NAME, ANAME, AVALUE> relative(final PathSeparator separator) {
         Objects.requireNonNull(separator, "separator");
         return new NodeSelectorBuilder<>(separator);
     }
@@ -42,6 +53,13 @@ public class NodeSelectorBuilder<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
     private NodeSelectorBuilder(final PathSeparator separator) {
         super();
         this.separator = separator;
+    }
+
+    /**
+     * {@see AncestorNodeSelector}
+     */
+    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> absolute() {
+        return this.append(AbsoluteNodeSelector.with(this.separator));
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/select/ParentNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/ParentNodeSelector.java
@@ -26,7 +26,7 @@ import walkingkooka.tree.Node;
  */
 final class ParentNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends
-        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+        UnaryRelativeNodeSelector2<N, NAME, ANAME, AVALUE> {
 
     /**
      * Type safe {@link ParentNodeSelector} getter

--- a/src/main/java/walkingkooka/tree/select/PathNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PathNodeSelector.java
@@ -24,19 +24,20 @@ import walkingkooka.tree.Node;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
  * An absolute path for a {@link Node}.
  */
-final class AbsolutePathNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> extends UnaryNodeSelector<N, NAME, ANAME, AVALUE> {
+final class PathNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> extends UnaryRelativeNodeSelector<N, NAME, ANAME, AVALUE> {
 
     static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodeSelector<N, NAME, ANAME, AVALUE> with(final N node) {
         Objects.requireNonNull(node, "node");
-        return node.isRoot() ? SelfNodeSelector.get() : new AbsolutePathNodeSelector(node);
+        return node.isRoot() ? SelfNodeSelector.get() : new PathNodeSelector(node);
     }
 
-    private AbsolutePathNodeSelector(final N node) {
+    private PathNodeSelector(final N node) {
         final List<Integer> path = Lists.array();
         this.path = path;
         walkAncestorPath(node, path);
@@ -95,7 +96,7 @@ final class AbsolutePathNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAM
         return this.equals2(Cast.to(other));
     }
 
-    private boolean equals2(final AbsolutePathNodeSelector<N, NAME, ANAME, AVALUE> other) {
+    private boolean equals2(final PathNodeSelector<N, NAME, ANAME, AVALUE> other) {
         return this.path.equals(other.path);
     }
 

--- a/src/main/java/walkingkooka/tree/select/PrecedingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PrecedingNodeSelector.java
@@ -29,7 +29,7 @@ import java.util.Optional;
  */
 final class PrecedingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends
-        UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+        UnaryRelativeNodeSelector2<N, NAME, ANAME, AVALUE> {
 
     /**
      * Type safe {@link PrecedingNodeSelector} getter

--- a/src/main/java/walkingkooka/tree/select/PrecedingSiblingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PrecedingSiblingNodeSelector.java
@@ -25,7 +25,7 @@ import walkingkooka.tree.Node;
  * A {@link NodeSelector} that selects all the preceding siblings of a given {@link Node}.
  */
 final class PrecedingSiblingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
-        extends UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+        extends UnaryRelativeNodeSelector2<N, NAME, ANAME, AVALUE> {
 
     /**
      * Type safe {@link PrecedingSiblingNodeSelector} getter

--- a/src/main/java/walkingkooka/tree/select/PredicateNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PredicateNodeSelector.java
@@ -29,7 +29,7 @@ import java.util.function.Predicate;
  */
 final class PredicateNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends
-        UnaryNodeSelector<N, NAME, ANAME, AVALUE> {
+        UnaryRelativeNodeSelector<N, NAME, ANAME, AVALUE> {
 
     /**
      * Type safe {@link PredicateNodeSelector} getter
@@ -61,7 +61,8 @@ final class PredicateNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
         return new PredicateNodeSelector(this.predicate, selector);
     }
 
-    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    @Override
+    final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         if(this.predicate.test(node)){
             context.match(node);
         }

--- a/src/main/java/walkingkooka/tree/select/SelfNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/SelfNodeSelector.java
@@ -27,7 +27,7 @@ import java.util.List;
  * A {@link NodeSelector} that pushes any given {@link Node} to the {@link List}.
  */
 final class SelfNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
-        extends UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+        extends UnaryRelativeNodeSelector2<N, NAME, ANAME, AVALUE> {
 
     /**
      * Type safe {@link ChildrenNodeSelector} getter

--- a/src/main/java/walkingkooka/tree/select/UnaryNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/UnaryNodeSelector.java
@@ -49,8 +49,7 @@ abstract class UnaryNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
     
     abstract NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector);
 
-    @Override
-    public final Set<N> accept(final N node) {
+    final Set<N> accept0(final N node) {
         final Set<N> matches = Sets.ordered();
         this.accept(node, new NodeSelectorNodeSelectorContext<>(matches));
         return matches;

--- a/src/main/java/walkingkooka/tree/select/UnaryRelativeNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/UnaryRelativeNodeSelector.java
@@ -22,25 +22,24 @@ package walkingkooka.tree.select;
 import walkingkooka.naming.Name;
 import walkingkooka.tree.Node;
 
+import java.util.Set;
+
 /**
- * Base class for all non logical (binary) selectors without any additional properties.
+ * Base class for all non logical (binary) selectors.
  */
-abstract class UnaryNodeSelector2<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+abstract class UnaryRelativeNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
     extends UnaryNodeSelector<N, NAME, ANAME, AVALUE> {
 
-    UnaryNodeSelector2() {
-        super();
+    UnaryRelativeNodeSelector() {
+        this(TerminalNodeSelector.get());
     }
 
-    UnaryNodeSelector2(final NodeSelector<N, NAME, ANAME, AVALUE> next) {
+    UnaryRelativeNodeSelector(final NodeSelector<N, NAME, ANAME, AVALUE> next) {
         super(next);
     }
 
-    final int hashCode0(final NodeSelector<N, NAME, ANAME, AVALUE> next) {
-        return next.hashCode();
-    }
-
-    final boolean equals1(final UnaryNodeSelector<N, NAME, ANAME, AVALUE> other) {
-        return true; // no extra properties...
+    @Override
+    public final Set<N> accept(final N node) {
+        return this.accept0(node);
     }
 }

--- a/src/main/java/walkingkooka/tree/select/UnaryRelativeNodeSelector2.java
+++ b/src/main/java/walkingkooka/tree/select/UnaryRelativeNodeSelector2.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Set;
+
+/**
+ * Base class for all non logical (binary) selectors without any additional properties.
+ */
+abstract class UnaryRelativeNodeSelector2<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
+    extends UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+
+    UnaryRelativeNodeSelector2() {
+        super();
+    }
+
+    UnaryRelativeNodeSelector2(final NodeSelector<N, NAME, ANAME, AVALUE> next) {
+        super(next);
+    }
+
+    @Override
+    public final Set<N> accept(final N node) {
+        return this.accept0(node);
+    }
+}

--- a/src/main/java/walkingkooka/xml/DomNode.java
+++ b/src/main/java/walkingkooka/xml/DomNode.java
@@ -69,6 +69,13 @@ public abstract class DomNode implements walkingkooka.tree.Node<DomNode, DomName
     public final static Optional<DomElement> NO_ELEMENT = Optional.empty();
 
     /**
+     * Absolute {@see NodeSelectorBuilder}
+     */
+    public static NodeSelectorBuilder<DomNode, DomName, DomAttributeName, String> absoluteNodeSelectorBuilder() {
+        return NodeSelectorBuilder.absolute(PathSeparator.requiredAtStart('/'));
+    }
+
+    /**
      * {@see DomAtttributeName}
      */
     public static DomAttributeName attribute(final String name, final Optional<DomNameSpacePrefix> prefix) {
@@ -108,10 +115,10 @@ public abstract class DomNode implements walkingkooka.tree.Node<DomNode, DomName
     }
 
     /**
-     * {@see NodeSelectorBuilder}
+     * relative {@see NodeSelectorBuilder}
      */
-    public static NodeSelectorBuilder<DomNode, DomName, DomAttributeName, String> nodeSelectorBuilder() {
-        return NodeSelectorBuilder.create(PathSeparator.requiredAtStart('/'));
+    public static NodeSelectorBuilder<DomNode, DomName, DomAttributeName, String> relativeNodeSelectorBuilder() {
+        return NodeSelectorBuilder.relative(PathSeparator.requiredAtStart('/'));
     }
 
     /**

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenNodeTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenNodeTest.java
@@ -126,7 +126,7 @@ public class SequenceParserTokenNodeTest extends ParserTokenNodeTestCase<Sequenc
 
     @Test
     public void testSelectorByName() {
-        final NodeSelector<ParserTokenNode, ParserTokenNodeName, ParserTokenNodeAttributeName, String> selector = ParserTokenNode.nodeSelectorBuilder()
+        final NodeSelector<ParserTokenNode, ParserTokenNodeName, ParserTokenNodeAttributeName, String> selector = ParserTokenNode.absoluteNodeSelectorBuilder()
                 .descendant()
                 .named(StringParserToken.NAME)
                 .build();

--- a/src/test/java/walkingkooka/tree/pojo/PojoNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoNodeTest.java
@@ -32,7 +32,7 @@ public final class PojoNodeTest extends PublicClassTestCase<PojoNode> {
     public void testSelectorNodeByClassName() {
         final TestBean bean = new TestBean("1", "2", 99, "3");
 
-        final NodeSelector<PojoNode, PojoName, PojoNodeAttributeName, Object> selector = PojoNode.nodeSelectorBuilder()
+        final NodeSelector<PojoNode, PojoName, PojoNodeAttributeName, Object> selector = PojoNode.absoluteNodeSelectorBuilder()
                 .descendant()
                 .attributeValueEquals(PojoNodeAttributeName.CLASS, String.class.getName())
                 .build();

--- a/src/test/java/walkingkooka/tree/select/AbsoluteNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/AbsoluteNodeSelectorTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.tree.select;
+
+import org.junit.Assert;
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.PathSeparator;
+import walkingkooka.naming.StringName;
+import walkingkooka.predicate.Predicates;
+
+import java.util.function.Predicate;
+
+final public class AbsoluteNodeSelectorTest extends
+        UnaryNodeSelectorTestCase<AbsoluteNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+
+    private final static PathSeparator SEPARATOR = PathSeparator.requiredAtStart('/');
+    private final static Predicate<TestFakeNode> PREDICATE = Predicates.always();
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullPathSeparatorFails() {
+        AbsoluteNodeSelector.with(null);
+    }
+
+    @Test
+    public void testAppendDescendant() {
+        final DescendantNodeSelector<TestFakeNode, StringName, StringName, Object> descendantNodeSelector = DescendantNodeSelector.with(SEPARATOR);
+        assertSame(descendantNodeSelector, this.createSelector().append(descendantNodeSelector));
+    }
+
+    @Test
+    public void testRoot() {
+        final TestFakeNode root = TestFakeNode.node("root");
+        this.acceptAndCheck(root, root);
+    }
+
+    @Test
+    public void testIgnoresDescedants() {
+        final TestFakeNode grandChild = TestFakeNode.node("grandChild");
+        final TestFakeNode child = TestFakeNode.node("child!", grandChild);
+        final TestFakeNode parent = TestFakeNode.node("parent!", child);
+
+        this.acceptAndCheck(parent, parent);
+    }
+
+    @Test
+    public void testStartUnimportant() {
+        final TestFakeNode grandChild = TestFakeNode.node("grandChild");
+        final TestFakeNode child = TestFakeNode.node("child!", grandChild);
+        final TestFakeNode parent = TestFakeNode.node("parent!", child);
+
+        this.acceptAndCheck(parent.child(0), parent);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("/", this.createSelector().toString());
+    }
+
+    @Test
+    public void testToString2() {
+        Assert.assertEquals("/" + PREDICATE, this.createSelector2().toString());
+    }
+
+    @Test
+    public void testToStringPathSeparatorNotRequiredAtStart() {
+        final PathSeparator separator = PathSeparator.notRequiredAtStart('/');
+        Assert.assertEquals("", this.createSelector(separator).toString());
+    }
+
+    @Override
+    protected AbsoluteNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return this.createSelector(SEPARATOR);
+    }
+
+    private AbsoluteNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector(final PathSeparator separator) {
+        return AbsoluteNodeSelector.with(separator);
+    }
+
+    private NodeSelector<TestFakeNode, StringName, StringName, Object> createSelector2() {
+        return this.createSelector().append(PredicateNodeSelector.with(PREDICATE));
+    }
+
+    @Override
+    protected Class<AbsoluteNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(AbsoluteNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/select/DescendantNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/DescendantNodeSelectorTest.java
@@ -88,6 +88,14 @@ final public class DescendantNodeSelectorTest extends
         Assert.assertEquals("//", this.createSelector().toString());
     }
 
+    @Test
+    public void testToStringAbsolute() {
+        Assert.assertEquals("//",
+                AbsoluteNodeSelector.<TestFakeNode, StringName, StringName, Object>with(SEPARATOR)
+                        .append(this.createSelector())
+                        .toString());
+    }
+
     @Override
     protected DescendantNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
         return DescendantNodeSelector.with(SEPARATOR);

--- a/src/test/java/walkingkooka/tree/select/NamedNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NamedNodeSelectorTest.java
@@ -74,17 +74,12 @@ final public class NamedNodeSelectorTest extends
 
     @Test
     public void testToString() {
-        Assert.assertEquals("/" + NAME.value(), this.createSelector().toString());
-    }
-
-    @Test
-    public void testToString2() {
-        Assert.assertEquals("!" + NAME.value(),  this.createSelector(PathSeparator.requiredAtStart('!')).toString());
+        Assert.assertEquals(NAME.value(), this.createSelector().toString());
     }
 
     @Test
     public void testToStringPathSeparatorNotRequiredAtStart() {
-        Assert.assertEquals("/" + NAME.value(),  this.createSelector(PathSeparator.notRequiredAtStart('/')).toString());
+        Assert.assertEquals(NAME.value(),  this.createSelector(PathSeparator.notRequiredAtStart('/')).toString());
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorBuilderTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorBuilderTest.java
@@ -283,7 +283,7 @@ public final class NodeSelectorBuilderTest extends BuilderTestCase<NodeSelectorB
         b.named(Names.string(PARENT))
                 .attributeValueContains(Names.string("attribute-name"), "attribute-value");
 
-        assertEquals("/parent[contains(@\"attribute-name\",\"attribute-value\")]", b.build().toString());
+        assertEquals("parent[contains(@\"attribute-name\",\"attribute-value\")]", b.build().toString());
     }
 
     @Test
@@ -307,6 +307,6 @@ public final class NodeSelectorBuilderTest extends BuilderTestCase<NodeSelectorB
     }
 
     @Override protected NodeSelectorBuilder<TestFakeNode, StringName, StringName, Object> createBuilder() {
-        return NodeSelectorBuilder.create(PathSeparator.requiredAtStart('/'));
+        return NodeSelectorBuilder.absolute(PathSeparator.requiredAtStart('/'));
     }
 }

--- a/src/test/java/walkingkooka/tree/select/PathNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/PathNodeSelectorTest.java
@@ -21,8 +21,8 @@ import org.junit.Test;
 import walkingkooka.Cast;
 import walkingkooka.naming.StringName;
 
-final public class AbsolutePathNodeSelectorTest extends
-        UnaryNodeSelectorTestCase<AbsolutePathNodeSelector<TestFakeNode, StringName, StringName, Object>> {
+final public class PathNodeSelectorTest extends
+        UnaryNodeSelectorTestCase<PathNodeSelector<TestFakeNode, StringName, StringName, Object>> {
 
     private static TestFakeNode make() {
         final TestFakeNode childChild = TestFakeNode.node("childChild");
@@ -49,44 +49,44 @@ final public class AbsolutePathNodeSelectorTest extends
 
     @Test
     public void testRoot() {
-        this.acceptAndCheck(AbsolutePathNodeSelector.with(ROOT), ROOT, ROOT);
+        this.acceptAndCheck(PathNodeSelector.with(ROOT), ROOT, ROOT);
     }
 
     @Test
     public void testDescendant() {
         final TestFakeNode child2 = child3();
-        this.acceptAndCheck(AbsolutePathNodeSelector.with(child2), ROOT, child2);
+        this.acceptAndCheck(PathNodeSelector.with(child2), ROOT, child2);
     }
 
     @Test
     public void testDescendantLeaf() {
         final TestFakeNode childChild = childChild();
-        this.acceptAndCheck(AbsolutePathNodeSelector.with(childChild), ROOT, childChild);
+        this.acceptAndCheck(PathNodeSelector.with(childChild), ROOT, childChild);
     }
 
     @Test
     public void testNotFound() {
         final TestFakeNode childChild = childChild();
-        this.acceptAndCheck(AbsolutePathNodeSelector.with(childChild), child3());
+        this.acceptAndCheck(PathNodeSelector.with(childChild), child3());
     }
 
     @Test
     public void testToString() {
-        Assert.assertEquals(".", AbsolutePathNodeSelector.with(ROOT).toString());
+        Assert.assertEquals(".", PathNodeSelector.with(ROOT).toString());
     }
 
     @Test
     public void testToString2() {
-        Assert.assertEquals("[3][2]", AbsolutePathNodeSelector.with(child3()).toString());
+        Assert.assertEquals("[3][2]", PathNodeSelector.with(child3()).toString());
     }
 
     @Override
-    protected AbsolutePathNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
-        return Cast.to(AbsolutePathNodeSelector.with(child3()));
+    protected PathNodeSelector<TestFakeNode, StringName, StringName, Object> createSelector() {
+        return Cast.to(PathNodeSelector.with(child3()));
     }
 
     @Override
-    protected Class<AbsolutePathNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
-        return Cast.to(AbsolutePathNodeSelector.class);
+    protected Class<PathNodeSelector<TestFakeNode, StringName, StringName, Object>> type() {
+        return Cast.to(PathNodeSelector.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/select/SelfNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/SelfNodeSelectorTest.java
@@ -20,6 +20,8 @@ package walkingkooka.tree.select;
 import org.junit.Assert;
 import org.junit.Test;
 import walkingkooka.Cast;
+import walkingkooka.naming.Names;
+import walkingkooka.naming.PathSeparator;
 import walkingkooka.naming.StringName;
 
 final public class SelfNodeSelectorTest
@@ -29,6 +31,54 @@ final public class SelfNodeSelectorTest
     public void testSelf() {
         final TestFakeNode node = TestFakeNode.node("self");
         this.acceptAndCheck(node, node);
+    }
+
+    @Test
+    public void testSelfAndDescendant() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(selfAndDescendant(),
+                parent,
+                child);
+    }
+
+    @Test
+    public void testSelfAndDescendant2() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(selfAndDescendant(),
+                parent.child(0));
+    }
+
+    private NodeSelector<TestFakeNode, StringName, StringName, Object> selfAndDescendant() {
+        return Cast.to(SelfNodeSelector.get()
+                .append(DescendantNodeSelector.with(PathSeparator.requiredAtStart('/'))));
+    }
+
+    @Test
+    public void testSelfAndNamed() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(selfAndNamed(),
+                parent);
+    }
+
+    @Test
+    public void testSelfAndNamed2() {
+        final TestFakeNode child = TestFakeNode.node("child");
+        final TestFakeNode parent = TestFakeNode.node("parent", child);
+
+        this.acceptAndCheck(selfAndNamed(),
+                parent.child(0),
+                child);
+    }
+
+    private NodeSelector<TestFakeNode, StringName, StringName, Object> selfAndNamed() {
+        return Cast.to(SelfNodeSelector.get()
+                .append(NamedNodeSelector.with(Names.string("child"), PathSeparator.requiredAtStart('/'))));
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/select/UnaryNodeSelectorTestCase.java
+++ b/src/test/java/walkingkooka/tree/select/UnaryNodeSelectorTestCase.java
@@ -17,11 +17,11 @@
 
 package walkingkooka.tree.select;
 
-import org.junit.Assert;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.naming.StringName;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public abstract class UnaryNodeSelectorTestCase<S extends NodeSelector<TestFakeNode, StringName, StringName, Object>>
 extends NodeSelectorTestCase<S>{
@@ -37,27 +37,13 @@ extends NodeSelectorTestCase<S>{
         this.acceptAndCheckUsingContext(selector, start, nodes);
     }
 
-    final void acceptAndCheckRequiringOrder(NodeSelector<TestFakeNode, StringName, StringName, Object> selector, TestFakeNode start, String[] nodes) {
-        final List<String> expected = Lists.array();
-        expected.addAll(Lists.of(nodes));
-
-        selector.accept(start, new NodeSelectorContext<TestFakeNode, StringName, StringName, Object>() {
-
-            int i = 0;
-
-            @Override void match(final TestFakeNode node) {
-                if(i == nodes.length) {
-                    Assert.fail("Unexpected matching node: " + node);
-                }
-
-                if(!nodes[i].equals(node.name().value())){
-                    Assert.fail("Unexpected node " + node + " expected "+ nodes[i]);
-                }
-                expected.remove(0);
-                i++;
-            }
-        });
-
-        assertEquals("Finished processing contains unmatched nodes", Lists.empty(), expected);
+    final void acceptAndCheckRequiringOrder(final NodeSelector<TestFakeNode, StringName, StringName, Object> selector,
+                                            final TestFakeNode start,
+                                            final String[] nodes) {
+        final List<String> actual = selector.accept(start)
+                .stream()
+                .map(n -> n.name().value())
+                .collect(Collectors.toList());
+        assertEquals("names of matched nodes", Lists.of(nodes), actual);
     }
 }

--- a/src/test/java/walkingkooka/tree/select/UnaryRelativeNodeSelector2Test.java
+++ b/src/test/java/walkingkooka/tree/select/UnaryRelativeNodeSelector2Test.java
@@ -20,8 +20,9 @@ package walkingkooka.tree.select;
 import walkingkooka.Cast;
 import walkingkooka.test.PackagePrivateClassTestCase;
 
-public final class UnaryNodeSelector2Test extends PackagePrivateClassTestCase<UnaryNodeSelector2<?, ?, ?, ?>> {
-    @Override protected Class<UnaryNodeSelector2<?, ?, ?, ?>> type() {
-        return Cast.to(UnaryNodeSelector2.class);
+public final class UnaryRelativeNodeSelector2Test extends PackagePrivateClassTestCase<UnaryRelativeNodeSelector2<?, ?, ?, ?>> {
+    @Override
+    protected Class<UnaryRelativeNodeSelector2<?, ?, ?, ?>> type() {
+        return Cast.to(UnaryRelativeNodeSelector2.class);
     }
 }

--- a/src/test/java/walkingkooka/tree/select/UnaryRelativeNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/UnaryRelativeNodeSelectorTest.java
@@ -1,0 +1,30 @@
+/*
+ *
+ *  * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *  *
+ *
+ */
+
+package walkingkooka.tree.select;
+
+import walkingkooka.Cast;
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class UnaryRelativeNodeSelectorTest extends PackagePrivateClassTestCase<UnaryRelativeNodeSelector<?, ?, ?, ?>> {
+    @Override
+    protected Class<UnaryRelativeNodeSelector<?, ?, ?, ?>> type() {
+        return Cast.to(UnaryRelativeNodeSelector.class);
+    }
+}

--- a/src/test/java/walkingkooka/xml/DomDocumentTest.java
+++ b/src/test/java/walkingkooka/xml/DomDocumentTest.java
@@ -778,7 +778,7 @@ public final class DomDocumentTest extends DomParentNodeTestCase<DomDocument> {
     @Test
     public void testSelectorUsage() throws Exception {
         final DomDocument document = this.fromXml();
-        final NodeSelector<DomNode, DomName, DomAttributeName, String> selector = DomNode.nodeSelectorBuilder()
+        final NodeSelector<DomNode, DomName, DomAttributeName, String> selector = DomNode.absoluteNodeSelectorBuilder()
                 .descendant()
                 .named(DomName.element("img"))
                 .build();
@@ -790,7 +790,7 @@ public final class DomDocumentTest extends DomParentNodeTestCase<DomDocument> {
     public void testSelectorUsage2() throws Exception {
         final DomDocument document = this.fromXml();
 
-        final NodeSelector<DomNode, DomName, DomAttributeName, String> selector = DomNode.nodeSelectorBuilder()
+        final NodeSelector<DomNode, DomName, DomAttributeName, String> selector = DomNode.absoluteNodeSelectorBuilder()
                 .descendant()
                 .named(DomName.element("a"))
                 .attributeValueContains(DomNode.attribute("href", DomNode.NO_PREFIX), "19")


### PR DESCRIPTION
- Named no longer assumes absolute.
- NodeSelectionBuilder now has two public factories absolute and relative.
- Updated sub classes of Node previously offering one type safe NodeSelectionBuilder to have
 2 (abs + rel).
- Improved naming of AbsolutePathNodeSelector renamed to PathNodeSelector.