### PR TITLE
Added default method Parser.build.

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/Parser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/Parser.java
@@ -36,6 +36,22 @@ public interface Parser<T extends ParserToken, C extends ParserContext> {
     Optional<T> parse(final TextCursor cursor, final C context);
 
     /**
+     * Creates a new {@link SequenceParserBuilder} and adds this parser as a required(default) or optional(if already an optional).
+     * The builder may then be used to continue building...
+     */
+    default <C extends ParserContext> SequenceParserBuilder<C> builder(final ParserTokenNodeName name){
+        Objects.requireNonNull(name, "name");
+
+        final SequenceParserBuilder<C> builder = Parsers.sequenceParserBuilder();
+        if(this instanceof OptionalParser) {
+            builder.optional(this.castC(), name);
+        } else {
+            builder.required(this.castC(), name);
+        }
+        return builder;
+    }
+
+    /**
      * Converts this parser into an optional.
      */
     default Parser<ParserToken, C> optional(final ParserTokenNodeName name) {
@@ -61,7 +77,15 @@ public interface Parser<T extends ParserToken, C extends ParserContext> {
     /**
      * Helper that makes casting and working around generics a little less noisy.
      */
-    default <P extends Parser<T, C>, T extends ParserToken> P cast() {
+    default <P extends Parser<T, C>, T extends ParserToken> P castTC() {
+        return Cast.to(this);
+    }
+
+
+    /**
+     * Helper that makes casting and working around generics a little less noisy.
+     */
+    default <C extends ParserContext> Parser<ParserToken, C> castC() {
         return Cast.to(this);
     }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTestCase.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTestCase.java
@@ -59,6 +59,11 @@ public abstract class ParserTestCase<P extends Parser<T, C>, T extends ParserTok
         assertEquals("" + parser, RepeatedParser.class, parser.getClass());
     }
 
+    @Test(expected = NullPointerException.class)
+    public final void testBuilderWithNull() {
+        this.createParser().builder(null);
+    }
+
     @Test
     public void testOr() {
         final P parser = this.createParser();

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokenNodeName.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokenNodeName.java
@@ -53,11 +53,42 @@ public final class ParserTokenNodeName implements Name {
     }
 
     /**
+     * Creates a new {@link ParserTokenNodeName} with an index.
+     */
+    public static ParserTokenNodeName with(final int index) {
+        if(index < 0) {
+            throw new IllegalArgumentException("Index " + index + " must not be negative");
+        }
+        return new ParserTokenNodeName(index);
+    }
+
+    /**
      * Package private ctor to limit creation.
      */
     ParserTokenNodeName(final String value) {
-        this.value = value;
+        this(value, -1);
     }
+
+    /**
+     * Package private ctor to limit creation.
+     */
+    ParserTokenNodeName(final int index) {
+        this(String.valueOf(index), index);
+    }
+
+    /**
+     * Private ctor to limit creation.
+     */
+    private ParserTokenNodeName(final String value, final int index) {
+        this.value = value;
+        this.index = index;
+    }
+
+    int index() {
+        return this.index;
+    }
+
+    private final int index;
 
     @Override
     public String value() {

--- a/src/main/java/walkingkooka/text/cursor/parser/RepeatedParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/RepeatedParser.java
@@ -33,7 +33,7 @@ final class RepeatedParser<T extends ParserToken, C extends ParserContext> exten
         Objects.requireNonNull(parser, "parser");
 
         return parser instanceof RepeatedParser ?
-                parser.cast() :
+                parser.castTC() :
                 new RepeatedParser<>(parser);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/SequenceParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SequenceParser.java
@@ -18,7 +18,9 @@
  */
 package walkingkooka.text.cursor.parser;
 
+import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.test.HashCodeEqualsDefined;
 import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.text.cursor.TextCursorSavePoint;
 
@@ -28,7 +30,7 @@ import java.util.Optional;
 /**
  * A {@link Parser} that requires all parsers are matched in order returning all tokens within a {@link SequenceParserToken}
  */
-final class SequenceParser<C extends ParserContext> extends ParserTemplate2<SequenceParserToken, C> {
+final class SequenceParser<C extends ParserContext> extends ParserTemplate2<SequenceParserToken, C> implements HashCodeEqualsDefined {
 
     /**
      * Factory method only called by {@link SequenceParserBuilder#build()}
@@ -63,6 +65,22 @@ final class SequenceParser<C extends ParserContext> extends ParserTemplate2<Sequ
     }
 
     private final List<SequenceParserComponent<C>> components;
+
+    // Object .............................................................................................................
+
+    @Override
+    public int hashCode() {
+        return this.components.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other || other instanceof SequenceParser && this.equals0(Cast.to(other));
+    }
+
+    private boolean equals0(final SequenceParser<?> other){
+        return this.components.equals(other.components);
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/walkingkooka/text/cursor/parser/SequenceParserBuilder.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SequenceParserBuilder.java
@@ -49,6 +49,7 @@ public final class SequenceParserBuilder<C extends ParserContext> implements Bui
     }
 
     private SequenceParserBuilder<C> add(final SequenceParserComponent component) {
+        component.checkName(this.components);
         this.components.add(component);
         return this;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/SequenceParserComponent.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SequenceParserComponent.java
@@ -16,6 +16,8 @@
  */
 package walkingkooka.text.cursor.parser;
 
+import walkingkooka.Cast;
+import walkingkooka.test.HashCodeEqualsDefined;
 import walkingkooka.text.cursor.TextCursor;
 
 import java.util.List;
@@ -26,7 +28,7 @@ import java.util.stream.Collectors;
 /**
  * A component within one of several parsers in a sequence.
  */
-abstract class SequenceParserComponent<C extends ParserContext> {
+abstract class SequenceParserComponent<C extends ParserContext> implements HashCodeEqualsDefined {
 
     SequenceParserComponent(final Parser<ParserToken, C> parser, final ParserTokenNodeName name) {
         Objects.requireNonNull(parser, "parser");
@@ -38,8 +40,37 @@ abstract class SequenceParserComponent<C extends ParserContext> {
 
     abstract Optional<ParserToken> parse(final TextCursor cursor, final C context);
 
+    final void checkName(final List<SequenceParserComponent<C>> components) {
+        final int index = this.name.index();
+        if(index != -1) {
+            final int requiredIndex = components.size();
+            if(index != requiredIndex) {
+                throw new IllegalArgumentException("Name contains invalid index " + index + " should have been " + requiredIndex);
+            }
+        }
+    }
+
     final Parser<ParserToken, C> parser;
     final ParserTokenNodeName name;
+
+    // Object .............................................................................................................
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.parser, this.name);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+                this.canBeEqual(other) && this.equals0(Cast.to(other));
+    }
+
+    abstract boolean canBeEqual(final Object other);
+
+    private boolean equals0(final SequenceParserComponent<?> other){
+        return this.parser.equals(other.parser) && this.name.equals(other.name);
+    }
 
     @Override
     abstract public String toString();

--- a/src/main/java/walkingkooka/text/cursor/parser/SequenceParserOptionalComponent.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SequenceParserOptionalComponent.java
@@ -39,6 +39,11 @@ final class SequenceParserOptionalComponent<C extends ParserContext> extends Seq
     }
 
     @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof SequenceParserOptionalComponent;
+    }
+
+    @Override
     public final String toString() {
         return this.parser.toString().concat("?");
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/SequenceParserRequiredComponent.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SequenceParserRequiredComponent.java
@@ -32,6 +32,11 @@ final class SequenceParserRequiredComponent<C extends ParserContext> extends Seq
     }
 
     @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof SequenceParserRequiredComponent;
+    }
+
+    @Override
     public final String toString() {
         return this.parser.toString();
     }

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserTokenNodeNameTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserTokenNodeNameTest.java
@@ -52,10 +52,21 @@ public final class ParserTokenNodeNameTest extends NameTestCase<ParserTokenNodeN
         ParserTokenNodeName.with("Hello Goodbye");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testWithNegativeIndexFails() {
+        ParserTokenNodeName.with(-1);
+    }
+
     @Test
     public void testWith() {
         final ParserTokenNodeName name = ParserTokenNodeName.with("Hello");
         assertEquals("name.value", "Hello", name.value());
+    }
+
+    @Test
+    public void testWithIndex() {
+        final ParserTokenNodeName name = ParserTokenNodeName.with(1);
+        assertEquals("name.value", "1", name.value());
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserBuilderTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserBuilderTest.java
@@ -46,6 +46,32 @@ public final class SequenceParserBuilderTest extends BuilderTestCase<SequencePar
         this.createBuilder().required(PARSER1, null);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testOptionalInvalidIndexName() {
+        this.createBuilder()
+                .optional(PARSER1, ParserTokenNodeName.with(1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRequiredInvalidIndexName() {
+        this.createBuilder()
+                .required(PARSER1, ParserTokenNodeName.with(1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testOptionalInvalidIndexName2() {
+        this.createBuilder()
+                .optional(PARSER1, ParserTokenNodeName.with(0))
+                .optional(PARSER1, ParserTokenNodeName.with(2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRequiredInvalidIndexName2() {
+        this.createBuilder()
+                .required(PARSER1, ParserTokenNodeName.with(0))
+                .required(PARSER1, ParserTokenNodeName.with(2));
+    }
+
     @Test(expected = BuilderException.class)
     public void testBuildOneParserFails() {
         this.createBuilder()
@@ -58,6 +84,13 @@ public final class SequenceParserBuilderTest extends BuilderTestCase<SequencePar
         SequenceParserBuilder.create()
                 .optional(PARSER1, StringParserToken.NAME)
                 .required(PARSER2, StringParserToken.NAME)
+                .build();
+    }
+
+    @Test
+    public void testParserBuilder() {
+        PARSER1.builder(StringParserToken.NAME)
+                .optional(PARSER2.castC(), StringParserToken.NAME)
                 .build();
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserEqualityTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserEqualityTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import walkingkooka.test.HashCodeEqualsDefinedEqualityTestCase;
+
+public final class SequenceParserEqualityTest extends HashCodeEqualsDefinedEqualityTestCase<SequenceParser> {
+
+    private final static Parser<StringParserToken, FakeParserContext> PARSER1 = Parsers.string("a");
+    private final static Parser<StringParserToken, FakeParserContext> PARSER2 = Parsers.string("b");
+    private final static Parser<StringParserToken, FakeParserContext> PARSER3 = Parsers.string("c");
+    
+    private final static ParserTokenNodeName NAME1 = ParserTokenNodeName.with(0);
+    private final static ParserTokenNodeName NAME2 = ParserTokenNodeName.with(1);
+    private final static ParserTokenNodeName NAME3 = ParserTokenNodeName.with(2);
+
+    @Test
+    @Ignore
+    public void testEqualsOnlyOverridesAbstractOrObject() {
+        // nop
+    }
+
+    @Test
+    public void testDifferent() {
+        this.checkNotEquals(SequenceParserBuilder.create()
+                .required(PARSER3, NAME1)
+                .required(PARSER2, NAME2)
+                .required(PARSER1, NAME3)
+                .build());
+    }
+
+    @Test
+    public void testDifferentRequiredOptionals() {
+        this.checkNotEquals(SequenceParserBuilder.create()
+                .optional(PARSER1, NAME1)
+                .required(PARSER2, NAME2)
+                .required(PARSER3, NAME3)
+                .build());
+    }
+
+    @Test
+    public void testEqualsBuiltUsingDefaultMethods() {
+        this.checkEquals(PARSER1.builder(NAME1)
+                .required(PARSER2.castC(), NAME2)
+                .optional(PARSER3.castC(), NAME3)
+                .build());
+    }
+
+    @Override
+    protected SequenceParser createObject() {
+        return SequenceParserBuilder.create()
+                .required(PARSER1, NAME1)
+                .required(PARSER2, NAME2)
+                .optional(PARSER3, NAME3)
+                .build();
+    }
+}


### PR DESCRIPTION
- Updated ParserTokenNodeName to include an with(int index).
- SequenceParserBuilder public methods complain if PTTN index is "wrong".
- SequenceParser now implements hashcode + equals
- Added default methods to assist casting to Parser.