### PR TITLE
Introduced EbnfParserToken.withoutCommentsSymbolsOrWhitespace and act…

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserToken.java
@@ -16,7 +16,6 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
-import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 
 import java.util.List;
@@ -29,11 +28,12 @@ final public class EbnfAlternativeParserToken extends EbnfParentParserToken {
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfAlternativeParserToken.class);
 
     static EbnfAlternativeParserToken with(final List<EbnfParserToken> tokens, final String text) {
-        return new EbnfAlternativeParserToken(copyAndCheckTokens(tokens), checkText(text));
+        return new EbnfAlternativeParserToken(copyAndCheckTokens(tokens), checkText(text), WITHOUT_COMPUTE_REQUIRED);
     }
 
-    EbnfAlternativeParserToken(final List<EbnfParserToken> tokens, final String text) {
-        super(tokens, text);
+    private EbnfAlternativeParserToken(final List<EbnfParserToken> tokens, final String text, final boolean computeWithout) {
+        super(tokens, text, computeWithout);
+        this.checkAtLeastTwoTokens();
     }
 
     @Override
@@ -43,7 +43,12 @@ final public class EbnfAlternativeParserToken extends EbnfParentParserToken {
 
     @Override
     EbnfAlternativeParserToken replaceText(final String text) {
-        return new EbnfAlternativeParserToken(this.value(), text);
+        return new EbnfAlternativeParserToken(this.value(), text, WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    @Override
+    EbnfAlternativeParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+        return new EbnfAlternativeParserToken(tokens, this.text(), WITHOUT_USE_THIS);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfCommentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfCommentParserToken.java
@@ -18,6 +18,8 @@ package walkingkooka.text.cursor.parser.ebnf;
 
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 
+import java.util.Optional;
+
 /**
  * Holds the text for a comment.
  */
@@ -32,7 +34,7 @@ public final class EbnfCommentParserToken extends EbnfLeafParserToken<String> {
         return new EbnfCommentParserToken(value, text);
     }
 
-    EbnfCommentParserToken(final String value, final String text){
+    private EbnfCommentParserToken(final String value, final String text){
         super(value, text);
     }
 
@@ -44,6 +46,11 @@ public final class EbnfCommentParserToken extends EbnfLeafParserToken<String> {
     @Override
     EbnfCommentParserToken replaceText(final String text) {
         return new EbnfCommentParserToken(this.value, text);
+    }
+
+    @Override
+    public Optional<EbnfParserToken> withoutCommentsSymbolsOrWhitespace(){
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserToken.java
@@ -16,7 +16,6 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
-import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 
 import java.util.List;
@@ -29,11 +28,12 @@ public final class EbnfConcatenationParserToken extends EbnfParentParserToken {
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfConcatenationParserToken.class);
 
     static EbnfConcatenationParserToken with(final List<EbnfParserToken> tokens, final String text) {
-        return new EbnfConcatenationParserToken(copyAndCheckTokens(tokens), checkText(text));
+        return new EbnfConcatenationParserToken(copyAndCheckTokens(tokens), checkText(text), WITHOUT_COMPUTE_REQUIRED);
     }
 
-    EbnfConcatenationParserToken(final List<EbnfParserToken> tokens, final String text) {
-        super(tokens, text);
+    private EbnfConcatenationParserToken(final List<EbnfParserToken> tokens, final String text, final boolean computeWithout) {
+        super(tokens, text, computeWithout);
+        this.checkAtLeastTwoTokens();
     }
 
     @Override
@@ -43,7 +43,12 @@ public final class EbnfConcatenationParserToken extends EbnfParentParserToken {
 
     @Override
     EbnfConcatenationParserToken replaceText(final String text) {
-        return new EbnfConcatenationParserToken(this.value(), text);
+        return new EbnfConcatenationParserToken(this.value(), text, WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    @Override
+    EbnfConcatenationParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+        return new EbnfConcatenationParserToken(tokens, text(), WITHOUT_USE_THIS);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParser.java
@@ -88,10 +88,10 @@ final class EbnfGrammarParser implements Parser<EbnfGrammarParserToken, EbnfPars
 
     private static Parser<ParserToken, EbnfParserContext> whitespaceOrComment() {
         final Parser<EbnfWhitespaceParserToken, EbnfParserContext> whitespace = Parsers.<EbnfParserContext>stringCharPredicate(CharPredicates.whitespace())
-                .transform((string, context) -> new EbnfWhitespaceParserToken(string.value(), string.text()))
+                .transform((string, context) -> EbnfWhitespaceParserToken.with(string.value(), string.text()))
                 .setToString("whitespace");
         final Parser<ParserToken, EbnfParserContext> comment = Parsers.<EbnfParserContext>surround("(*", "*)")
-                .transform((string, context) -> new EbnfCommentParserToken(string.value(), string.text()))
+                .transform((string, context) -> EbnfCommentParserToken.with(string.value(), string.text()))
                 .setToString("comment")
                 .castC();
 
@@ -176,7 +176,7 @@ final class EbnfGrammarParser implements Parser<EbnfGrammarParserToken, EbnfPars
      */
     private static Parser<ParserToken, EbnfParserContext> symbol(final char c, final String name){
         return EbnfParserContext.character(c)
-                        .transform((character, context) -> new EbnfSymbolParserToken(character.value(), character.text()))
+                        .transform((character, context) -> EbnfSymbolParserToken.with(character.value(), character.text()))
                         .setToString(name)
                         .castTC();
     }
@@ -214,7 +214,7 @@ final class EbnfGrammarParser implements Parser<EbnfGrammarParserToken, EbnfPars
                 .required(LETTER)
                 .required(CHARACTER.repeating())
                 .build()
-                .transform((sequence, context) -> new EbnfIdentifierParserToken(string(sequence), sequence.text()))
+                .transform((sequence, context) -> EbnfIdentifierParserToken.with(string(sequence), sequence.text()))
                 .setToString("identifier")
                 .castC();
     };
@@ -250,7 +250,7 @@ final class EbnfGrammarParser implements Parser<EbnfGrammarParserToken, EbnfPars
 
     private static EbnfTerminalParserToken terminal(final SequenceParserToken token, final EbnfParserContext context) {
         final String quotedText = string(token);
-        return new EbnfTerminalParserToken(quotedText.substring(1, quotedText.length()-1),
+        return EbnfTerminalParserToken.with(quotedText.substring(1, quotedText.length()-1),
                 token.text());
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserToken.java
@@ -25,6 +25,7 @@ import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A grammar holds all the rules and is the root of the graph.
@@ -64,6 +65,10 @@ public final class EbnfGrammarParserToken extends EbnfParserToken {
     private final List<EbnfRuleParserToken> rules;
 
     private final Map<EbnfIdentifierParserToken, Parser<?, ?>> identifierToParser;
+
+    public Optional<EbnfParserToken> withoutCommentsSymbolsOrWhitespace(){
+        return Optional.of(this);
+    }
 
     @Override
     public boolean isAlternative() {

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserToken.java
@@ -16,7 +16,6 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
-import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 
 import java.util.List;
@@ -29,11 +28,12 @@ public final class EbnfGroupParserToken extends EbnfParentParserToken {
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfGroupParserToken.class);
 
     static EbnfGroupParserToken with(final List<EbnfParserToken> tokens, final String text) {
-        return new EbnfGroupParserToken(copyAndCheckTokens(tokens), checkText(text));
+        return new EbnfGroupParserToken(copyAndCheckTokens(tokens), checkText(text), WITHOUT_COMPUTE_REQUIRED);
     }
 
-    EbnfGroupParserToken(final List<EbnfParserToken> tokens, final String text) {
-        super(tokens, text);
+    private EbnfGroupParserToken(final List<EbnfParserToken> tokens, final String text, final boolean computeWithout) {
+        super(tokens, text, computeWithout);
+        this.checkOnlyOneToken();
     }
 
     @Override
@@ -43,7 +43,12 @@ public final class EbnfGroupParserToken extends EbnfParentParserToken {
 
     @Override
     EbnfGroupParserToken replaceText(final String text) {
-        return new EbnfGroupParserToken(this.value(), text);
+        return new EbnfGroupParserToken(this.value(), text, WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    @Override
+    EbnfGroupParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+        return new EbnfGroupParserToken(tokens, this.text(), WITHOUT_USE_THIS);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserToken.java
@@ -19,6 +19,8 @@ package walkingkooka.text.cursor.parser.ebnf;
 import walkingkooka.naming.Name;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 
+import java.util.Optional;
+
 /**
  * Holds the text for an identifier. Identifiers may appear on the left of a definition or as a reference to another rule definition.
  */
@@ -36,7 +38,7 @@ public final class EbnfIdentifierParserToken extends EbnfLeafParserToken<String>
         return new EbnfIdentifierParserToken(value, text);
     }
 
-    EbnfIdentifierParserToken(final String value, final String text){
+    private EbnfIdentifierParserToken(final String value, final String text){
         super(value, text);
     }
 
@@ -48,6 +50,11 @@ public final class EbnfIdentifierParserToken extends EbnfLeafParserToken<String>
     @Override
     EbnfIdentifierParserToken replaceText(final String text) {
         return new EbnfIdentifierParserToken(this.value, text);
+    }
+
+    @Override
+    public Optional<EbnfParserToken> withoutCommentsSymbolsOrWhitespace(){
+        return Optional.of(this);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserToken.java
@@ -28,11 +28,12 @@ public final class EbnfOptionalParserToken extends EbnfParentParserToken {
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfOptionalParserToken.class);
 
     static EbnfOptionalParserToken with(final List<EbnfParserToken> tokens, final String text) {
-        return new EbnfOptionalParserToken(copyAndCheckTokens(tokens), checkText(text));
+        return new EbnfOptionalParserToken(copyAndCheckTokens(tokens), checkText(text), WITHOUT_COMPUTE_REQUIRED);
     }
 
-    EbnfOptionalParserToken(final List<EbnfParserToken> tokens, final String text) {
-        super(tokens, text);
+    private EbnfOptionalParserToken(final List<EbnfParserToken> tokens, final String text, final boolean computeWithout) {
+        super(tokens, text, computeWithout);
+        this.checkOnlyOneToken();
     }
 
     @Override
@@ -42,7 +43,12 @@ public final class EbnfOptionalParserToken extends EbnfParentParserToken {
 
     @Override
     EbnfOptionalParserToken replaceText(final String text) {
-        return new EbnfOptionalParserToken(this.value(), text);
+        return new EbnfOptionalParserToken(this.value(), text, WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    @Override
+    EbnfOptionalParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+        return new EbnfOptionalParserToken(tokens, this.text(), WITHOUT_USE_THIS);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserToken.java
@@ -24,6 +24,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Represents a token within the grammar.
@@ -76,7 +77,7 @@ public abstract class EbnfParserToken implements ParserToken {
      * {@see EbnfOptionalParserToken}
      */
     public static EbnfOptionalParserToken optional(final List<EbnfParserToken> tokens, final String text) {
-        return new EbnfOptionalParserToken(tokens, text);
+        return EbnfOptionalParserToken.with(tokens, text);
     }
     
     /**
@@ -160,6 +161,12 @@ public abstract class EbnfParserToken implements ParserToken {
     }
 
     abstract EbnfParserToken replaceText(final String text);
+
+    /**
+     * Sub classes must override. Not all types of token support this operation, eg this doesnt make sense
+     * given a {@link EbnfCommentParserToken} will return empty.
+     */
+    abstract public Optional<EbnfParserToken> withoutCommentsSymbolsOrWhitespace();
 
     /**
      * Only alternative tokens return true

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatedParserToken.java
@@ -28,11 +28,12 @@ public final class EbnfRepeatedParserToken extends EbnfParentParserToken {
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfRepeatedParserToken.class);
 
     static EbnfRepeatedParserToken with(final List<EbnfParserToken> tokens, final String text) {
-        return new EbnfRepeatedParserToken(copyAndCheckTokens(tokens), checkText(text));
+        return new EbnfRepeatedParserToken(copyAndCheckTokens(tokens), checkText(text), WITHOUT_COMPUTE_REQUIRED);
     }
 
-    EbnfRepeatedParserToken(final List<EbnfParserToken> tokens, final String text) {
-        super(tokens, text);
+    private EbnfRepeatedParserToken(final List<EbnfParserToken> tokens, final String text, final boolean computeWithout) {
+        super(tokens, text, computeWithout);
+        this.checkOnlyOneToken();
     }
 
     @Override
@@ -42,7 +43,12 @@ public final class EbnfRepeatedParserToken extends EbnfParentParserToken {
 
     @Override
     EbnfRepeatedParserToken replaceText(final String text) {
-        return new EbnfRepeatedParserToken(this.value(), text);
+        return new EbnfRepeatedParserToken(this.value(), text, WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    @Override
+    EbnfRepeatedParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+        return new EbnfRepeatedParserToken(tokens, this.text(), WITHOUT_USE_THIS);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserToken.java
@@ -51,11 +51,11 @@ public final class EbnfRuleParserToken extends EbnfParentParserToken {
                 token);
     }
 
-    EbnfRuleParserToken(final List<EbnfParserToken> tokens,
+    private EbnfRuleParserToken(final List<EbnfParserToken> tokens,
                         final String text,
                         final EbnfIdentifierParserToken identifier,
                         final EbnfParserToken token) {
-        super(tokens, text);
+        super(tokens, text, WITHOUT_USE_THIS);
         this.identifier = identifier;
         this.token = token;
     }
@@ -81,6 +81,11 @@ public final class EbnfRuleParserToken extends EbnfParentParserToken {
     }
 
     private final EbnfParserToken token;
+
+    @Override
+    EbnfRuleParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+        return with(tokens, this.text());
+    }
 
     @Override
     public boolean isAlternative() {

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfSymbolParserToken.java
@@ -18,6 +18,8 @@ package walkingkooka.text.cursor.parser.ebnf;
 
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 
+import java.util.Optional;
+
 /**
  * Holds any of the symbols that separate actual tokens, such as the parens around a grouping.
  */
@@ -29,7 +31,7 @@ final public class EbnfSymbolParserToken extends EbnfLeafParserToken<Character> 
         return new EbnfSymbolParserToken(symbol, checkText(text));
     }
 
-    EbnfSymbolParserToken(final char symbol, final String text){
+    private EbnfSymbolParserToken(final char symbol, final String text){
         super(symbol, text);
     }
 
@@ -41,6 +43,11 @@ final public class EbnfSymbolParserToken extends EbnfLeafParserToken<Character> 
     @Override
     EbnfSymbolParserToken replaceText(final String text) {
         return new EbnfSymbolParserToken(this.value, text);
+    }
+
+    @Override
+    public Optional<EbnfParserToken> withoutCommentsSymbolsOrWhitespace(){
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserToken.java
@@ -18,6 +18,8 @@ package walkingkooka.text.cursor.parser.ebnf;
 
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 
+import java.util.Optional;
+
 /**
  * Holds the terminal token portion of the rhs of a rule.
  */
@@ -32,7 +34,7 @@ public final class EbnfTerminalParserToken extends EbnfLeafParserToken<String> {
         return new EbnfTerminalParserToken(value, text);
     }
 
-    EbnfTerminalParserToken(final String value, final String text){
+    private EbnfTerminalParserToken(final String value, final String text){
         super(value, text);
     }
 
@@ -44,6 +46,11 @@ public final class EbnfTerminalParserToken extends EbnfLeafParserToken<String> {
     @Override
     EbnfTerminalParserToken replaceText(final String text) {
         return new EbnfTerminalParserToken(this.value, text);
+    }
+
+    @Override
+    public Optional<EbnfParserToken> withoutCommentsSymbolsOrWhitespace(){
+        return Optional.of(this);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfWhitespaceParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfWhitespaceParserToken.java
@@ -19,6 +19,8 @@ package walkingkooka.text.cursor.parser.ebnf;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 
+import java.util.Optional;
+
 /**
  * Holds the combination of whitespace or comments.
  */
@@ -33,7 +35,7 @@ public final class EbnfWhitespaceParserToken extends EbnfLeafParserToken<String>
         return new EbnfWhitespaceParserToken(value, text);
     }
 
-    EbnfWhitespaceParserToken(final String value, final String text){
+    private EbnfWhitespaceParserToken(final String value, final String text){
         super(value, text);
     }
 
@@ -45,6 +47,11 @@ public final class EbnfWhitespaceParserToken extends EbnfLeafParserToken<String>
     @Override
     EbnfWhitespaceParserToken replaceText(final String text) {
         return new EbnfWhitespaceParserToken(this.value, text);
+    }
+
+    @Override
+    public Optional<EbnfParserToken> withoutCommentsSymbolsOrWhitespace(){
+        return Optional.empty();
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeConcatenationParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeConcatenationParentParserTokenTestCase.java
@@ -16,14 +16,42 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
 import walkingkooka.collect.list.Lists;
+
+import java.util.List;
+
+import static org.junit.Assert.assertNotSame;
 
 public abstract class EbnfAlternativeConcatenationParentParserTokenTestCase<T extends EbnfParentParserToken> extends EbnfParentParserTokenTestCase2<T> {
 
+    @Test(expected = IllegalArgumentException.class)
+    public final void testOnlyOneTokenIgnoringCommentsSymbolsWhitespaceFails() {
+        this.createToken(this.text(), this.identifier("first"), this.comment("(*comment-2*)"));
+    }
+
+    @Test
+    public void testWithoutCommentsSymbolsWhitespace() {
+        final EbnfParserToken identifier1 = this.identifier("identifier1");
+        final EbnfParserToken comment2 = this.comment("(*comment2*)");
+        final EbnfParserToken identifier3 = this.identifier("identifier3");
+
+        final T token = this.createToken(this.text(), identifier1, comment2, identifier3);
+        assertEquals("value", Lists.of(identifier1, comment2, identifier3), token.value());
+
+        final T without = token.withoutCommentsSymbolsOrWhitespace().get().cast();
+        assertNotSame(token, without);
+        assertEquals("value", Lists.of(identifier1, identifier3), without.value());
+    }
+
+    @Override
+    final List<EbnfParserToken> tokens() {
+        return Lists.of(this.identifier("identifier-1"), this.identifier("identifier-2"));
+    }
+
     @Override
     protected T createDifferentToken() {
-        return this.createToken("(*comment-3*)" + separatorChar() + "(*comment-4*)", Lists.of(this.comment("(*comment-3*)"), this.comment("(*comment-4*)"))
-        );
+        return this.createToken("diff-1" + separatorChar() + "diff-2", this.identifier("diff-1"), this.identifier("diff-2"));
     }
 
     abstract char separatorChar();

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupOptionalRepeatParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupOptionalRepeatParentParserTokenTestCase.java
@@ -22,6 +22,8 @@ import walkingkooka.collect.list.Lists;
 
 import java.util.List;
 
+import static org.junit.Assert.assertNotSame;
+
 public abstract class EbnfGroupOptionalRepeatParentParserTokenTestCase<T extends EbnfParentParserToken> extends EbnfParentParserTokenTestCase2<T> {
 
     @Test(expected = NullPointerException.class)
@@ -29,15 +31,38 @@ public abstract class EbnfGroupOptionalRepeatParentParserTokenTestCase<T extends
         this.createToken(this.text(), Cast.<List<EbnfParserToken>>to(null));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public final void testTooManyTokensIgnoringCommentsSymbolsWhitespaceFails() {
+        this.createToken(this.text(), this.identifier("identifier-1"), this.comment("(*comment-2*)"), this.identifier("identifier-3"));
+    }
+
+    @Test
+    public void testWithoutCommentsSymbolsWhitespace() {
+        final EbnfParserToken identifier1 = this.identifier("identifier1");
+        final EbnfParserToken comment2 = this.comment("(*comment2*)");
+
+        final T token = this.createToken(this.text(), identifier1, comment2);
+        assertEquals("value", Lists.of(identifier1, comment2), token.value());
+
+        final T without = token.withoutCommentsSymbolsOrWhitespace().get().cast();
+        assertNotSame(token, without);
+        assertEquals("value", Lists.of(identifier1), without.value());
+    }
+
+
+    @Override
+    final List<EbnfParserToken> tokens() {
+        return Lists.of(this.identifier("identifier-1"));
+    }
+
     @Override
     protected T createDifferentToken() {
-        return this.createToken(this.openChar() + "(*comment-3*)(*comment-4*)" + this.closeChar(), Lists.of(this.comment("(*comment-3*)"), this.comment("(*comment-4*)"))
-        );
+        return this.createToken(this.openChar() + "different" + this.closeChar(), this.identifier("different"));
     }
 
     @Override
     final String text() {
-        return this.openChar() + "(*comment-1*)" + this.closeChar();
+        return this.openChar() + "identifier1" + this.closeChar();
     }
 
     abstract char openChar();

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserTest.java
@@ -33,7 +33,7 @@ public final class EbnfIdentifierParserTest extends EbnfParserTestCase3<EbnfIden
 
     @Override
     EbnfIdentifierParserToken token(final String text) {
-        return new EbnfIdentifierParserToken(
+        return EbnfIdentifierParserToken.with(
                 this.text(),
                 text);
     }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase.java
@@ -44,6 +44,19 @@ public abstract class EbnfParentParserTokenTestCase<T extends EbnfParentParserTo
         assertSame("tokens not copied", tokens, token.value());
     }
 
+    @Test
+    public void testWithoutCommentsSymbolsOrWhitespaceCached() {
+        final T token = this.createToken();
+        assertSame(token.withoutCommentsSymbolsOrWhitespace(), token.withoutCommentsSymbolsOrWhitespace());
+        assertSame(token.withoutCommentsSymbolsOrWhitespace().get().withoutCommentsSymbolsOrWhitespace(), token.withoutCommentsSymbolsOrWhitespace().get().withoutCommentsSymbolsOrWhitespace());
+    }
+
+    @Test
+    public void testWithoutCommentsSymbolsOrWhitespaceDoubleSame() {
+        final T token = this.createToken();
+        assertSame(token, token.withoutCommentsSymbolsOrWhitespace().get());
+    }
+
     @Override
     final T createToken(final String text) {
         return this.createToken(text, this.tokens());
@@ -59,5 +72,13 @@ public abstract class EbnfParentParserTokenTestCase<T extends EbnfParentParserTo
 
     final EbnfCommentParserToken comment(final String text) {
         return EbnfParserToken.comment(text, text);
+    }
+
+    final EbnfIdentifierParserToken identifier(final String text) {
+        return EbnfParserToken.identifier(text, text);
+    }
+
+    final EbnfWhitespaceParserToken whitespace(final String text) {
+        return EbnfParserToken.whitespace(text, text);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase2.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase2.java
@@ -16,14 +16,35 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 
 import java.util.List;
 
 public abstract class EbnfParentParserTokenTestCase2<T extends EbnfParentParserToken> extends EbnfParentParserTokenTestCase<T> {
 
-    @Override
-    final List<EbnfParserToken> tokens() {
-        return Lists.of(this.comment("(*comment-1*)"), this.comment("(*comment-2*)"));
+    @Test(expected = IllegalArgumentException.class)
+    public final void testOnlyCommentsFails() {
+        this.createToken(this.text(), this.comment("(*comment-1*)"), this.comment("(*comment-2*)"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public final void testOnlySymbolsFails() {
+        this.createToken(this.text(), symbol('a'), symbol('z'));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public final void testOnlyWhitespaceFails() {
+        this.createToken(this.text(), this.whitespace("   "), this.whitespace(" "));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public final void testOnlyCommentsSymbolsWhitespaceFails() {
+        this.createToken(this.text(), this.comment("(*comment-1*)"), symbol('2'), this.whitespace("   "));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public final void testOnlyCommentWhitespaceFails() {
+        this.createToken(this.text(), this.whitespace("   "), this.whitespace(" "));
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRhsParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRhsParserTest.java
@@ -33,7 +33,7 @@ public final class EbnfRhsParserTest extends EbnfParserTestCase2<EbnfParserToken
 
     @Override
     EbnfParserToken token(final String text) {
-        return new EbnfIdentifierParserToken(
+        return EbnfIdentifierParserToken.with(
                 this.text(),
                 text);
     }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTest.java
@@ -173,9 +173,9 @@ public final class EbnfRuleParserTest extends EbnfParserTestCase2<EbnfRuleParser
     @Override
     EbnfRuleParserToken token(final String text) {
         return rule(text,
-                new EbnfIdentifierParserToken(IDENTIFIER1, IDENTIFIER1),
+                EbnfParserToken.identifier(IDENTIFIER1, IDENTIFIER1),
                 assignmentToken(),
-                new EbnfTerminalParserToken(TERMINAL1, TERMINAL1_TEXT),
+                EbnfParserToken.terminal(TERMINAL1, TERMINAL1_TEXT),
                 terminatorToken());
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTokenTest.java
@@ -44,6 +44,12 @@ public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfR
         this.createToken(this.text(), identifier(), assignment(), terminator());
     }
 
+    @Test
+    public void testWithoutCommentsSymbolsOrWhitespace() {
+        final EbnfRuleParserToken token = this.createToken();
+        assertSame(token, token.withoutCommentsSymbolsOrWhitespace().get());
+    }
+
     @Override
     protected EbnfRuleParserToken createDifferentToken() {
         return this.createToken("xyz=qrs;",
@@ -66,10 +72,6 @@ public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfR
 
     private EbnfIdentifierParserToken identifier() {
         return identifier("abc");
-    }
-
-    private EbnfIdentifierParserToken identifier(final String text) {
-        return EbnfParserToken.identifier(text, text);
     }
 
     private EbnfTerminalParserToken terminal() {

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserTest.java
@@ -32,7 +32,7 @@ public final class EbnfTerminalParserTest extends EbnfParserTestCase3<EbnfTermin
         final String text = "hello";
         final String quoted = singleQuote(text);
 
-        this.parseAndCheck(quoted, new EbnfTerminalParserToken(text, quoted), quoted);
+        this.parseAndCheck(quoted, EbnfTerminalParserToken.with(text, quoted), quoted);
     }
 
     @Test
@@ -40,7 +40,7 @@ public final class EbnfTerminalParserTest extends EbnfParserTestCase3<EbnfTermin
         final String text = "hello";
         final String quoted = doubleQuote(text);
 
-        this.parseAndCheck(quoted, new EbnfTerminalParserToken(text, quoted), quoted);
+        this.parseAndCheck(quoted, EbnfTerminalParserToken.with(text, quoted), quoted);
     }
 
     private static String singleQuote(final String text) {
@@ -64,7 +64,7 @@ public final class EbnfTerminalParserTest extends EbnfParserTestCase3<EbnfTermin
     @Override
     EbnfTerminalParserToken token(final String text) {
         final String quotedText = this.text();
-        return new EbnfTerminalParserToken(
+        return EbnfTerminalParserToken.with(
                 quotedText.substring(1, quotedText.length() -1),
                 text);
     }


### PR DESCRIPTION
…ual token count check in factory.

- all types now check during construction that they have the right count of non comment/symbol/whitespace tokens.
- also made all EbnfParserToken ctors private and force everything to use factory methods called "with".