### PR TITLE
Parsing text containing a EBNF grammar into tokens.

### DIFF
--- a/src/main/java/walkingkooka/test/ClassTestCase.java
+++ b/src/main/java/walkingkooka/test/ClassTestCase.java
@@ -108,7 +108,8 @@ abstract public class ClassTestCase<T> extends TestCase {
         }
     }
 
-    @Test final public void testAllFieldsVisibility() {
+    @Test
+    public void testAllFieldsVisibility() {
         final Class<T> type = this.type();
         if (false == type.isAnnotationPresent(PublicClass.class)) {
             if (false == type.isEnum()) {

--- a/src/main/java/walkingkooka/test/PackagePrivateClassTestCase.java
+++ b/src/main/java/walkingkooka/test/PackagePrivateClassTestCase.java
@@ -37,21 +37,24 @@ abstract public class PackagePrivateClassTestCase<T> extends ClassTestCase<T> {
         super();
     }
 
-    @Test final public void testClassIsFinalIfAllConstructorsArePrivate() {
+    @Test
+    public void testClassIsFinalIfAllConstructorsArePrivate() {
         this.classIsFinalIfAllConstructorsArePrivateTest();
     }
 
     /**
      * Constructor is private if this class is final, otherwise they are package private.
      */
-    @Test final public void testAllConstructorsArePackagePrivateOrPrivate() {
+    @Test
+    public void testAllConstructorsArePackagePrivateOrPrivate() {
         this.checkAllConstructorsVisibility();
     }
 
     /**
      * If a method is not overridden it should be package private or private.
      */
-    @Test final public void testAllMethodsVisibility() {
+    @Test
+    public void testAllMethodsVisibility() {
         final Class<T> type = this.type();
         if (false == type.isAnnotationPresent(PublicClass.class)) {
             final Set<Method> overridable = this.overridableMethods(type);

--- a/src/main/java/walkingkooka/text/cursor/parser/Parser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/Parser.java
@@ -104,4 +104,11 @@ public interface Parser<T extends ParserToken, C extends ParserContext> {
     default <C extends ParserContext> Parser<ParserToken, C> castC() {
         return Cast.to(this);
     }
+
+    /**
+     * Helper that makes casting and working around generics a little less noisy.
+     */
+    default <TT extends ParserToken> Parser<TT, C> cast(final Class<TT> token) {
+        return Cast.to(this);
+    }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTestCase3.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTestCase3.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser;
+
+/**
+ * The same as {@link ParserTestCase} but with the type related tests disabled.
+ */
+public abstract class ParserTestCase3<P extends Parser<T, C>, T extends ParserToken, C extends ParserContext> extends ParserTestCase<P, T, C> {
+
+    public void testClassIsFinalIfAllConstructorsArePrivate() {
+        // nop
+    }
+
+    public void testAllConstructorsArePackagePrivateOrPrivate() {
+        // nop
+    }
+
+    public void testAllMethodsVisibility() {
+        // nop
+    }
+
+    public void testAllFieldsVisibility() {
+        // nop
+    }
+
+    public void testClassIsPackagePrivate() {
+        // nop
+    }
+
+    protected Class<P> type() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserToken.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
+
+/**
+ * Represents a list of alternative token in the grammar.
+ */
+final public class EbnfAlternativeParserToken extends EbnfParentParserToken {
+
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfAlternativeParserToken.class);
+
+    static EbnfAlternativeParserToken with(final List<EbnfParserToken> tokens, final String text) {
+        return new EbnfAlternativeParserToken(copyAndCheckTokens(tokens), checkText(text));
+    }
+
+    EbnfAlternativeParserToken(final List<EbnfParserToken> tokens, final String text) {
+        super(tokens, text);
+    }
+
+    @Override
+    public EbnfAlternativeParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    EbnfAlternativeParserToken replaceText(final String text) {
+        return new EbnfAlternativeParserToken(this.value(), text);
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return true;
+    }
+
+    @Override
+    public boolean isConcatenation() {
+        return false;
+    }
+
+    @Override
+    public boolean isGroup() {
+        return false;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return false;
+    }
+
+    @Override
+    public boolean isRepeated() {
+        return false;
+    }
+
+    @Override
+    public boolean isRule() {
+        return false;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof EbnfAlternativeParserToken;
+    }
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfCommentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfCommentParserToken.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+/**
+ * Holds the text for a comment.
+ */
+public final class EbnfCommentParserToken extends EbnfLeafParserToken<String> {
+
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfCommentParserToken.class);
+
+    static EbnfCommentParserToken with(final String value, final String text){
+        checkValue(value);
+        checkText(text);
+
+        return new EbnfCommentParserToken(value, text);
+    }
+
+    EbnfCommentParserToken(final String value, final String text){
+        super(value, text);
+    }
+
+    @Override
+    public EbnfCommentParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    EbnfCommentParserToken replaceText(final String text) {
+        return new EbnfCommentParserToken(this.value, text);
+    }
+
+    @Override
+    public boolean isComment() {
+        return true;
+    }
+
+    @Override
+    public boolean isIdentifier() {
+        return false;
+    }
+
+    @Override
+    public boolean isSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminal() {
+        return false;
+    }
+
+    @Override
+    public boolean isWhitespace() {
+        return false;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof EbnfCommentParserToken;
+    }
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserToken.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
+
+/**
+ * Represents a concatenation of tokens in the grammar.
+ */
+public final class EbnfConcatenationParserToken extends EbnfParentParserToken {
+
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfConcatenationParserToken.class);
+
+    static EbnfConcatenationParserToken with(final List<EbnfParserToken> tokens, final String text) {
+        return new EbnfConcatenationParserToken(copyAndCheckTokens(tokens), checkText(text));
+    }
+
+    EbnfConcatenationParserToken(final List<EbnfParserToken> tokens, final String text) {
+        super(tokens, text);
+    }
+
+    @Override
+    public EbnfConcatenationParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    EbnfConcatenationParserToken replaceText(final String text) {
+        return new EbnfConcatenationParserToken(this.value(), text);
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    public boolean isConcatenation() {
+        return true;
+    }
+
+    @Override
+    public boolean isGroup() {
+        return false;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return false;
+    }
+
+    @Override
+    public boolean isRepeated() {
+        return false;
+    }
+
+    @Override
+    public boolean isRule() {
+        return false;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof EbnfConcatenationParserToken;
+    }
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParser.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.Cast;
+import walkingkooka.predicate.character.CharPredicates;
+import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.parser.CharacterParserToken;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.Parsers;
+import walkingkooka.text.cursor.parser.SequenceParserBuilder;
+import walkingkooka.text.cursor.parser.SequenceParserToken;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+/**
+ * A parser that accepts a grammar and returns a {@link EbnfGrammarParserToken}.
+ * <br>
+ * <a href="https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form">EBNF</a>
+ */
+final class EbnfGrammarParser implements Parser<EbnfGrammarParserToken, EbnfParserContext> {
+
+    // low level ATOMS ..................................................................................................
+
+    /**
+     * <pre>
+     *     letter = "A" | "B" | "C" | "D" | "E" | "F" | "G"
+     *             | "H" | "I" | "J" | "K" | "L" | "M" | "N"
+     *             | "O" | "P" | "Q" | "R" | "S" | "T" | "U"
+     *             | "V" | "W" | "X" | "Y" | "Z" | "a" | "b"
+     *             | "c" | "d" | "e" | "f" | "g" | "h" | "i"
+     *             | "j" | "k" | "l" | "m" | "n" | "o" | "p"
+     *             | "q" | "r" | "s" | "t" | "u" | "v" | "w"
+     *             | "x" | "y" | "z" ;
+     * </pre>
+     */
+    final static Parser<CharacterParserToken, EbnfParserContext> LETTER = EbnfParserContext.character(
+            CharPredicates.range('A', 'Z').or(CharPredicates.range('a', 'z')))
+            .setToString("letter");
+
+    /**
+     * <pre>
+     * digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+     * </pre>
+     */
+    final static Parser<CharacterParserToken, EbnfParserContext> DIGIT = EbnfParserContext.character('0', '9')
+            .setToString("digit");
+
+    /**
+     * <pre>
+     * _
+     * </pre>
+     */
+    final static Parser<CharacterParserToken, EbnfParserContext> UNDERSCORE = EbnfParserContext.character('_');
+
+    /**
+     * <pre>
+     * character = letter | digit |  "_" ;
+     * </pre>
+     */
+    final static Parser<CharacterParserToken, EbnfParserContext> CHARACTER = LETTER
+            .or(DIGIT)
+            .or(UNDERSCORE)
+            .setToString("character");
+
+    /**
+     * This needs to be initialized before references below to avoid forward reference problems.
+     */
+    private static final Parser<ParserToken, EbnfParserContext> WHITESPACE_OR_COMMENT = whitespaceOrComment();
+
+    private static Parser<ParserToken, EbnfParserContext> whitespaceOrComment() {
+        final Parser<EbnfWhitespaceParserToken, EbnfParserContext> whitespace = Parsers.<EbnfParserContext>stringCharPredicate(CharPredicates.whitespace())
+                .transform((string, context) -> new EbnfWhitespaceParserToken(string.value(), string.text()))
+                .setToString("whitespace");
+        final Parser<ParserToken, EbnfParserContext> comment = Parsers.<EbnfParserContext>surround("(*", "*)")
+                .transform((string, context) -> new EbnfCommentParserToken(string.value(), string.text()))
+                .setToString("comment")
+                .castC();
+
+        return whitespace.<EbnfParserContext>castC()
+                .or(comment)
+                .repeating()
+                .castC();
+    }
+    
+    /**
+     * <pre>
+     * =
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> ASSIGN = symbol('=', "assign");
+
+    /**
+     * <pre>
+     * ;
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> TERMINATION = symbol(';', "termination");
+
+    /**
+     * <pre>
+     * |
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> ALTERNATIVES_SEPARATOR = symbol('|', "alternatives_separator");
+
+    /**
+     * <pre>
+     * ,
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> CONCAT_SEPARATOR = symbol(',', "concat_separator");
+
+    /**
+     * <pre>
+     * [
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> OPTIONAL_OPEN = symbol('[', "optional_open");
+
+    /**
+     * <pre>
+     * ]
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> OPTIONAL_CLOSE = symbol(']', "optional_close");
+
+    /**
+     * <pre>
+     * {
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> REPETITION_OPEN = symbol('{', "repetition_open");
+
+    /**
+     * <pre>
+     * }
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> REPETITION_CLOSE = symbol('}', "repetition_close");
+
+    /**
+     * <pre>
+     * (
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> GROUP_OPEN = symbol('(', "group_open");
+
+    /**
+     * <pre>
+     * )
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> GROUP_CLOSE = symbol(')', "group_close");
+
+    /**
+     * Creates a parser that matches the given character and wraps it inside a {@link EbnfSymbolParserToken}
+     */
+    private static Parser<ParserToken, EbnfParserContext> symbol(final char c, final String name){
+        return EbnfParserContext.character(c)
+                        .transform((character, context) -> new EbnfSymbolParserToken(character.value(), character.text()))
+                        .setToString(name)
+                        .castTC();
+    }
+
+    /**
+     * Accepts a {@link SequenceParserToken} that contains a mixture of symbols and {@link CharacterParserToken}
+     * returning a string holding all the characters.
+     */
+    static String string(final SequenceParserToken token) {
+        final StringBuilder string = new StringBuilder();
+
+        // join all the character parser tokens
+        token.flat()
+                .value()
+                .stream()
+                .filter(t -> t instanceof CharacterParserToken)
+                .forEach(t -> {
+                    CharacterParserToken character = Cast.to(t);
+                    string.append(character.value());
+                });
+        return string.toString();
+    }
+
+    /**
+     * <pre>
+     * identifier = letter , { letter | digit | "_" } ;
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> IDENTIFIER =
+            identifier()
+            .setToString("terminal");
+
+    private static Parser<ParserToken, EbnfParserContext> identifier() {
+        return EbnfParserContext.sequenceParserBuilder()
+                .required(LETTER)
+                .required(CHARACTER.repeating())
+                .build()
+                .transform((sequence, context) -> new EbnfIdentifierParserToken(string(sequence), sequence.text()))
+                .setToString("identifier")
+                .castC();
+    };
+
+    /**
+     * <pre>
+     * terminal = "'" , character , { character } , "'"
+     *          | '"' , character , { character } , '"' ;
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> TERMINAL =
+            terminal()
+            .setToString("terminal")
+            .castC();
+
+    private static Parser<ParserToken, EbnfParserContext> terminal() {
+        final Parser<EbnfTerminalParserToken, EbnfParserContext> singleQuoted = terminalQuote('\'');
+        final Parser<EbnfTerminalParserToken, EbnfParserContext> doubleQuoted = terminalQuote('"');
+
+        return singleQuoted.or(doubleQuoted).castC();
+    }
+
+    private static Parser<EbnfTerminalParserToken, EbnfParserContext> terminalQuote(final char quote) {
+        final Parser<CharacterParserToken, EbnfParserContext> quoteParser = EbnfParserContext.character(quote);
+
+        return EbnfParserContext.sequenceParserBuilder()
+                .required(quoteParser)
+                .required(CHARACTER.repeating())
+                .required(quoteParser)
+                .build()
+                .transform(EbnfGrammarParser::terminal);
+    }
+
+    private static EbnfTerminalParserToken terminal(final SequenceParserToken token, final EbnfParserContext context) {
+        final String quotedText = string(token);
+        return new EbnfTerminalParserToken(quotedText.substring(1, quotedText.length()-1),
+                token.text());
+    }
+
+    /**
+     * <pre>
+     * lhs = identifier ;
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> LHS = IDENTIFIER;
+
+    /**
+     * <pre>
+     * rhs = identifier
+     *      | terminal
+     *      | "[" , rhs , "]"/
+     *      | "{" , rhs , "}"
+     *      | "(" , rhs , ")"
+     *      | rhs , "|" , rhs
+     *      | rhs , "," , rhs ;
+     * </pre>
+     */
+    static Parser<ParserToken, EbnfParserContext> RHS = new Parser<ParserToken, EbnfParserContext>() {
+
+        @Override
+        public Optional<ParserToken> parse(TextCursor cursor, EbnfParserContext context) {
+            return rhs().parse(cursor, context);
+        }
+
+        public String toString() {
+            return "rhs";
+        }
+    };
+
+    /**
+     * <pre>
+     * "[" , rhs , "]"
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> OPTIONAL = parser(OPTIONAL_OPEN, WHITESPACE_OR_COMMENT, RHS, WHITESPACE_OR_COMMENT, OPTIONAL_CLOSE)
+            .transform(filterAndWrapMany(EbnfParserToken::optional))
+            .castC();
+
+    /**
+     * <pre>
+     * "{" , rhs , "}"
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> REPETITION = parser(REPETITION_OPEN, WHITESPACE_OR_COMMENT, RHS, WHITESPACE_OR_COMMENT, REPETITION_CLOSE)
+            .transform(filterAndWrapMany(EbnfParserToken::repeated))
+            .castC();
+
+    /**
+     * <pre>
+     * "(" , rhs , ")"
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> GROUPING = parser(GROUP_OPEN, WHITESPACE_OR_COMMENT, RHS, WHITESPACE_OR_COMMENT, GROUP_CLOSE)
+            .transform(filterAndWrapMany(EbnfParserToken::grouping))
+            .castC();
+
+
+    /**
+     * <pre>
+     * "(" , rhs , ")"
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> RHS_WITHOUT_ALT_CONCAT = IDENTIFIER
+            .or(TERMINAL)
+            .or(OPTIONAL)
+            .or(REPETITION)
+            .or(GROUPING);
+
+    /**
+     * <pre>
+     * rhs , "|" , rhs
+     * </pre>
+     * To avoid left recursion problems the first rhs is replaced as RHS_WITHOUT_ALT_CONCAT which doesnt include ALT and CONCAT
+     */
+    final static Parser<ParserToken, EbnfParserContext> ALTERNATIVE = parser(WHITESPACE_OR_COMMENT, RHS_WITHOUT_ALT_CONCAT, WHITESPACE_OR_COMMENT, ALTERNATIVES_SEPARATOR, WHITESPACE_OR_COMMENT, RHS)
+            .transform(filterAndWrapMany(EbnfParserToken::alternative))
+            .castC();
+
+    /**
+     * <pre>
+     * | rhs , "," , rhs ;
+     * </pre>
+     * To avoid left recursion problems the first rhs is replaced as RHS_WITHOUT_ALT_CONCAT which doesnt include ALT and CONCAT
+     */
+    final static Parser<ParserToken, EbnfParserContext> CONCATENATION = parser(WHITESPACE_OR_COMMENT, RHS_WITHOUT_ALT_CONCAT, WHITESPACE_OR_COMMENT, CONCAT_SEPARATOR, WHITESPACE_OR_COMMENT, RHS)
+            .transform(filterAndWrapMany(EbnfParserToken::concatenation))
+            .castC();
+
+    /**
+     * <pre>
+     * lhs , "=" , rhs , ";" ;
+     * </pre>
+     */
+    final static Parser<ParserToken, EbnfParserContext> RULE = parser(WHITESPACE_OR_COMMENT, LHS, WHITESPACE_OR_COMMENT, ASSIGN, WHITESPACE_OR_COMMENT, RHS, WHITESPACE_OR_COMMENT, TERMINATION)
+            .transform(filterAndWrapMany(EbnfParserToken::rule))
+            .castC();
+
+    /**
+     * Matches any of the tokens, assumes that any leading or trailing whitespace or comments is handled elsewhere...(parent)
+     * @return
+     */
+    private static Parser<ParserToken, EbnfParserContext> rhs() {
+        if(null==RHS_CACHE) {
+            RHS_CACHE = IDENTIFIER
+                    .or(TERMINAL)
+                    .or(OPTIONAL)
+                    .or(REPETITION)
+                    .or(GROUPING)
+                    .or(ALTERNATIVE)
+                    .or(CONCATENATION)
+                    .setToString("RHS");
+        }
+        return RHS_CACHE;
+    }
+
+    private static Parser<ParserToken, EbnfParserContext> RHS_CACHE;
+
+    private static Parser<SequenceParserToken, EbnfParserContext> parser(final Parser<? super ParserToken, EbnfParserContext>...parsers) {
+        final SequenceParserBuilder<EbnfParserContext> b = EbnfParserContext.sequenceParserBuilder();
+        for(Parser<? super ParserToken, EbnfParserContext> parser : parsers) {
+            if(parser == WHITESPACE_OR_COMMENT) {
+                b.optional(parser);
+            } else {
+                b.required(parser);
+            }
+        }
+
+        return b.build();
+    }
+
+    private static final BiFunction<SequenceParserToken, EbnfParserContext, ParserToken> filterAndWrapMany(final BiFunction<List<EbnfParserToken>, String, EbnfParserToken> wrapper) {
+        return (sequence, context) -> {
+            final List<EbnfParserToken> many = filterNonEbnfParserTokens(sequence);
+            return wrapper.apply(Cast.to(many), sequence.text());
+        };
+    }
+
+    private static List<EbnfParserToken> filterNonEbnfParserTokens(final SequenceParserToken sequence) {
+        return sequence.flat()
+                .value()
+                .stream()
+                .filter(token -> token instanceof EbnfParserToken)
+                .map(t -> EbnfParserToken.class.cast(t))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * <pre>
+     * grammar = { rule } ;
+     * </pre>
+     */
+    final static Parser<EbnfGrammarParserToken, EbnfParserContext> GRAMMAR = RULE.repeating()
+            .transform((repeated, context) -> {
+                return new EbnfGrammarParserToken(
+                        Cast.to(repeated.value()), // list of rules
+                        repeated.text());
+            })
+            .cast(EbnfGrammarParserToken.class);
+
+    @Override
+    public Optional<EbnfGrammarParserToken> parse(final TextCursor cursor, final EbnfParserContext context) {
+        return GRAMMAR.parse(cursor, context);
+    }
+
+    @Override
+    public String toString() {
+        return GRAMMAR.toString();
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserToken.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A grammar holds all the rules and is the root of the graph.
+ */
+public final class EbnfGrammarParserToken extends EbnfParserToken {
+
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfGrammarParserToken.class);
+
+    static EbnfGrammarParserToken with(final List<EbnfRuleParserToken> rules, final String text) {
+        Objects.requireNonNull(rules, "rules");
+        checkText(text);
+
+        final List<EbnfRuleParserToken> copy = Lists.array();
+        copy.addAll(rules);
+
+        return new EbnfGrammarParserToken(copy, text);
+    }
+
+    EbnfGrammarParserToken(final List<EbnfRuleParserToken> rules, final String text) {
+        super(text);
+        this.rules = rules;
+        this.identifierToParser = Maps.sorted();
+    }
+
+    @Override
+    public EbnfGrammarParserToken setText(String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    EbnfGrammarParserToken replaceText(final String text) {
+        return new EbnfGrammarParserToken(this.rules, text);
+    }
+
+    /// need a get parser for identifier
+
+    private final List<EbnfRuleParserToken> rules;
+
+    private final Map<EbnfIdentifierParserToken, Parser<?, ?>> identifierToParser;
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    public boolean isComment() {
+        return false;
+    }
+
+    @Override
+    public boolean isConcatenation() {
+        return false;
+    }
+
+    @Override
+    public boolean isGrammar() {
+        return true;
+    }
+
+    @Override
+    public boolean isGroup() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdentifier() {
+        return false;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return false;
+    }
+
+    @Override
+    public boolean isRepeated() {
+        return false;
+    }
+
+    @Override
+    public boolean isRule() {
+        return false;
+    }
+
+    @Override
+    public boolean isSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminal() {
+        return false;
+    }
+
+    @Override
+    public boolean isWhitespace() {
+        return false;
+    }
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof EbnfGrammarParserToken;
+    }
+
+    @Override
+    boolean equals1(final EbnfParserToken other) {
+        return this.equals2(Cast.to(other));
+    }
+
+    private boolean equals2(final EbnfGrammarParserToken other) {
+        return this.rules.equals(other.rules);
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserToken.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
+
+/**
+ * Represents an grouped token in the grammar.
+ */
+public final class EbnfGroupParserToken extends EbnfParentParserToken {
+
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfGroupParserToken.class);
+
+    static EbnfGroupParserToken with(final List<EbnfParserToken> tokens, final String text) {
+        return new EbnfGroupParserToken(copyAndCheckTokens(tokens), checkText(text));
+    }
+
+    EbnfGroupParserToken(final List<EbnfParserToken> tokens, final String text) {
+        super(tokens, text);
+    }
+
+    @Override
+    public EbnfGroupParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    EbnfGroupParserToken replaceText(final String text) {
+        return new EbnfGroupParserToken(this.value(), text);
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    public boolean isConcatenation() {
+        return false;
+    }
+
+    @Override
+    public boolean isGroup() {
+        return true;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return false;
+    }
+
+    @Override
+    public boolean isRepeated() {
+        return false;
+    }
+
+    @Override
+    public boolean isRule() {
+        return false;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof EbnfGroupParserToken;
+    }
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserToken.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.naming.Name;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+/**
+ * Holds the text for an identifier. Identifiers may appear on the left of a definition or as a reference to another rule definition.
+ */
+public final class EbnfIdentifierParserToken extends EbnfLeafParserToken<String> implements Name, Comparable<EbnfIdentifierParserToken> {
+
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfIdentifierParserToken.class);
+
+    final static String OPEN = "(*";
+    final static String CLOSE = "*)";
+
+    static EbnfIdentifierParserToken with(final String value, final String text){
+        checkValue(value);
+        checkText(text);
+
+        return new EbnfIdentifierParserToken(value, text);
+    }
+
+    EbnfIdentifierParserToken(final String value, final String text){
+        super(value, text);
+    }
+
+    @Override
+    public EbnfIdentifierParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    EbnfIdentifierParserToken replaceText(final String text) {
+        return new EbnfIdentifierParserToken(this.value, text);
+    }
+
+    @Override
+    public boolean isComment() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdentifier() {
+        return true;
+    }
+
+    @Override
+    public boolean isSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminal() {
+        return false;
+    }
+
+    @Override
+    public boolean isWhitespace() {
+        return false;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof EbnfIdentifierParserToken;
+    }
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    @Override
+    public int compareTo(final EbnfIdentifierParserToken other) {
+        return this.value.compareTo(other.value);
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfLeafParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfLeafParserToken.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.Value;
+
+import java.util.Objects;
+
+/**
+ * Base class for a leaf token. A leaf has no further breakdown into more detailed tokens.
+ */
+abstract class EbnfLeafParserToken<T> extends EbnfParserToken implements Value<T> {
+
+    static void checkValue(final String value) {
+        Objects.requireNonNull(value, "value");
+    }
+
+    EbnfLeafParserToken(final T value, final String text){
+        super(text);
+        this.value = value;
+    }
+
+    public final T value() {
+        return this.value;
+    }
+
+    final T value;
+
+    @Override
+    public final boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    public final boolean isConcatenation() {
+        return false;
+    }
+
+    @Override
+    public final boolean isGrammar() {
+        return false;
+    }
+
+    @Override
+    public final boolean isGroup() {
+        return false;
+    }
+
+    @Override
+    public final boolean isOptional() {
+        return false;
+    }
+
+    @Override
+    public final boolean isRepeated() {
+        return false;
+    }
+
+    @Override
+    public final boolean isRule() {
+        return false;
+    }
+
+    @Override
+    final boolean equals1(final EbnfParserToken other) {
+        return this.equals2(other.cast());
+    }
+
+    private boolean equals2(final EbnfLeafParserToken other) {
+        return this.value.equals(other.value);
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserToken.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
+
+/**
+ * Represents an optional token in the grammar.
+ */
+public final class EbnfOptionalParserToken extends EbnfParentParserToken {
+
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfOptionalParserToken.class);
+
+    static EbnfOptionalParserToken with(final List<EbnfParserToken> tokens, final String text) {
+        return new EbnfOptionalParserToken(copyAndCheckTokens(tokens), checkText(text));
+    }
+
+    EbnfOptionalParserToken(final List<EbnfParserToken> tokens, final String text) {
+        super(tokens, text);
+    }
+
+    @Override
+    public EbnfOptionalParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    EbnfOptionalParserToken replaceText(final String text) {
+        return new EbnfOptionalParserToken(this.value(), text);
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    public boolean isConcatenation() {
+        return false;
+    }
+
+    @Override
+    public boolean isGroup() {
+        return false;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return true;
+    }
+
+    @Override
+    public boolean isRepeated() {
+        return false;
+    }
+
+    @Override
+    public boolean isRule() {
+        return false;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof EbnfOptionalParserToken;
+    }
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserToken.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.Cast;
+import walkingkooka.Value;
+
+import java.util.List;
+
+/**
+ * Base class for a token that contain another child token, with the class knowing the cardinality.
+ */
+abstract class EbnfParentParserToken extends EbnfParserToken implements Value<List<EbnfParserToken>> {
+
+    EbnfParentParserToken(final List<EbnfParserToken> value, final String text) {
+        super(text);
+        this.value = value;
+    }
+
+    @Override
+    public final boolean isComment() {
+        return false;
+    }
+
+    @Override
+    public final boolean isGrammar() {
+        return false;
+    }
+
+    @Override
+    public final boolean isIdentifier() {
+        return false;
+    }
+
+    @Override
+    public final boolean isSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isTerminal() {
+        return false;
+    }
+
+    @Override
+    public final boolean isWhitespace() {
+        return false;
+    }
+
+    @Override
+    public final List<EbnfParserToken> value() {
+        return this.value;
+    }
+
+    final List<EbnfParserToken> value;
+
+    @Override
+    final boolean equals1(final EbnfParserToken other) {
+        return this.equals2(Cast.to(other));
+    }
+
+    private boolean equals2(final EbnfParentParserToken other) {
+        return this.value.equals(other.value);
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserContext.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserContext.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.predicate.character.CharPredicate;
+import walkingkooka.predicate.character.CharPredicates;
+import walkingkooka.text.cursor.parser.CharacterParserToken;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserContext;
+import walkingkooka.text.cursor.parser.Parsers;
+import walkingkooka.text.cursor.parser.SequenceParserBuilder;
+
+public final class EbnfParserContext implements ParserContext {
+
+    EbnfParserContext() {
+    }
+
+    static Parser<CharacterParserToken, EbnfParserContext> character(final char c) {
+        return character(CharPredicates.is(c));
+    }
+
+    static Parser<CharacterParserToken, EbnfParserContext> character(final char start, final char end) {
+        return character(CharPredicates.range(start, end));
+    }
+
+    static Parser<CharacterParserToken, EbnfParserContext> character(final CharPredicate predicate) {
+        return Parsers.character(predicate);
+    }
+
+    static SequenceParserBuilder<EbnfParserContext> sequenceParserBuilder() {
+        return Parsers.sequenceParserBuilder();
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserToken.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.Whitespace;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents a token within the grammar.
+ */
+public abstract class EbnfParserToken implements ParserToken {
+
+    /**
+     * {@see EbnfAlternativeParserToken}
+     */
+    public static EbnfAlternativeParserToken alternative(final List<EbnfParserToken> tokens, final String text) {
+        return EbnfAlternativeParserToken.with(tokens, text);
+    }
+
+    /**
+     * {@see EbnfCommentParserToken}
+     */
+    static EbnfCommentParserToken comment(final String value, final String text){
+        return EbnfCommentParserToken.with(value, text);
+    }
+
+    /**
+     * {@see EbnfConcatenationParserToken}
+     */
+    public static EbnfConcatenationParserToken concatenation(final List<EbnfParserToken> tokens, final String text) {
+        return EbnfConcatenationParserToken.with(tokens, text);
+    }
+
+    /**
+     * {@see EbnfGrammarParserToken}
+     */
+    public static EbnfGrammarParserToken grammar(final List<EbnfRuleParserToken> rules, final String text) {
+        return EbnfGrammarParserToken.with(rules, text);
+    }
+
+    /**
+     * {@see EbnfGroupingParserToken}
+     */
+    public static EbnfGroupParserToken grouping(final List<EbnfParserToken> tokens, final String text) {
+        return EbnfGroupParserToken.with(tokens, text);
+    }
+
+    /**
+     * {@see EbnfIdentifierParserToken}
+     */
+    static EbnfIdentifierParserToken identifier(final String value, final String text){
+        return EbnfIdentifierParserToken.with(value, text);
+    }
+
+    /**
+     * {@see EbnfOptionalParserToken}
+     */
+    public static EbnfOptionalParserToken optional(final List<EbnfParserToken> tokens, final String text) {
+        return new EbnfOptionalParserToken(tokens, text);
+    }
+    
+    /**
+     * {@see EbnfRepeatedParserToken}
+     */
+    public static EbnfRepeatedParserToken repeated(final List<EbnfParserToken> tokens, final String text) {
+        return EbnfRepeatedParserToken.with(tokens, text);
+    }
+
+    /**
+     * {@see EbnfRuleParserToken}
+     */
+    public static EbnfRuleParserToken rule(final List<EbnfParserToken> tokens, final String text) {
+       return EbnfRuleParserToken.with(tokens, text);
+    }
+
+    /**
+     * {@see EbnfSymbolParserToken}
+     */
+    public static EbnfSymbolParserToken symbol(final char c, final String text) {
+        return EbnfSymbolParserToken.with(c, text);
+    }
+
+    /**
+     * {@see EbnfTerminalParserToken}
+     */
+    public static EbnfTerminalParserToken terminal(final String value, final String text){
+        return EbnfTerminalParserToken.with(value, text);
+    }
+
+    /**
+     * {@see EbnfWhitespaceParserToken}
+     */
+    public static EbnfWhitespaceParserToken whitespace(final String value, final String text){
+        return EbnfWhitespaceParserToken.with(value, text);
+    }
+
+    static List<EbnfParserToken> copyAndCheckTokens(final List<EbnfParserToken> tokens) {
+        Objects.requireNonNull(tokens, "tokens");
+
+        final List<EbnfParserToken> copy = Lists.array();
+        copy.addAll(tokens);
+
+        if(copy.isEmpty()) {
+            throw new IllegalArgumentException("Tokens is empty");
+        }
+        return copy;
+    }
+
+    static String checkText(final String text) {
+        Whitespace.failIfNullOrWhitespace(text, "text");
+        return text;
+    }
+
+    /**
+     * {@see EbnfGrammarParser}
+     */
+    public static Parser<EbnfGrammarParserToken, EbnfParserContext> grammarParser() {
+        return EbnfGrammarParser.GRAMMAR;
+    }
+
+    /**
+     * Package private ctor to limit sub classing.
+     */
+    EbnfParserToken(final String text) {
+        this.text = text;
+    }
+
+    @Override
+    public final String text() {
+        return this.text;
+    }
+
+    private final String text;
+
+    final EbnfParserToken setText0(final String text) {
+        Objects.requireNonNull(text, "text");
+        return this.text.equals(text) ?
+                this :
+                replaceText(text);
+    }
+
+    abstract EbnfParserToken replaceText(final String text);
+
+    /**
+     * Only alternative tokens return true
+     */
+    public abstract boolean isAlternative();
+
+    /**
+     * Only comment tokens return true
+     */
+    public abstract boolean isComment();
+
+    /**
+     * Only concatenation tokens return true
+     */
+    public abstract boolean isConcatenation();
+
+    /**
+     * Only grouping tokens return true
+     */
+    public abstract boolean isGroup();
+
+    /**
+     * Only grammar tokens return true
+     */
+    public abstract boolean isGrammar();
+
+    /**
+     * Only identifiers return true
+     */
+    public abstract boolean isIdentifier();
+
+    /**
+     * Only optional tokens return true
+     */
+    public abstract boolean isOptional();
+
+    /**
+     * Only repeating tokens return true
+     */
+    public abstract boolean isRepeated();
+
+    /**
+     * Only rule tokens return true
+     */
+    public abstract boolean isRule();
+
+    /**
+     * Only symbols tokens return true
+     */
+    public abstract boolean isSymbol();
+
+    /**
+     * Only terminals return true
+     */
+    public abstract boolean isTerminal();
+
+    /**
+     * Only whitespace return true
+     */
+    public abstract boolean isWhitespace();
+
+    /**
+     * Useful to get help reduce casting noise.
+     */
+    final <T extends EbnfParserToken> T cast() {
+        return Cast.to(this);
+    }
+
+    // Object ...........................................................................................................
+
+    @Override
+    public int hashCode() {
+        return this.text().hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+               this.canBeEqual(other) &&
+               this.equals0(Cast.to(other));
+    }
+
+    abstract boolean canBeEqual(final Object other);
+
+    private boolean equals0(final EbnfParserToken other) {
+        return this.text().equals(other.text()) &&
+               this.equals1(other);
+    }
+
+    abstract boolean equals1(EbnfParserToken other);
+
+    @Override
+    public final String toString() {
+        return this.text();
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatedParserToken.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
+
+/**
+ * Represents an repeated token in the grammar.
+ */
+public final class EbnfRepeatedParserToken extends EbnfParentParserToken {
+
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfRepeatedParserToken.class);
+
+    static EbnfRepeatedParserToken with(final List<EbnfParserToken> tokens, final String text) {
+        return new EbnfRepeatedParserToken(copyAndCheckTokens(tokens), checkText(text));
+    }
+
+    EbnfRepeatedParserToken(final List<EbnfParserToken> tokens, final String text) {
+        super(tokens, text);
+    }
+
+    @Override
+    public EbnfRepeatedParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    EbnfRepeatedParserToken replaceText(final String text) {
+        return new EbnfRepeatedParserToken(this.value(), text);
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    public boolean isConcatenation() {
+        return false;
+    }
+
+    @Override
+    public boolean isGroup() {
+        return false;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return false;
+    }
+
+    @Override
+    public boolean isRepeated() {
+        return true;
+    }
+
+    @Override
+    public boolean isRule() {
+        return false;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof EbnfRepeatedParserToken;
+    }
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserToken.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
+
+/**
+ * Represents a single rule definition within a grammar.
+ */
+public final class EbnfRuleParserToken extends EbnfParentParserToken {
+
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfRuleParserToken.class);
+
+    static EbnfRuleParserToken with(final List<EbnfParserToken> tokens, final String text) {
+        final List<EbnfParserToken> copy = copyAndCheckTokens(tokens);
+        checkText(text);
+
+        final EbnfRuleParserTokenConsumer checker = new EbnfRuleParserTokenConsumer();
+        tokens.stream()
+                .filter(t -> t instanceof EbnfParserToken)
+                .forEach(checker);
+
+        final EbnfIdentifierParserToken identifier = checker.identifier;
+        if(null==identifier){
+            throw new IllegalArgumentException("Rule missing Identifier on lhs=" + text);
+        }
+        final EbnfParserToken token = checker.token;
+        if(null==token){
+            throw new IllegalArgumentException("Rule missing Token on rhs=" + text);
+        }
+
+        return new EbnfRuleParserToken(copy,
+                text,
+                identifier,
+                token);
+    }
+
+    EbnfRuleParserToken(final List<EbnfParserToken> tokens,
+                        final String text,
+                        final EbnfIdentifierParserToken identifier,
+                        final EbnfParserToken token) {
+        super(tokens, text);
+        this.identifier = identifier;
+        this.token = token;
+    }
+
+    @Override
+    public EbnfRuleParserToken setText(String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    EbnfRuleParserToken replaceText(final String text) {
+        return new EbnfRuleParserToken(this.value(), text, this.identifier, this.token);
+    }
+
+    public EbnfIdentifierParserToken identifier() {
+        return this.identifier;
+    }
+
+    private final EbnfIdentifierParserToken identifier;
+
+    public EbnfParserToken token() {
+        return this.token;
+    }
+
+    private final EbnfParserToken token;
+
+    @Override
+    public boolean isAlternative() {
+        return false;
+    }
+
+    @Override
+    public boolean isConcatenation() {
+        return false;
+    }
+
+    @Override
+    public boolean isGroup() {
+        return false;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return false;
+    }
+
+    @Override
+    public boolean isRepeated() {
+        return false;
+    }
+
+    @Override
+    public boolean isRule() {
+        return true;
+    }
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof EbnfRuleParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTokenConsumer.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTokenConsumer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import java.util.function.Consumer;
+
+final class EbnfRuleParserTokenConsumer implements Consumer<EbnfParserToken> {
+
+    @Override
+    public void accept(final EbnfParserToken token) {
+        if(token.isAlternative() || token.isConcatenation() || token.isGroup() || token.isIdentifier() || token.isOptional() || token.isRepeated() || token.isTerminal()) {
+            if(null ==this.identifier) {
+                if(!token.isIdentifier()) {
+                    throw new IllegalArgumentException("Rule expected identifier but got " + token);
+                }
+                identifier = token.cast();
+            } else {
+                if (null == this.token) {
+                    this.token = token;
+                }
+            }
+        }
+    }
+
+    EbnfIdentifierParserToken identifier;
+    EbnfParserToken token;
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfSymbolParserToken.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+/**
+ * Holds any of the symbols that separate actual tokens, such as the parens around a grouping.
+ */
+final public class EbnfSymbolParserToken extends EbnfLeafParserToken<Character> {
+
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfSymbolParserToken.class);
+
+    static EbnfSymbolParserToken with(final char symbol, final String text){
+        return new EbnfSymbolParserToken(symbol, checkText(text));
+    }
+
+    EbnfSymbolParserToken(final char symbol, final String text){
+        super(symbol, text);
+    }
+
+    @Override
+    public EbnfSymbolParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    EbnfSymbolParserToken replaceText(final String text) {
+        return new EbnfSymbolParserToken(this.value, text);
+    }
+
+    @Override
+    public boolean isComment() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdentifier() {
+        return false;
+    }
+
+    @Override
+    public boolean isSymbol() {
+        return true;
+    }
+
+    @Override
+    public boolean isTerminal() {
+        return false;
+    }
+
+    @Override
+    public boolean isWhitespace() {
+        return false;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof EbnfSymbolParserToken;
+    }
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserToken.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+/**
+ * Holds the terminal token portion of the rhs of a rule.
+ */
+public final class EbnfTerminalParserToken extends EbnfLeafParserToken<String> {
+
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfTerminalParserToken.class);
+
+    static EbnfTerminalParserToken with(final String value, final String text){
+        checkValue(value);
+        checkText(text);
+
+        return new EbnfTerminalParserToken(value, text);
+    }
+
+    EbnfTerminalParserToken(final String value, final String text){
+        super(value, text);
+    }
+
+    @Override
+    public EbnfTerminalParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    EbnfTerminalParserToken replaceText(final String text) {
+        return new EbnfTerminalParserToken(this.value, text);
+    }
+
+    @Override
+    public boolean isComment() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdentifier() {
+        return false;
+    }
+
+    @Override
+    public boolean isSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminal() {
+        return true;
+    }
+
+    @Override
+    public boolean isWhitespace() {
+        return false;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof EbnfTerminalParserToken;
+    }
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfWhitespaceParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfWhitespaceParserToken.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.CharSequences;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+/**
+ * Holds the combination of whitespace or comments.
+ */
+public final class EbnfWhitespaceParserToken extends EbnfLeafParserToken<String> {
+
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.with("EbnfWhitespace");
+
+    static EbnfWhitespaceParserToken with(final String value, final String text){
+        checkValue(value);
+        CharSequences.failIfNullOrEmpty(text, "text");
+
+        return new EbnfWhitespaceParserToken(value, text);
+    }
+
+    EbnfWhitespaceParserToken(final String value, final String text){
+        super(value, text);
+    }
+
+    @Override
+    public EbnfWhitespaceParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    EbnfWhitespaceParserToken replaceText(final String text) {
+        return new EbnfWhitespaceParserToken(this.value, text);
+    }
+
+    @Override
+    public boolean isComment() {
+        return false;
+    }
+
+    @Override
+    public boolean isIdentifier() {
+        return false;
+    }
+
+    @Override
+    public boolean isSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminal() {
+        return false;
+    }
+
+    @Override
+    public boolean isWhitespace() {
+        return true;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof EbnfWhitespaceParserToken;
+    }
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeConcatenationParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeConcatenationParentParserTokenTestCase.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.collect.list.Lists;
+
+public abstract class EbnfAlternativeConcatenationParentParserTokenTestCase<T extends EbnfParentParserToken> extends EbnfParentParserTokenTestCase2<T> {
+
+    @Override
+    protected T createDifferentToken() {
+        return this.createToken("(*comment-3*)" + separatorChar() + "(*comment-4*)", Lists.of(this.comment("(*comment-3*)"), this.comment("(*comment-4*)"))
+        );
+    }
+
+    abstract char separatorChar();
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeOrConcatenationParserTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeOrConcatenationParserTestCase.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+
+import java.util.List;
+
+public abstract class EbnfAlternativeOrConcatenationParserTestCase<T extends EbnfParserToken> extends EbnfParserTestCase2<T>{
+
+    @Test
+    public final void testOnlyToken() {
+        final String text = this.text();
+        final T token = this.token(text);
+        this.parseAndCheck(text, token, text);
+    }
+
+    @Test
+    public final void testWhitespaceIdentifier() {
+        final String text = WHITESPACE1 + IDENTIFIER1 + this.separatorChar() + IDENTIFIER2;
+        this.parseAndCheck(text,
+                this.token(text, whitespace1(), identifier1(), this.separatorCharToken(), identifier2()),
+                text);
+    }
+
+    @Test
+    public final void testWhitespaceIdentifierWhitespace() {
+        final String text = WHITESPACE1 + IDENTIFIER1 + WHITESPACE2 + this.separatorChar() + IDENTIFIER2;
+        this.parseAndCheck(text,
+                this.token(text, whitespace1(), identifier1(), whitespace2(), this.separatorCharToken(), identifier2()),
+                text);
+    }
+
+    @Test
+    public final void testWhitespaceIdentifierWhitespaceWhitespaceIdentifier2() {
+        final String text = WHITESPACE1 + IDENTIFIER1 + WHITESPACE2 + this.separatorChar() + WHITESPACE1 + IDENTIFIER2;
+        this.parseAndCheck(text,
+                this.token(text, whitespace1(), identifier1(), whitespace2(), this.separatorCharToken(), whitespace1(), identifier2()),
+                text);
+    }
+
+    @Test
+    public final void testWhitespaceIdentifierWhitespaceWhitespaceIdentifier2Whitespace() {
+        final String text = WHITESPACE1 + IDENTIFIER1 + WHITESPACE2 + this.separatorChar() + WHITESPACE1 + IDENTIFIER2;
+        this.parseAndCheck(text + WHITESPACE2,
+                this.token(text, whitespace1(), identifier1(), whitespace2(), this.separatorCharToken(), whitespace1(), identifier2()),
+                text,
+                WHITESPACE2);
+    }
+
+    @Test
+    public final void testCommentIdentifier() {
+        final String text = COMMENT1 + IDENTIFIER1 + this.separatorChar() + IDENTIFIER2;
+        this.parseAndCheck(text,
+                this.token(text, comment1(), identifier1(), this.separatorCharToken(), identifier2()),
+                text);
+    }
+
+    @Test
+    public final void testCommentIdentifierComment() {
+        final String text = COMMENT1 + IDENTIFIER1 + COMMENT2 + this.separatorChar() + IDENTIFIER2;
+        this.parseAndCheck(text,
+                this.token(text, comment1(), identifier1(), comment2(), this.separatorCharToken(), identifier2()),
+                text);
+    }
+
+    @Test
+    public final void testCommentIdentifierCommentCommentIdentifier2() {
+        final String text = COMMENT1 + IDENTIFIER1 + COMMENT2 + this.separatorChar() + COMMENT1 + IDENTIFIER2;
+        this.parseAndCheck(text,
+                this.token(text, comment1(), identifier1(), comment2(), this.separatorCharToken(), comment1(), identifier2()),
+                text);
+    }
+
+    @Test
+    public final void testCommentIdentifierCommentCommentIdentifier2Comment() {
+        final String text = COMMENT1 + IDENTIFIER1 + COMMENT2 + this.separatorChar() + COMMENT1 + IDENTIFIER2;
+        this.parseAndCheck(text + COMMENT2,
+                this.token(text, comment1(), identifier1(), comment2(), this.separatorCharToken(), comment1(), identifier2()),
+                text,
+                COMMENT2);
+    }
+
+    @Test
+    public final void testWhitespaceCommentIdentifier() {
+        final String text = WHITESPACE1 + COMMENT1 + IDENTIFIER1 + this.separatorChar() + IDENTIFIER2;
+        this.parseAndCheck(text,
+                this.token(text, whitespace1(), comment1(), identifier1(), this.separatorCharToken(), identifier2()),
+                text);
+    }
+
+    @Test
+    public final void testWhitespaceCommentWhitespaceIdentifier() {
+        final String text = WHITESPACE1 + COMMENT1 + WHITESPACE2 + IDENTIFIER1 + this.separatorChar() + IDENTIFIER2;
+        this.parseAndCheck(text,
+                this.token(text, whitespace1(), comment1(), whitespace2(), identifier1(), this.separatorCharToken(), identifier2()),
+                text);
+    }
+
+    @Override
+    final String text() {
+        return IDENTIFIER1 + this.separatorChar() + IDENTIFIER2;
+    }
+
+    abstract char separatorChar();
+
+    final EbnfSymbolParserToken separatorCharToken() {
+        final char c = this.separatorChar();
+        return EbnfParserToken.symbol(c, String.valueOf(c));
+    }
+
+    @Override
+    final T token(final String text) {
+        return this.token(text,
+                identifier1(),
+                separatorCharToken(),
+                identifier2());
+    }
+
+    final T token(final String text, final EbnfParserToken...tokens) {
+        return this.token(text, Lists.of(tokens));
+    }
+
+    abstract T token(final String text, final List<EbnfParserToken> tokens);
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.List;
+
+public final class EbnfAlternativeParserTest extends EbnfAlternativeOrConcatenationParserTestCase<EbnfAlternativeParserToken> {
+
+    @Override
+    protected Parser<ParserToken, EbnfParserContext> createParser() {
+        return EbnfGrammarParser.ALTERNATIVE;
+    }
+
+    @Override
+    char separatorChar() {
+        return '|';
+    }
+
+    @Override
+    EbnfAlternativeParserToken token(final String text, final List<EbnfParserToken> tokens) {
+        return EbnfParserToken.alternative(tokens, text);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserTokenTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import java.util.List;
+
+public final class EbnfAlternativeParserTokenTest extends EbnfAlternativeConcatenationParentParserTokenTestCase<EbnfAlternativeParserToken> {
+
+    @Override
+    EbnfAlternativeParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+        return EbnfAlternativeParserToken.with(tokens, text);
+    }
+
+    @Override
+    String text() {
+        return "(*comment1*)|(*comment2*)";
+    }
+
+    @Override
+    char separatorChar() {
+        return '|';
+    }
+
+    @Override
+    protected Class<EbnfAlternativeParserToken> type() {
+        return EbnfAlternativeParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfCommentParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfCommentParserTokenTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+public final class EbnfCommentParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfCommentParserToken, String> {
+
+    @Override
+    String text() {
+        return "(* comment *)";
+    }
+
+    String value() {
+        return this.text();
+    }
+
+    @Override
+    protected EbnfCommentParserToken createToken(final String value, final String text) {
+        return EbnfCommentParserToken.with(value, text);
+    }
+
+    @Override
+    protected EbnfCommentParserToken createDifferentToken() {
+        return EbnfCommentParserToken.with("(* different *)", "(* different *)");
+    }
+
+    @Override
+    protected Class<EbnfCommentParserToken> type() {
+        return EbnfCommentParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.List;
+
+public final class EbnfConcatenationParserTest extends EbnfAlternativeOrConcatenationParserTestCase<EbnfConcatenationParserToken> {
+
+    @Override
+    protected Parser<ParserToken, EbnfParserContext> createParser() {
+        return EbnfGrammarParser.CONCATENATION;
+    }
+
+    @Override
+    char separatorChar() {
+        return ',';
+    }
+
+    @Override
+    EbnfConcatenationParserToken token(final String text, final List<EbnfParserToken> tokens) {
+        return EbnfParserToken.concatenation(tokens, text);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserTokenTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import java.util.List;
+
+public final class EbnfConcatenationParserTokenTest extends EbnfAlternativeConcatenationParentParserTokenTestCase<EbnfConcatenationParserToken> {
+
+    @Override
+    EbnfConcatenationParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+        return EbnfConcatenationParserToken.with(tokens, text);
+    }
+
+    @Override
+    String text() {
+        return "(*comment1*)|(*comment2*)";
+    }
+
+    @Override
+    char separatorChar() {
+        return ',';
+    }
+
+    @Override
+    protected Class<EbnfConcatenationParserToken> type() {
+        return EbnfConcatenationParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+public final class EbnfGrammarParserTest extends EbnfParserTestCase<EbnfGrammarParserToken>{
+
+    private final static String RULE1 = IDENTIFIER1 + "=" + TERMINAL1_TEXT + ";";
+    private final static String RULE2 = IDENTIFIER2 + "=" + TERMINAL2_TEXT + ";";
+
+    @Test
+    public void testCompact() {
+        final String text = RULE1 + RULE2;
+        this.parseAndCheck(text,
+                grammar(text,
+                        rule1(),
+                        rule2()),
+                text);
+    }
+
+
+    @Test
+    public void testWhitespaceBetweenRules() {
+        final String between = WHITESPACE1;
+        final String text = RULE1 + between + RULE2;
+        this.parseAndCheck(text,
+                grammar(text,
+                        rule1(),
+                        rule(WHITESPACE1 + RULE2, whitespace1(), identifier2(), assignmentToken(), terminal2(), terminatorToken())),
+                text);
+    }
+
+    @Test
+    public void testWhitespaceAfterRules() {
+        final String text = RULE1+RULE2;
+        final String textAfter = "   ";
+        this.parseAndCheck(text + textAfter,
+                grammar(text,
+                        rule1(),
+                        rule2()),
+                text,
+                textAfter);
+    }
+
+    private EbnfGrammarParserToken grammar(final String text, final EbnfRuleParserToken...rules) {
+        return new EbnfGrammarParserToken(Lists.of(rules), text);
+    }
+
+    private EbnfRuleParserToken rule1() {
+        return rule(RULE1, identifier1(), assignmentToken(), terminal1(), terminatorToken());
+    }
+
+    private EbnfRuleParserToken rule2() {
+        return rule(RULE2, identifier2(), assignmentToken(), terminal2(), terminatorToken());
+    }
+
+    @Override
+    protected Parser<ParserToken, EbnfParserContext> createParser() {
+        return Cast.to(EbnfGrammarParser.GRAMMAR);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupOptionalRepeatParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupOptionalRepeatParentParserTokenTestCase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+
+import java.util.List;
+
+public abstract class EbnfGroupOptionalRepeatParentParserTokenTestCase<T extends EbnfParentParserToken> extends EbnfParentParserTokenTestCase2<T> {
+
+    @Test(expected = NullPointerException.class)
+    public final void testWithNullTokenFails() {
+        this.createToken(this.text(), Cast.<List<EbnfParserToken>>to(null));
+    }
+
+    @Override
+    protected T createDifferentToken() {
+        return this.createToken(this.openChar() + "(*comment-3*)(*comment-4*)" + this.closeChar(), Lists.of(this.comment("(*comment-3*)"), this.comment("(*comment-4*)"))
+        );
+    }
+
+    @Override
+    final String text() {
+        return this.openChar() + "(*comment-1*)" + this.closeChar();
+    }
+
+    abstract char openChar();
+
+    abstract char closeChar();
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserTokenTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import java.util.List;
+
+public class EbnfGroupParserTokenTest extends EbnfGroupOptionalRepeatParentParserTokenTestCase<EbnfGroupParserToken> {
+
+    @Override
+    EbnfGroupParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+        return EbnfGroupParserToken.with(tokens, text);
+    }
+
+    @Override
+    char openChar() {
+        return ')';
+    }
+
+    @Override
+    char closeChar() {
+        return '(';
+    }
+
+    @Override
+    protected Class<EbnfGroupParserToken> type() {
+        return EbnfGroupParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupingParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupingParserTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.List;
+
+public final class EbnfGroupingParserTest extends EbnfParserTestCase4<EbnfGroupParserToken> {
+
+    @Override
+    protected Parser<ParserToken, EbnfParserContext> createParser() {
+        return EbnfGrammarParser.GROUPING;
+    }
+
+    @Override
+    char beginChar() {
+        return '(';
+    }
+
+    @Override
+    char endChar() {
+        return ')';
+    }
+
+    @Override
+    EbnfGroupParserToken token(final String text, final List<EbnfParserToken> tokens) {
+        return EbnfParserToken.grouping(tokens, text);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+public final class EbnfIdentifierParserTest extends EbnfParserTestCase3<EbnfIdentifierParserToken>{
+
+    @Override
+    protected Parser<ParserToken, EbnfParserContext> createParser() {
+        return EbnfGrammarParser.IDENTIFIER;
+    }
+
+    @Override
+    String text() {
+        return IDENTIFIER1;
+    }
+
+    @Override
+    EbnfIdentifierParserToken token(final String text) {
+        return new EbnfIdentifierParserToken(
+                this.text(),
+                text);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserTokenTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+public final class EbnfIdentifierParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfIdentifierParserToken, String> {
+
+    @Override
+    String text() {
+        return "abc123";
+    }
+
+    String value() {
+        return this.text();
+    }
+
+    @Override
+    protected EbnfIdentifierParserToken createToken(final String value, final String text) {
+        return EbnfIdentifierParserToken.with(value, text);
+    }
+
+    @Override
+    protected EbnfIdentifierParserToken createDifferentToken() {
+        return EbnfIdentifierParserToken.with("different", "different");
+    }
+
+    @Override
+    protected Class<EbnfIdentifierParserToken> type() {
+        return EbnfIdentifierParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfLeafParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfLeafParserTokenTestCase.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+public abstract class EbnfLeafParserTokenTestCase<T extends EbnfLeafParserToken, V> extends EbnfParserTokenTestCase<T> {
+
+    @Override
+    protected final T createToken(final String text) {
+        return this.createToken(this.value(), text);
+    }
+
+    abstract V value();
+
+    abstract T createToken(final V value, final String text);
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.List;
+
+public final class EbnfOptionalParserTest extends EbnfParserTestCase4<EbnfOptionalParserToken> {
+
+    @Override
+    protected Parser<ParserToken, EbnfParserContext> createParser() {
+        return EbnfGrammarParser.OPTIONAL;
+    }
+
+    @Override
+    char beginChar() {
+        return '[';
+    }
+
+    @Override
+    char endChar() {
+        return ']';
+    }
+
+    @Override
+    EbnfOptionalParserToken token(final String text, final List<EbnfParserToken> tokens) {
+        return EbnfParserToken.optional(tokens, text);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserTokenTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import java.util.List;
+
+public class EbnfOptionalParserTokenTest extends EbnfGroupOptionalRepeatParentParserTokenTestCase<EbnfOptionalParserToken> {
+
+    @Override
+    EbnfOptionalParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+        return EbnfOptionalParserToken.with(tokens, text);
+    }
+
+    @Override
+    char openChar() {
+        return ']';
+    }
+
+    @Override
+    char closeChar() {
+        return '[';
+    }
+
+    @Override
+    protected Class<EbnfOptionalParserToken> type() {
+        return EbnfOptionalParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+
+import java.util.List;
+
+public abstract class EbnfParentParserTokenTestCase<T extends EbnfParentParserToken> extends EbnfParserTokenTestCase<T> {
+
+    @Test(expected = NullPointerException.class)
+    public final void testWithNullTokensFails() {
+        this.createToken(this.text(), Cast.<List<EbnfParserToken>>to(null));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public final void testWithEmptyTokensFails() {
+        this.createToken(this.text(), Lists.empty());
+    }
+
+    @Test
+    public final void testWithCopiesTokens() {
+        final List<EbnfParserToken> tokens = this.tokens();
+        final String text = this.text();
+        final T token = this.createToken(text, tokens);
+        this.checkText(token, text);
+        assertEquals("tokens", tokens, token.value());
+        assertSame("tokens not copied", tokens, token.value());
+    }
+
+    @Override
+    final T createToken(final String text) {
+        return this.createToken(text, this.tokens());
+    }
+
+    final T createToken(final String text, final EbnfParserToken...tokens) {
+        return this.createToken(text, Lists.of(tokens));
+    }
+
+    abstract T createToken(final String text, final List<EbnfParserToken> tokens);
+
+    abstract List<EbnfParserToken> tokens();
+
+    final EbnfCommentParserToken comment(final String text) {
+        return EbnfParserToken.comment(text, text);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase2.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase2.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.collect.list.Lists;
+
+import java.util.List;
+
+public abstract class EbnfParentParserTokenTestCase2<T extends EbnfParentParserToken> extends EbnfParentParserTokenTestCase<T> {
+
+    @Override
+    final List<EbnfParserToken> tokens() {
+        return Lists.of(this.comment("(*comment-1*)"), this.comment("(*comment-2*)"));
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserTestCase3;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+public abstract class EbnfParserTestCase<T extends EbnfParserToken> extends ParserTestCase3<Parser<ParserToken, EbnfParserContext>, ParserToken, EbnfParserContext> {
+
+    final static String COMMENT1 = "(*comment-1*)";
+    final static String COMMENT2 = "(*comment-2*)";
+
+    final static String IDENTIFIER1 = "abc123";
+    final static String IDENTIFIER2 = "def456";
+
+    final static String WHITESPACE1 = " ";
+    final static String WHITESPACE2 = "   ";
+
+    final static String TERMINAL1 = "terminal456";
+    final static String TERMINAL1_TEXT = '"' + TERMINAL1 + '"';
+
+    final static String TERMINAL2 = "terminal789";
+    final static String TERMINAL2_TEXT = '"' + TERMINAL2 + '"';
+
+    final static String ASSIGNMENT = "=";
+    final static String TERMINATOR = ";";
+
+    @Test
+    public void testOrphanedAssignmentFail() {
+        this.parseFailAndCheck("=");
+    }
+
+    @Test
+    public void testInvalidSymbolToken() {
+        this.parseFailAndCheck("$");
+    }
+
+    @Override
+    protected final EbnfParserContext createContext() {
+        return new EbnfParserContext();
+    }
+
+    final EbnfParserToken comment1() {
+        return EbnfParserToken.comment(COMMENT1, COMMENT1);
+    }
+
+    final EbnfParserToken comment2() {
+        return EbnfParserToken.comment(COMMENT2, COMMENT2);
+    }
+
+    final EbnfParserToken identifier1() {
+        return EbnfParserToken.identifier(IDENTIFIER1, IDENTIFIER1);
+    }
+
+    final EbnfParserToken identifier2() {
+        return EbnfParserToken.identifier(IDENTIFIER2, IDENTIFIER2);
+    }
+
+    final EbnfParserToken whitespace1() {
+        return EbnfParserToken.whitespace(WHITESPACE1, WHITESPACE1);
+    }
+
+    final EbnfParserToken whitespace2() {
+        return EbnfParserToken.whitespace(WHITESPACE2, WHITESPACE2);
+    }
+
+    static EbnfSymbolParserToken symbol(final char c) {
+        return EbnfParserToken.symbol(c, String.valueOf(c));
+    }
+
+    static EbnfRuleParserToken rule(final String text, final EbnfParserToken...tokens) {
+        return EbnfParserToken.rule(Lists.of(tokens), text);
+    }
+
+    static EbnfSymbolParserToken assignmentToken() {
+        return symbol('=');
+    }
+
+    static EbnfTerminalParserToken terminal1() {
+        return EbnfParserToken.terminal(TERMINAL1, TERMINAL1_TEXT);
+    }
+
+    static EbnfTerminalParserToken terminal2() {
+        return EbnfParserToken.terminal(TERMINAL2, TERMINAL2_TEXT);
+    }
+
+    static EbnfSymbolParserToken terminatorToken() {
+        return symbol(';');
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase2.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase2.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+public abstract class EbnfParserTestCase2<T extends EbnfParserToken> extends EbnfParserTestCase<T> {
+
+    abstract String text();
+
+    abstract T token(final String text);
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase3.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase3.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import org.junit.Test;
+
+public abstract class EbnfParserTestCase3<T extends EbnfParserToken> extends EbnfParserTestCase2<T>{
+
+    @Test
+    public final void testOnlyToken() {
+        final String text = this.text();
+        final T token = this.token(text);
+        this.parseAndCheck(text, token, text);
+    }
+
+    @Test
+    public final void testWhitespaceBeforeFails() {
+        this.parseFailAndCheck(" " + this.text());
+    }
+
+    @Test
+    public final void testCommentBeforeFails() {
+        this.parseFailAndCheck(" " + this.text());
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase4.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase4.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+
+import java.util.List;
+
+public abstract class EbnfParserTestCase4<T extends EbnfParserToken> extends EbnfParserTestCase2<T>{
+
+    @Test
+    public final void testWhitespaceIdentifier() {
+        final String text = this.beginChar() + WHITESPACE1 + IDENTIFIER1 + this.endChar();
+        this.parseAndCheck(text,
+                this.token(text, this.beginCharToken(), whitespace1(), this.identifier1(), this.endCharToken()),
+                text);
+    }
+
+    @Test
+    public final void testWhitespaceIdentifierWhitespace() {
+        final String text = this.beginChar() + WHITESPACE1 + IDENTIFIER1 + WHITESPACE2 + this.endChar();
+        this.parseAndCheck(text,
+                this.token(text, this.beginCharToken(), whitespace1(), this.identifier1(), this.whitespace2(), this.endCharToken()),
+                text);
+    }
+
+    @Test
+    public final void testCommentIdentifier() {
+        final String text = this.beginChar() + COMMENT1 + IDENTIFIER1 + this.endChar();
+        this.parseAndCheck(text,
+                this.token(text, this.beginCharToken(), comment1(), this.identifier1(), this.endCharToken()),
+                text);
+    }
+
+    @Test
+    public final void testCommentIdentifierComment() {
+        final String text = this.beginChar() + COMMENT1 + IDENTIFIER1 + COMMENT2 + this.endChar();
+        this.parseAndCheck(text,
+                this.token(text, this.beginCharToken(), comment1(), this.identifier1(), this.comment2(), this.endCharToken()),
+                text);
+    }
+
+    @Test
+    public final void testWhitespaceIdentifierComment() {
+        final String text = this.beginChar() + WHITESPACE1 + IDENTIFIER1 + COMMENT2 + this.endChar();
+        this.parseAndCheck(text,
+                this.token(text, this.beginCharToken(), whitespace1(), this.identifier1(), this.comment2(), this.endCharToken()),
+                text);
+    }
+
+    @Override
+    String text() {
+        return this.beginChar() + IDENTIFIER1 + this.endChar();
+    }
+
+    abstract char beginChar();
+
+    final EbnfSymbolParserToken beginCharToken() {
+        return symbolToken(this.beginChar());
+    }
+
+    abstract char endChar();
+
+    final EbnfSymbolParserToken endCharToken() {
+        return symbolToken(this.endChar());
+    }
+
+    private EbnfSymbolParserToken symbolToken(final char c) {
+        return EbnfParserToken.symbol(c, String.valueOf(c));
+    }
+
+    final T token(final String text) {
+        return this.token(text, identifier1());
+    }
+
+    final T token(final String text, final EbnfParserToken...tokens) {
+        return this.token(text, Lists.of(tokens));
+    }
+
+    abstract T token(final String text, final List<EbnfParserToken> tokens);
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTokenTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import org.junit.Test;
+import walkingkooka.text.CharSequences;
+import walkingkooka.text.cursor.parser.ParserTokenTestCase;
+import walkingkooka.type.MethodAttributes;
+
+import java.lang.reflect.Method;
+
+public abstract class EbnfParserTokenTestCase<T extends EbnfParserToken> extends ParserTokenTestCase<T> {
+
+    @Test(expected =  NullPointerException.class)
+    public final void testNullTextFails() {
+        this.createToken(null);
+    }
+
+    @Test(expected =  IllegalArgumentException.class)
+    public final void testEmptyTextFails() {
+        this.createToken("");
+    }
+
+    @Test
+    public void testText() {
+        assertEquals(this.text(), this.createToken().text());
+    }
+
+    @Test
+    public void testIsMethods() throws Exception {
+        final T token = this.createToken();
+        final String name = token.getClass().getSimpleName();
+        assertEquals(name + " starts with Ebnf", true, name.startsWith("Ebnf"));
+        assertEquals(name + " ends with ParserToken", true, name.endsWith("ParserToken"));
+
+        final String isMethodName = "is" + CharSequences.capitalize(name.substring(4, name.length() - "ParserToken".length()));
+
+        for(Method method : token.getClass().getMethods()) {
+            if(MethodAttributes.STATIC.is(method)) {
+                continue;
+            }
+            final String methodName = method.getName();
+            if(!methodName.startsWith("is")) {
+                continue;
+            }
+            assertEquals(method + " returned",
+                    methodName.equals(isMethodName),
+                    method.invoke(token));
+        }
+    }
+
+    @Test
+    public final void testToString() {
+        assertEquals(this.text(), this.createToken().toString());
+    }
+
+    @Override
+    protected final T createToken() {
+        return this.createToken(this.text());
+    }
+
+    abstract T createToken(final String text);
+
+    abstract String text();
+
+    static EbnfSymbolParserToken symbol(final char c) {
+        return EbnfParserToken.symbol(c, String.valueOf(c));
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatParserTokenTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import java.util.List;
+
+public class EbnfRepeatParserTokenTest extends EbnfGroupOptionalRepeatParentParserTokenTestCase<EbnfRepeatedParserToken> {
+
+    @Override
+    EbnfRepeatedParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+        return EbnfRepeatedParserToken.with(tokens, text);
+    }
+
+    @Override
+    char openChar() {
+        return ')';
+    }
+
+    @Override
+    char closeChar() {
+        return '(';
+    }
+
+    @Override
+    protected Class<EbnfRepeatedParserToken> type() {
+        return EbnfRepeatedParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepetitionParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepetitionParserTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.List;
+
+public final class EbnfRepetitionParserTest extends EbnfParserTestCase4<EbnfRepeatedParserToken> {
+
+    @Override
+    protected Parser<ParserToken, EbnfParserContext> createParser() {
+        return EbnfGrammarParser.REPETITION;
+    }
+
+    @Override
+    char beginChar() {
+        return '{';
+    }
+
+    @Override
+    char endChar() {
+        return '}';
+    }
+
+    @Override
+    EbnfRepeatedParserToken token(final String text, final List<EbnfParserToken> tokens) {
+        return EbnfParserToken.repeated(tokens, text);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRhsParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRhsParserTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+public final class EbnfRhsParserTest extends EbnfParserTestCase2<EbnfParserToken>{
+
+    @Override
+    protected Parser<ParserToken, EbnfParserContext> createParser() {
+        return EbnfGrammarParser.RHS;
+    }
+
+    @Override
+    String text() {
+        return "abc123";
+    }
+
+    @Override
+    EbnfParserToken token(final String text) {
+        return new EbnfIdentifierParserToken(
+                this.text(),
+                text);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import org.junit.Test;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+public final class EbnfRuleParserTest extends EbnfParserTestCase2<EbnfRuleParserToken> {
+
+    @Test
+    public void testIdentifierOnlyFails() {
+        this.parseFailAndCheck(IDENTIFIER1);
+    }
+
+    @Test
+    public void testIdentifierAndAssignmentOnlyFails() {
+        this.parseFailAndCheck(IDENTIFIER1 + ASSIGNMENT);
+    }
+
+    @Test
+    public void testAssignmentOnlyFails() {
+        this.parseFailAndCheck(ASSIGNMENT);
+    }
+
+    @Test
+    public void testDoubleTerminalFails() {
+        this.parseFailAndCheck(IDENTIFIER1 + ASSIGNMENT + TERMINAL1_TEXT + ASSIGNMENT + TERMINAL1_TEXT);
+    }
+
+    @Test
+    public void testWhitespaceAssignment() {
+        final String text = IDENTIFIER1 + WHITESPACE1 + ASSIGNMENT + TERMINAL1_TEXT + TERMINATOR;
+        this.parseAndCheck(text,
+                rule(text, identifier1(), whitespace1(), assignmentToken(), terminal1(), terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testCommentAssignment() {
+        final String text = IDENTIFIER1 + COMMENT1 + ASSIGNMENT + TERMINAL1_TEXT + TERMINATOR;
+        this.parseAndCheck(text,
+                rule(text, identifier1(), comment1(), assignmentToken(), terminal1(), terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testWhitespaceCommentAssignment() {
+        final String text = IDENTIFIER1 + WHITESPACE1 + COMMENT1 + ASSIGNMENT + TERMINAL1_TEXT + TERMINATOR;
+        this.parseAndCheck(text,
+                rule(text, identifier1(), whitespace1(), comment1(), assignmentToken(), terminal1(), terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testWhitespaceCommentWhitespaceAssignment() {
+        final String text = IDENTIFIER1 + WHITESPACE1 + COMMENT1 + WHITESPACE2 + ASSIGNMENT + TERMINAL1_TEXT + TERMINATOR;
+        this.parseAndCheck(text,
+                rule(text, identifier1(), whitespace1(), comment1(), whitespace2(), assignmentToken(), terminal1(), terminatorToken()),
+                text);
+    }
+    
+    // assignment
+
+    @Test
+    public void testeAssignmentWhitespac() {
+        final String text = IDENTIFIER1 + ASSIGNMENT + WHITESPACE1 + TERMINAL1_TEXT + TERMINATOR;
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), whitespace1(), terminal1(), terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testeAssignmentComment() {
+        final String text = IDENTIFIER1 + ASSIGNMENT + COMMENT1 + TERMINAL1_TEXT + TERMINATOR;
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), comment1(), terminal1(), terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testAssignmentWhitespaceComment() {
+        final String text = IDENTIFIER1 + ASSIGNMENT + WHITESPACE1 + COMMENT1 + TERMINAL1_TEXT + TERMINATOR;
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), whitespace1(), comment1(), terminal1(), terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testAssignmentWhitespaceCommentWhitespace() {
+        final String text = IDENTIFIER1 +  ASSIGNMENT + WHITESPACE1 + COMMENT1 + WHITESPACE2 + TERMINAL1_TEXT + TERMINATOR;
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), whitespace1(), comment1(), whitespace2(), terminal1(), terminatorToken()),
+                text);
+    }
+    
+    // terminator
+
+    @Test
+    public void testeTokenWhitespace() {
+        final String text = IDENTIFIER1 + ASSIGNMENT + TERMINAL1_TEXT + WHITESPACE1 + TERMINATOR;
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), terminal1(), whitespace1(), terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testeTokenComment() {
+        final String text = IDENTIFIER1 + ASSIGNMENT + TERMINAL1_TEXT + COMMENT1 + TERMINATOR;
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), terminal1(), comment1(), terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testTokenWhitespaceComment() {
+        final String text = IDENTIFIER1 + ASSIGNMENT + TERMINAL1_TEXT + WHITESPACE1 + COMMENT1 + TERMINATOR;
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), terminal1(), whitespace1(), comment1(), terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testTokenWhitespaceCommentWhitespace() {
+        final String text = IDENTIFIER1 +  ASSIGNMENT + TERMINAL1_TEXT + WHITESPACE1 + COMMENT1 + WHITESPACE2 +TERMINATOR;
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), terminal1(), whitespace1(), comment1(), whitespace2(), terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testTerminatorWhitespace() {
+        final String text = IDENTIFIER1 + ASSIGNMENT + TERMINAL1_TEXT + TERMINATOR;
+        this.parseAndCheck(text + WHITESPACE1,
+                rule(text, identifier1(), assignmentToken(), terminal1(), terminatorToken()),
+                text,
+                WHITESPACE1);
+    }
+
+    @Test
+    public void testTerminatorComments() {
+        final String text = IDENTIFIER1 + ASSIGNMENT + TERMINAL1_TEXT + TERMINATOR;
+        this.parseAndCheck(text + COMMENT1,
+                rule(text, identifier1(), assignmentToken(), terminal1(), terminatorToken()),
+                text,
+                COMMENT1);
+    }
+
+    @Override
+    protected Parser<ParserToken, EbnfParserContext> createParser() {
+        return EbnfGrammarParser.RULE;
+    }
+
+    @Override
+    String text() {
+        return "identifier123=\"terminal456\";";
+    }
+
+    @Override
+    EbnfRuleParserToken token(final String text) {
+        return rule(text,
+                new EbnfIdentifierParserToken(IDENTIFIER1, IDENTIFIER1),
+                assignmentToken(),
+                new EbnfTerminalParserToken(TERMINAL1, TERMINAL1_TEXT),
+                terminatorToken());
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTokenConsumerTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTokenConsumerTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class EbnfRuleParserTokenConsumerTest extends PackagePrivateClassTestCase<EbnfRuleParserTokenConsumer> {
+    @Override
+    protected Class<EbnfRuleParserTokenConsumer> type() {
+        return EbnfRuleParserTokenConsumer.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTokenTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+
+import java.util.List;
+
+public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfRuleParserToken> {
+
+    @Test(expected = NullPointerException.class)
+    public final void testWithNullTokenFails() {
+        this.createToken(this.text(), Cast.<List<EbnfParserToken>>to(null));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingIdentifierFails() {
+        this.createToken(this.text(), assignment(), terminal(), terminator());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingIdentifierFails2() {
+        this.createToken(this.text(), terminal(), assignment(), identifier(), terminator());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingTokenFails() {
+        this.createToken(this.text(), identifier(), assignment(), terminator());
+    }
+
+    @Override
+    protected EbnfRuleParserToken createDifferentToken() {
+        return this.createToken("xyz=qrs;",
+                identifier("xyz"), assignment(), identifier("qrs"), terminator());
+    }
+
+    @Override
+    final String text() {
+        return "abc123=def456";
+    }
+
+    final List<EbnfParserToken> tokens() {
+        return Lists.of(this.identifier(), this.assignment(), this.terminal(), this.terminator());
+    }
+
+    @Override
+    EbnfRuleParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+        return EbnfRuleParserToken.with(tokens, text);
+    }
+
+    private EbnfIdentifierParserToken identifier() {
+        return identifier("abc");
+    }
+
+    private EbnfIdentifierParserToken identifier(final String text) {
+        return EbnfParserToken.identifier(text, text);
+    }
+
+    private EbnfTerminalParserToken terminal() {
+        return terminal("xyz");
+    }
+
+    private EbnfTerminalParserToken terminal(final String text) {
+        return EbnfParserToken.terminal(text, '"' + text + '"');
+    }
+
+    private EbnfSymbolParserToken assignment() {
+        return symbol('=');
+    }
+
+    private EbnfSymbolParserToken terminator() {
+        return symbol(';');
+    }
+
+    @Override
+    protected Class<EbnfRuleParserToken> type() {
+        return EbnfRuleParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfSymbolParserTokenTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class EbnfSymbolParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfSymbolParserToken, Character> {
+
+    @Override
+    String text() {
+        return ";";
+    }
+
+    Character value() {
+        return ';';
+    }
+
+    @Override
+    protected EbnfSymbolParserToken createToken(final Character value, final String text) {
+        return EbnfSymbolParserToken.with(value, text);
+    }
+
+    @Override
+    protected EbnfSymbolParserToken createDifferentToken() {
+        return EbnfSymbolParserToken.with('|', "|");
+    }
+
+    @Override
+    protected Class<EbnfSymbolParserToken> type() {
+        return EbnfSymbolParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+import org.junit.Test;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+public final class EbnfTerminalParserTest extends EbnfParserTestCase3<EbnfTerminalParserToken>{
+
+    @Test
+    public void testIncompleteFails() {
+        this.parseFailAndCheck("'incomplete");
+    }
+
+    @Test
+    public void testSingleQuoteLiteral() {
+        final String text = "hello";
+        final String quoted = singleQuote(text);
+
+        this.parseAndCheck(quoted, new EbnfTerminalParserToken(text, quoted), quoted);
+    }
+
+    @Test
+    public void testDoubleQuoteLiteral() {
+        final String text = "hello";
+        final String quoted = doubleQuote(text);
+
+        this.parseAndCheck(quoted, new EbnfTerminalParserToken(text, quoted), quoted);
+    }
+
+    private static String singleQuote(final String text) {
+        return '\'' + text + '\'';
+    }
+
+    private static String doubleQuote(final String text) {
+        return '"' + text + '"';
+    }
+
+    @Override
+    protected Parser<ParserToken, EbnfParserContext> createParser() {
+        return EbnfGrammarParser.TERMINAL;
+    }
+
+    @Override
+    String text() {
+        return singleQuote("hello");
+    }
+
+    @Override
+    EbnfTerminalParserToken token(final String text) {
+        final String quotedText = this.text();
+        return new EbnfTerminalParserToken(
+                quotedText.substring(1, quotedText.length() -1),
+                text);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserTokenTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+public final class EbnfTerminalParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfTerminalParserToken, String> {
+
+    @Override
+    String text() {
+        return "'A'";
+    }
+
+    String value() {
+        return this.text();
+    }
+
+    @Override
+    protected EbnfTerminalParserToken createToken(final String value, final String text) {
+        return EbnfTerminalParserToken.with(value, text);
+    }
+
+    @Override
+    protected EbnfTerminalParserToken createDifferentToken() {
+        return EbnfTerminalParserToken.with("'different'", "'different'");
+    }
+
+    @Override
+    protected Class<EbnfTerminalParserToken> type() {
+        return EbnfTerminalParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfWhitespaceParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfWhitespaceParserTokenTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package walkingkooka.text.cursor.parser.ebnf;
+
+public final class EbnfWhitespaceParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfWhitespaceParserToken, String> {
+
+    @Override
+    String text() {
+        return " ";
+    }
+
+    String value() {
+        return this.text();
+    }
+
+    @Override
+    protected EbnfWhitespaceParserToken createToken(final String value, final String text) {
+        return EbnfWhitespaceParserToken.with(value, text);
+    }
+
+    @Override
+    protected EbnfWhitespaceParserToken createDifferentToken() {
+        return EbnfWhitespaceParserToken.with("\n\r", "\n\r");
+    }
+
+    @Override
+    protected Class<EbnfWhitespaceParserToken> type() {
+        return EbnfWhitespaceParserToken.class;
+    }
+}


### PR DESCRIPTION
- Grammar parser returns all tokens including whitespace and comments.
- Created token classes for all ebnf tokens.
- Removed final from PackagePrivateClassTest so tests can be "disabled".
- Introduced ParserTestCase3 for testing parsers without the type() checks of ParserTestCase.
- TODO need some error recovery mechanism in parsing to report hints of desired but failed to match token.
- TODO introduce support for defining a character range (EbnfRange)
- TODO parent tokens need a withoutCommentsOrWhitespace()