### PR TITLE
Introduced ParserTokenVisitor and EbnfParserTokenVisitor

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/CharacterParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/CharacterParserToken.java
@@ -53,6 +53,11 @@ public final class CharacterParserToken extends ParserTemplateToken<Character> {
     }
 
     @Override
+    public void accept(final ParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
+
+    @Override
     boolean canBeEqual(final Object other) {
         return other instanceof CharacterParserToken;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/DecimalParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DecimalParserToken.java
@@ -66,6 +66,11 @@ public final class DecimalParserToken extends ParserTemplateToken<BigDecimal> im
                 this :
                 new DecimalParserToken(value.negate(), this.text());
     }
+
+    @Override
+    public void accept(final ParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
     
     @Override
     boolean canBeEqual(final Object other) {

--- a/src/main/java/walkingkooka/text/cursor/parser/DoubleQuotedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DoubleQuotedParserToken.java
@@ -62,6 +62,11 @@ public final class DoubleQuotedParserToken extends QuotedParserToken {
     }
 
     @Override
+    public void accept(final ParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
+
+    @Override
     boolean canBeEqual(final Object other) {
         return other instanceof DoubleQuotedParserToken;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/FakeParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/FakeParserTokenVisitor.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import walkingkooka.test.Fake;
+import walkingkooka.tree.visit.Visiting;
+
+public class FakeParserTokenVisitor extends ParserTokenVisitor implements Fake {
+
+    @Override
+    protected Visiting startVisit(final ParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final ParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final CharacterParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final DecimalParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final DoubleQuotedParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final MissingParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final NumberParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Visiting startVisit(final RepeatedParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final RepeatedParserToken token) {
+        super.endVisit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SequenceParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final SequenceParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final SingleQuotedParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final SignParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final StringParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/MissingParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/MissingParserToken.java
@@ -59,6 +59,11 @@ public final class MissingParserToken extends ParserTemplateToken<ParserTokenNod
     }
 
     @Override
+    public void accept(final ParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
+
+    @Override
     boolean canBeEqual(final Object other) {
         return other instanceof MissingParserToken;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/NumberParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/NumberParserToken.java
@@ -66,7 +66,12 @@ public final class NumberParserToken extends ParserTemplateToken<BigInteger> imp
                 this :
                 new NumberParserToken(value.negate(), this.text());
     }
-    
+
+    @Override
+    public void accept(final ParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
+
     @Override
     boolean canBeEqual(final Object other) {
         return other instanceof NumberParserToken;

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTemplateToken2.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTemplateToken2.java
@@ -33,6 +33,12 @@ abstract class ParserTemplateToken2<T extends ParserToken> extends ParserTemplat
         super(value, text);
     }
 
+    final void acceptValues(final ParserTokenVisitor visitor){
+        for(ParserToken token: this.value()){
+            visitor.accept(token);
+        }
+    }
+
     /**
      * Takes the tokens of something that implements {@link SupportsFlat} and flattens them so no tokens that remain are also flattenable.
      */

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
@@ -50,4 +50,10 @@ public interface ParserToken {
     default boolean isMissing() {
        return false;
     }
+
+    /**
+     * Called by the visitor responsible for this group of tokens, which typically resides in the same package.
+     * The token must then call the appropriate visit or start/end visit and also visit any child token values as appropriate.
+     */
+    void accept(final ParserTokenVisitor visitor);
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokenTestCase.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokenTestCase.java
@@ -18,9 +18,12 @@
 package walkingkooka.text.cursor.parser;
 
 import org.junit.Test;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.test.PublicClassTestCase;
+import walkingkooka.tree.visit.Visiting;
 
 import java.lang.reflect.Field;
+import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
 
@@ -59,6 +62,32 @@ public abstract class ParserTokenTestCase<T extends ParserToken> extends PublicC
 
         final ParserToken token3 = token2.setText(token.text());
         assertEquals("after setting original text tokens must be equal", token, token3);
+    }
+
+    @Test
+    public final void testAcceptStartParserTokenSkip() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final T token = this.createToken();
+
+        new FakeParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("1");
+                visited.add(t);
+                return Visiting.SKIP;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+                visited.add(t);
+            }
+        }.accept(token);
+        assertEquals("12", b.toString());
+        assertEquals("visited tokens", Lists.of(token, token), visited);
     }
 
     @Test

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokenVisitor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import walkingkooka.tree.visit.Visiting;
+import walkingkooka.tree.visit.Visitor;
+
+import java.util.List;
+import java.util.Objects;
+
+public abstract class ParserTokenVisitor extends Visitor<ParserToken> {
+
+    // ParserToken.......................................................................
+
+    public final void accept(final ParserToken token) {
+        Objects.requireNonNull(token, "token");
+
+        if(Visiting.CONTINUE == this.startVisit(token)) {
+            token.accept(this);
+        }
+        this.endVisit(token);
+    }
+
+    protected Visiting startVisit(final ParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final ParserToken token) {
+        // nop
+    }
+
+    protected void visit(final CharacterParserToken token) {
+        // nop
+    }
+
+    protected void visit(final DecimalParserToken token) {
+        // nop
+    }
+
+    protected void visit(final DoubleQuotedParserToken token) {
+        // nop
+    }
+
+    protected void visit(final MissingParserToken token) {
+        // nop
+    }
+
+    protected void visit(final NumberParserToken token) {
+        // nop
+    }
+
+    protected Visiting startVisit(final RepeatedParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final RepeatedParserToken token) {
+        // nop
+    }
+
+    protected Visiting startVisit(final SequenceParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final SequenceParserToken token) {
+        // nop
+    }
+
+    protected void visit(final SingleQuotedParserToken token) {
+        // nop
+    }
+
+    protected void visit(final SignParserToken token) {
+        // nop
+    }
+
+    protected void visit(final StringParserToken token) {
+        // nop
+    }
+    
+    /**
+     * Useful to dispatch and visit all the child nodes of a parent.
+     */
+    protected final void acceptTokens(final List<? extends ParserToken> tokens) {
+        tokens.stream().forEach( t -> this.accept(t));
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/RepeatedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/RepeatedParserToken.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser;
 
 import walkingkooka.Cast;
+import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
 import java.util.Objects;
@@ -62,6 +63,14 @@ public final class RepeatedParserToken<T extends ParserToken> extends ParserTemp
     @Override
     public ParserTokenNodeName name() {
         return NAME;
+    }
+
+    @Override
+    public void accept(final ParserTokenVisitor visitor){
+        if(Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/SequenceParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SequenceParserToken.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser;
 
 import walkingkooka.Cast;
+import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
 import java.util.Objects;
@@ -62,6 +63,14 @@ public final class SequenceParserToken extends ParserTemplateToken2<ParserToken>
     @Override
     public ParserTokenNodeName name() {
         return NAME;
+    }
+
+    @Override
+    public void accept(final ParserTokenVisitor visitor){
+        if(Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/SignParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SignParserToken.java
@@ -55,6 +55,11 @@ public final class SignParserToken extends ParserTemplateToken<Boolean> {
     }
 
     @Override
+    public void accept(final ParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
+
+    @Override
     boolean canBeEqual(final Object other) {
         return other instanceof SignParserToken;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/SingleQuotedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SingleQuotedParserToken.java
@@ -62,6 +62,11 @@ public final class SingleQuotedParserToken extends QuotedParserToken {
     }
 
     @Override
+    public void accept(final ParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
+
+    @Override
     boolean canBeEqual(final Object other) {
         return other instanceof SingleQuotedParserToken;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/StringParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/StringParserToken.java
@@ -54,6 +54,11 @@ public final class StringParserToken extends ParserTemplateToken<String> {
     }
 
     @Override
+    public void accept(final ParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
+
+    @Override
     boolean canBeEqual(final Object other) {
         return other instanceof StringParserToken;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserToken.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
 
@@ -67,6 +68,11 @@ final public class EbnfAlternativeParserToken extends EbnfParentParserToken {
     }
 
     @Override
+    public boolean isGrammar() {
+        return false;
+    }
+
+    @Override
     public boolean isGroup() {
         return false;
     }
@@ -89,6 +95,14 @@ final public class EbnfAlternativeParserToken extends EbnfParentParserToken {
     @Override
     public boolean isRule() {
         return false;
+    }
+
+    @Override
+    public void accept(final EbnfParserTokenVisitor visitor) {
+        if(Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfCommentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfCommentParserToken.java
@@ -79,6 +79,11 @@ public final class EbnfCommentParserToken extends EbnfLeafParserToken<String> {
     }
 
     @Override
+    public void accept(final EbnfParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
+
+    @Override
     boolean canBeEqual(final Object other) {
         return other instanceof EbnfCommentParserToken;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserToken.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
 
@@ -67,6 +68,11 @@ public final class EbnfConcatenationParserToken extends EbnfParentParserToken {
     }
 
     @Override
+    public boolean isGrammar() {
+        return false;
+    }
+
+    @Override
     public boolean isGroup() {
         return false;
     }
@@ -89,6 +95,14 @@ public final class EbnfConcatenationParserToken extends EbnfParentParserToken {
     @Override
     public boolean isRule() {
         return false;
+    }
+
+    @Override
+    public void accept(final EbnfParserTokenVisitor visitor) {
+        if(Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserToken.java
@@ -18,6 +18,7 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
 
@@ -80,6 +81,11 @@ public final class EbnfExceptionParserToken extends EbnfParentParserToken {
     }
 
     @Override
+    public boolean isGrammar() {
+        return false;
+    }
+
+    @Override
     public boolean isGroup() {
         return false;
     }
@@ -102,6 +108,14 @@ public final class EbnfExceptionParserToken extends EbnfParentParserToken {
     @Override
     public boolean isRule() {
         return false;
+    }
+
+    @Override
+    public void accept(final EbnfParserTokenVisitor visitor) {
+        if(Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParser.java
@@ -465,7 +465,7 @@ final class EbnfGrammarParser implements Parser<EbnfGrammarParserToken, EbnfPars
      */
     final static Parser<EbnfGrammarParserToken, EbnfParserContext> GRAMMAR = RULE.repeating()
             .transform((repeated, context) -> {
-                return new EbnfGrammarParserToken(
+                return EbnfGrammarParserToken.with(
                         Cast.to(repeated.value()), // list of rules
                         repeated.text());
             })

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserToken.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
 
@@ -67,6 +68,11 @@ public final class EbnfGroupParserToken extends EbnfParentParserToken {
     }
 
     @Override
+    public boolean isGrammar() {
+        return false;
+    }
+
+    @Override
     public boolean isGroup() {
         return true;
     }
@@ -89,6 +95,14 @@ public final class EbnfGroupParserToken extends EbnfParentParserToken {
     @Override
     public boolean isRule() {
         return false;
+    }
+
+    @Override
+    public void accept(final EbnfParserTokenVisitor visitor) {
+        if(Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserToken.java
@@ -83,6 +83,11 @@ public final class EbnfIdentifierParserToken extends EbnfLeafParserToken<String>
     }
 
     @Override
+    public void accept(final EbnfParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
+
+    @Override
     boolean canBeEqual(final Object other) {
         return other instanceof EbnfIdentifierParserToken;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfLeafParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfLeafParserToken.java
@@ -85,6 +85,8 @@ abstract class EbnfLeafParserToken<T> extends EbnfParserToken implements Value<T
         return false;
     }
 
+    abstract public void accept(final EbnfParserTokenVisitor visitor);
+
     @Override
     final boolean equals1(final EbnfParserToken other) {
         return this.equals2(other.cast());

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserToken.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
 
@@ -67,6 +68,11 @@ public final class EbnfOptionalParserToken extends EbnfParentParserToken {
     }
 
     @Override
+    public boolean isGrammar() {
+        return false;
+    }
+
+    @Override
     public boolean isGroup() {
         return false;
     }
@@ -89,6 +95,14 @@ public final class EbnfOptionalParserToken extends EbnfParentParserToken {
     @Override
     public boolean isRule() {
         return false;
+    }
+
+    @Override
+    public void accept(final EbnfParserTokenVisitor visitor) {
+        if(Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserToken.java
@@ -73,6 +73,13 @@ abstract class EbnfParentParserToken extends EbnfParserToken implements Value<Li
         }
     }
 
+    final void checkAtLeastOneRule() {
+        final int count = this.tokenCount();
+        if(count <1) {
+            throw new IllegalArgumentException("Expected at least one rule(ignoring comments, symbols and whitespace) but was " + count + "=" + this.text());
+        }
+    }
+
     private int tokenCount() {
         final EbnfParentParserToken without = this.without.get().cast();
         return without.value().size();
@@ -80,11 +87,6 @@ abstract class EbnfParentParserToken extends EbnfParserToken implements Value<Li
 
     @Override
     public final boolean isComment() {
-        return false;
-    }
-
-    @Override
-    public final boolean isGrammar() {
         return false;
     }
 
@@ -129,6 +131,12 @@ abstract class EbnfParentParserToken extends EbnfParserToken implements Value<Li
      * Factory that creates a new {@link EbnfParentParserToken} with the same text but new tokens.
      */
     abstract EbnfParentParserToken replaceTokens(final List<EbnfParserToken> tokens);
+
+    final void acceptValues(final EbnfParserTokenVisitor visitor){
+        for(EbnfParserToken token: this.value()){
+            visitor.accept(token);
+        }
+    }
 
     @Override
     final boolean equals1(final EbnfParserToken other) {

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserToken.java
@@ -21,6 +21,8 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.text.Whitespace;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenVisitor;
+import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
 import java.util.Objects;
@@ -62,8 +64,8 @@ public abstract class EbnfParserToken implements ParserToken {
     /**
      * {@see EbnfGrammarParserToken}
      */
-    public static EbnfGrammarParserToken grammar(final List<EbnfRuleParserToken> rules, final String text) {
-        return EbnfGrammarParserToken.with(rules, text);
+    public static EbnfGrammarParserToken grammar(final List<EbnfParserToken> tokens, final String text) {
+        return EbnfGrammarParserToken.with(tokens, text);
     }
 
     /**
@@ -258,6 +260,18 @@ public abstract class EbnfParserToken implements ParserToken {
     final <T extends EbnfParserToken> T cast() {
         return Cast.to(this);
     }
+
+    public final void accept(final ParserTokenVisitor visitor) {
+        final EbnfParserTokenVisitor ebnfParserTokenVisitor = Cast.to(visitor);
+        final EbnfParserToken token = this;
+
+        if(Visiting.CONTINUE == ebnfParserTokenVisitor.startVisit(token)){
+            this.accept(EbnfParserTokenVisitor.class.cast(visitor));
+        }
+        ebnfParserTokenVisitor.endVisit(token);
+    }
+
+    abstract public void accept(final EbnfParserTokenVisitor visitor);
 
     // Object ...........................................................................................................
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTokenVisitor.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.Cast;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenVisitor;
+import walkingkooka.tree.visit.Visiting;
+
+public abstract class EbnfParserTokenVisitor extends ParserTokenVisitor {
+
+    // EbnfGrammarParserToken....................................................................................
+
+    protected Visiting startVisit(final EbnfGrammarParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final EbnfGrammarParserToken token) {
+        // nop
+    }
+
+    // EbnfParentParserTokens.........................................................................................
+
+    // EbnfAlternativeParserToken ....................................................................................
+
+    protected Visiting startVisit(final EbnfAlternativeParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final EbnfAlternativeParserToken token) {
+        // nop
+    }
+
+    // EbnfConcatenationParserToken....................................................................................
+
+    protected Visiting startVisit(final EbnfConcatenationParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final EbnfConcatenationParserToken token) {
+        // nop
+    }
+
+    // EbnfExceptionParserToken....................................................................................
+
+    protected Visiting startVisit(final EbnfExceptionParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final EbnfExceptionParserToken token) {
+        // nop
+    }
+
+    // EbnfGroupParserToken....................................................................................
+
+    protected Visiting startVisit(final EbnfGroupParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final EbnfGroupParserToken token) {
+        // nop
+    }
+
+    // EbnfOptionalParserToken....................................................................................
+
+    protected Visiting startVisit(final EbnfOptionalParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final EbnfOptionalParserToken token) {
+        // nop
+    }
+
+    // EbnfRangeParserToken....................................................................................
+
+    protected Visiting startVisit(final EbnfRangeParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final EbnfRangeParserToken token) {
+        // nop
+    }
+
+    // EbnfRepeatedParserToken....................................................................................
+
+    protected Visiting startVisit(final EbnfRepeatedParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final EbnfRepeatedParserToken token) {
+        // nop
+    }
+
+    // EbnfRuleParserToken....................................................................................
+
+    protected Visiting startVisit(final EbnfRuleParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final EbnfRuleParserToken token) {
+        // nop
+    }
+
+    // EbnfLeafParserToken ....................................................................................
+
+    final void acceptComment(final EbnfCommentParserToken token) {
+        if(Visiting.CONTINUE == this.startVisit(token)) {
+            this.visit(token);
+        }
+    }
+
+    protected void visit(final EbnfCommentParserToken token) {
+        // nop
+    }
+
+    final void acceptIdentifier(final EbnfIdentifierParserToken token) {
+        if(Visiting.CONTINUE == this.startVisit(token)) {
+            this.visit(token);
+        }
+    }
+
+    protected void visit(final EbnfIdentifierParserToken token) {
+        // nop
+    }
+
+
+    final void acceptSymbol(final EbnfSymbolParserToken token) {
+        if(Visiting.CONTINUE == this.startVisit(token)) {
+            this.visit(token);
+        }
+    }
+
+    protected void visit(final EbnfSymbolParserToken token) {
+        // nop
+    }
+
+    final void acceptTerminal(final EbnfTerminalParserToken token) {
+        if(Visiting.CONTINUE == this.startVisit(token)) {
+            this.visit(token);
+        }
+    }
+
+    protected void visit(final EbnfTerminalParserToken token) {
+        // nop
+    }
+
+    final void acceptWhitespace(final EbnfWhitespaceParserToken token) {
+        if(Visiting.CONTINUE == this.startVisit(token)) {
+            this.visit(token);
+        }
+    }
+
+    protected void visit(final EbnfWhitespaceParserToken token) {
+        // nop
+    }
+
+    // ParserToken.......................................................................
+
+    private void acceptParserToken(final ParserToken token) {
+        if(Visiting.CONTINUE == this.startVisit(token)) {
+            if(token instanceof EbnfParserToken) {
+                this.acceptEbnfParserToken(Cast.to(token));
+            }
+        }
+    }
+
+    protected Visiting startVisit(final ParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final ParserToken token) {
+        // nop
+    }
+
+    // EbnfParserToken.......................................................................
+
+    private void acceptEbnfParserToken(final EbnfParserToken token) {
+        if(Visiting.CONTINUE == this.startVisit(token)) {
+            token.accept(this);
+        }
+    }
+
+    protected Visiting startVisit(final EbnfParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final EbnfParserToken token) {
+        // nop
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserToken.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
 
@@ -103,6 +104,11 @@ final public class EbnfRangeParserToken extends EbnfParentParserToken {
     }
 
     @Override
+    public boolean isGrammar() {
+        return false;
+    }
+
+    @Override
     public boolean isGroup() {
         return false;
     }
@@ -125,6 +131,14 @@ final public class EbnfRangeParserToken extends EbnfParentParserToken {
     @Override
     public boolean isRule() {
         return false;
+    }
+
+    @Override
+    public void accept(final EbnfParserTokenVisitor visitor) {
+        if(Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatedParserToken.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
 
@@ -67,6 +68,11 @@ public final class EbnfRepeatedParserToken extends EbnfParentParserToken {
     }
 
     @Override
+    public boolean isGrammar() {
+        return false;
+    }
+
+    @Override
     public boolean isGroup() {
         return false;
     }
@@ -89,6 +95,14 @@ public final class EbnfRepeatedParserToken extends EbnfParentParserToken {
     @Override
     public boolean isRule() {
         return false;
+    }
+
+    @Override
+    public void accept(final EbnfParserTokenVisitor visitor) {
+        if(Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserToken.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
 
@@ -103,6 +104,11 @@ public final class EbnfRuleParserToken extends EbnfParentParserToken {
     }
 
     @Override
+    public boolean isGrammar() {
+        return false;
+    }
+
+    @Override
     public boolean isGroup() {
         return false;
     }
@@ -125,6 +131,14 @@ public final class EbnfRuleParserToken extends EbnfParentParserToken {
     @Override
     public boolean isRule() {
         return true;
+    }
+
+    @Override
+    public void accept(final EbnfParserTokenVisitor visitor) {
+        if(Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfSymbolParserToken.java
@@ -79,6 +79,11 @@ final public class EbnfSymbolParserToken extends EbnfLeafParserToken<String> {
     }
 
     @Override
+    public void accept(final EbnfParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
+
+    @Override
     boolean canBeEqual(final Object other) {
         return other instanceof EbnfSymbolParserToken;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserToken.java
@@ -79,6 +79,11 @@ public final class EbnfTerminalParserToken extends EbnfLeafParserToken<String> {
     }
 
     @Override
+    public void accept(final EbnfParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
+
+    @Override
     boolean canBeEqual(final Object other) {
         return other instanceof EbnfTerminalParserToken;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfWhitespaceParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfWhitespaceParserToken.java
@@ -80,6 +80,11 @@ public final class EbnfWhitespaceParserToken extends EbnfLeafParserToken<String>
     }
 
     @Override
+    public void accept(final EbnfParserTokenVisitor visitor){
+        visitor.visit(this);
+    }
+
+    @Override
     boolean canBeEqual(final Object other) {
         return other instanceof EbnfWhitespaceParserToken;
     }

--- a/src/main/java/walkingkooka/tree/visit/Visiting.java
+++ b/src/main/java/walkingkooka/tree/visit/Visiting.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.visit;
+
+/**
+ * Returned by visit methods for objects that are not leafs allowing the visitor to control whether any descendants are
+ * themselves visited.
+ */
+public enum Visiting {
+    CONTINUE,
+    SKIP;
+}

--- a/src/main/java/walkingkooka/tree/visit/Visitor.java
+++ b/src/main/java/walkingkooka/tree/visit/Visitor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.visit;
+
+/**
+ * A visitor for an object that has a graph or tree like structure, following the visitor pattern.
+ */
+public abstract class Visitor<T> {
+
+    abstract public void accept(T object);
+}

--- a/src/main/java/walkingkooka/tree/visit/VisitorTestCase.java
+++ b/src/main/java/walkingkooka/tree/visit/VisitorTestCase.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.visit;
+
+import org.junit.Test;
+import walkingkooka.test.ClassTestCase;
+
+abstract public class VisitorTestCase<V extends Visitor<T>, T>
+        extends
+        ClassTestCase<V> {
+
+    protected VisitorTestCase() {
+        super();
+    }
+
+    @Test
+    public final void testAcceptNullFails() {
+        this.createVisitor().accept(null);
+    }
+
+    abstract protected V createVisitor();
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/CharacterParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/CharacterParserTokenTest.java
@@ -17,12 +17,41 @@
 package walkingkooka.text.cursor.parser;
 
 import org.junit.Test;
+import walkingkooka.tree.visit.Visiting;
 
 public final class CharacterParserTokenTest extends ParserTokenTestCase<CharacterParserToken> {
 
     @Test(expected = NullPointerException.class)
     public void testWithNullTextFails() {
         CharacterParserToken.with('a', null);
+    }
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final CharacterParserToken token = this.createToken();
+
+        new FakeParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected void visit(final CharacterParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+            }
+        }.accept(token);
+        assertEquals("132", b.toString());
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/DecimalParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/DecimalParserTokenTest.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser;
 
 import org.junit.Test;
+import walkingkooka.tree.visit.Visiting;
 
 import java.math.BigDecimal;
 
@@ -30,6 +31,34 @@ public final class DecimalParserTokenTest extends ParserTokenTestCase<DecimalPar
     @Test(expected = NullPointerException.class)
     public void testWithNullTextFails() {
         DecimalParserToken.with(BigDecimal.ZERO, null);
+    }
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final DecimalParserToken token = this.createToken();
+
+        new FakeParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected void visit(final DecimalParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+            }
+        }.accept(token);
+        assertEquals("132", b.toString());
     }
     
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/DoubleQuotedParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/DoubleQuotedParserTokenTest.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser;
 
 import org.junit.Test;
+import walkingkooka.tree.visit.Visiting;
 
 public final class DoubleQuotedParserTokenTest extends ParserTokenTestCase<DoubleQuotedParserToken> {
 
@@ -38,6 +39,34 @@ public final class DoubleQuotedParserTokenTest extends ParserTokenTestCase<Doubl
     @Test(expected = IllegalArgumentException.class)
     public void testWithMissingEndQuoteFails() {
         DoubleQuotedParserToken.with("abc", "\"abc");
+    }
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final DoubleQuotedParserToken token = this.createToken();
+
+        new FakeParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected void visit(final DoubleQuotedParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+            }
+        }.accept(token);
+        assertEquals("132", b.toString());
     }
     
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/MissingParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/MissingParserTokenTest.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser;
 
 import org.junit.Test;
+import walkingkooka.tree.visit.Visiting;
 
 public final class MissingParserTokenTest extends ParserTokenTestCase<MissingParserToken> {
 
@@ -30,6 +31,34 @@ public final class MissingParserTokenTest extends ParserTokenTestCase<MissingPar
     @Test(expected = NullPointerException.class)
     public void testWithNullTextFails() {
         MissingParserToken.with(MISSING_NAME, null);
+    }
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final MissingParserToken token = this.createToken();
+
+        new FakeParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected void visit(final MissingParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+            }
+        }.accept(token);
+        assertEquals("132", b.toString());
     }
     
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/NumberParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/NumberParserTokenTest.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser;
 
 import org.junit.Test;
+import walkingkooka.tree.visit.Visiting;
 
 import java.math.BigInteger;
 
@@ -30,6 +31,34 @@ public final class NumberParserTokenTest extends ParserTokenTestCase<NumberParse
     @Test(expected = NullPointerException.class)
     public void testWithNullTextFails() {
         NumberParserToken.with(BigInteger.ZERO, null);
+    }
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final NumberParserToken token = this.createToken();
+
+        new FakeParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected void visit(final NumberParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+            }
+        }.accept(token);
+        assertEquals("132", b.toString());
     }
     
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/RepeatedParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/RepeatedParserTokenTest.java
@@ -18,8 +18,10 @@ package walkingkooka.text.cursor.parser;
 
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.tree.visit.Visiting;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertNotSame;
@@ -67,6 +69,96 @@ public final class RepeatedParserTokenTest extends ParserTokenTestCase<RepeatedP
         assertNotSame(parent, flat);
         assertEquals("values after flattening", Lists.of(STRING1, STRING2, STRING4, STRING5, STRING6), flat.value());
         this.checkText(flat,"a1b2d4e5f6");
+    }
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final StringParserToken string = this.string("abc");
+        final RepeatedParserToken token = this.repeated(string);
+
+        new FakeParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("1");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final RepeatedParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final RepeatedParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final StringParserToken t) {
+                b.append("5");
+                visited.add(t);
+            }
+        }.accept(token);
+        assertEquals("1315242", b.toString());
+        assertEquals("visited tokens", Lists.of(token, token, string, string, string, token, token), visited);
+    }
+
+    @Test
+    public void testAcceptSkip() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final StringParserToken string = this.string("abc");
+        final RepeatedParserToken token = this.repeated(string);
+
+        new FakeParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("1");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final RepeatedParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                visited.add(t);
+                return Visiting.SKIP;
+            }
+
+            @Override
+            protected void endVisit(final RepeatedParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+                visited.add(t);
+            }
+        }.accept(token);
+        assertEquals("1342", b.toString());
+        assertEquals("visited tokens", Lists.of(token, token, token, token), visited);
     }
     
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/SignParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SignParserTokenTest.java
@@ -19,12 +19,41 @@
 package walkingkooka.text.cursor.parser;
 
 import org.junit.Test;
+import walkingkooka.tree.visit.Visiting;
 
 public final class SignParserTokenTest extends ParserTokenTestCase<SignParserToken> {
 
     @Test(expected = NullPointerException.class)
     public void testWithNullTextFails() {
         SignParserToken.with(true, null);
+    }
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final SignParserToken token = this.createToken();
+
+        new FakeParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+            }
+
+            @Override
+            protected void visit(final SignParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+        }.accept(token);
+        assertEquals("123", b.toString());
     }
     
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/SingleQuotedParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SingleQuotedParserTokenTest.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser;
 
 import org.junit.Test;
+import walkingkooka.tree.visit.Visiting;
 
 public final class SingleQuotedParserTokenTest extends ParserTokenTestCase<SingleQuotedParserToken> {
 
@@ -38,6 +39,34 @@ public final class SingleQuotedParserTokenTest extends ParserTokenTestCase<Singl
     @Test(expected = IllegalArgumentException.class)
     public void testWithMissingEndQuoteFails() {
         SingleQuotedParserToken.with("abc", "'abc");
+    }
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final SingleQuotedParserToken token = this.createToken();
+
+        new FakeParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected void visit(final SingleQuotedParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+            }
+        }.accept(token);
+        assertEquals("132", b.toString());
     }
     
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/StringParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/StringParserTokenTest.java
@@ -17,6 +17,7 @@
 package walkingkooka.text.cursor.parser;
 
 import org.junit.Test;
+import walkingkooka.tree.visit.Visiting;
 
 public final class StringParserTokenTest extends ParserTokenTestCase<StringParserToken> {
 
@@ -28,6 +29,34 @@ public final class StringParserTokenTest extends ParserTokenTestCase<StringParse
     @Test(expected = NullPointerException.class)
     public void testWithNullTextFails() {
         StringParserToken.with("abc", null);
+    }
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final StringParserToken token = this.createToken();
+
+        new FakeParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected void visit(final StringParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+            }
+        }.accept(token);
+        assertEquals("132", b.toString());
     }
     
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeConcatenationParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeConcatenationParentParserTokenTestCase.java
@@ -27,13 +27,13 @@ public abstract class EbnfAlternativeConcatenationParentParserTokenTestCase<T ex
 
     @Test(expected = IllegalArgumentException.class)
     public final void testOnlyOneTokenIgnoringCommentsSymbolsWhitespaceFails() {
-        this.createToken(this.text(), this.identifier("first"), this.comment("(*comment-2*)"));
+        this.createToken(this.text(), this.identifier("first"), this.comment2());
     }
 
     @Test
     public void testWithoutCommentsSymbolsWhitespace() {
-        final EbnfParserToken identifier1 = this.identifier("identifier1");
-        final EbnfParserToken comment2 = this.comment("(*comment2*)");
+        final EbnfParserToken identifier1 = this.identifier1();
+        final EbnfParserToken comment2 = this.comment2();
         final EbnfParserToken identifier3 = this.identifier("identifier3");
 
         final T token = this.createToken(this.text(), identifier1, comment2, identifier3);
@@ -46,7 +46,7 @@ public abstract class EbnfAlternativeConcatenationParentParserTokenTestCase<T ex
 
     @Override
     final List<EbnfParserToken> tokens() {
-        return Lists.of(this.identifier("identifier-1"), this.identifier("identifier-2"));
+        return Lists.of(this.identifier1(), this.identifier2());
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserTokenTest.java
@@ -16,9 +16,80 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
 import java.util.List;
 
 public final class EbnfAlternativeParserTokenTest extends EbnfAlternativeConcatenationParentParserTokenTestCase<EbnfAlternativeParserToken> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final EbnfAlternativeParserToken alt = this.createToken();
+        final EbnfIdentifierParserToken identifier1 = this.identifier1();
+        final EbnfIdentifierParserToken identifier2 = this.identifier2();
+
+        new FakeEbnfParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("1");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                b.append("2");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfParserToken t) {
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfParserToken t) {
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfAlternativeParserToken t) {
+                assertSame(alt, t);
+                b.append("5");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfAlternativeParserToken t) {
+                assertSame(alt, t);
+                b.append("6");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final EbnfIdentifierParserToken t) {
+                b.append("7");
+                visited.add(t);
+            }
+        }.accept(alt);
+        assertEquals("1351374213742642", b.toString());
+        assertEquals("visited",
+                Lists.of(alt, alt, alt,
+                        identifier1, identifier1, identifier1, identifier1, identifier1,
+                        identifier2, identifier2, identifier2, identifier2, identifier2,
+                        alt, alt, alt),
+                visited);
+    }
 
     @Override
     EbnfAlternativeParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
@@ -27,7 +98,7 @@ public final class EbnfAlternativeParserTokenTest extends EbnfAlternativeConcate
 
     @Override
     String text() {
-        return "(*comment1*)|(*comment2*)";
+        return "identifier1|identifier2";
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfCommentParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfCommentParserTokenTest.java
@@ -16,8 +16,53 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
 public final class EbnfCommentParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfCommentParserToken, String> {
 
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final EbnfCommentParserToken token = this.createToken();
+
+        new FakeEbnfParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final EbnfCommentParserToken t) {
+                assertSame(token, t);
+                b.append("5");
+            }
+        }.accept(token);
+        assertEquals("13542", b.toString());
+    }
+    
     @Override
     String text() {
         return "(* comment *)";

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserTokenTest.java
@@ -16,10 +16,81 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
 import java.util.List;
 
 public final class EbnfConcatenationParserTokenTest extends EbnfAlternativeConcatenationParentParserTokenTestCase<EbnfConcatenationParserToken> {
 
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final EbnfConcatenationParserToken concat = this.createToken();
+        final EbnfIdentifierParserToken identifier1 = this.identifier1();
+        final EbnfIdentifierParserToken identifier2 = this.identifier2();
+
+        new FakeEbnfParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("1");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                b.append("2");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfParserToken t) {
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfParserToken t) {
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfConcatenationParserToken t) {
+                assertSame(concat, t);
+                b.append("5");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfConcatenationParserToken t) {
+                assertSame(concat, t);
+                b.append("6");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final EbnfIdentifierParserToken t) {
+                b.append("7");
+                visited.add(t);
+            }
+        }.accept(concat);
+        assertEquals("1351374213742642", b.toString());
+        assertEquals("visited",
+                Lists.of(concat, concat, concat,
+                        identifier1, identifier1, identifier1, identifier1, identifier1,
+                        identifier2, identifier2, identifier2, identifier2, identifier2,
+                        concat, concat, concat),
+                visited);
+    }
+    
     @Override
     EbnfConcatenationParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
         return EbnfConcatenationParserToken.with(tokens, text);
@@ -27,7 +98,7 @@ public final class EbnfConcatenationParserTokenTest extends EbnfAlternativeConca
 
     @Override
     String text() {
-        return "(*comment1*)|(*comment2*)";
+        return "identifier1,identifier2)";
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionGroupOptionalRepeatParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionGroupOptionalRepeatParentParserTokenTestCase.java
@@ -33,13 +33,13 @@ public abstract class EbnfExceptionGroupOptionalRepeatParentParserTokenTestCase<
 
     @Test(expected = IllegalArgumentException.class)
     public final void testTooManyTokensIgnoringCommentsSymbolsWhitespaceFails() {
-        this.createToken(this.text(), this.identifier("identifier-1"), this.comment("(*comment-2*)"), this.identifier("identifier-3"));
+        this.createToken(this.text(), this.identifier1(), this.comment2(), this.identifier("identifier-3"));
     }
 
     @Test
     public void testWithoutCommentsSymbolsWhitespace() {
-        final EbnfParserToken identifier1 = this.identifier("identifier1");
-        final EbnfParserToken comment2 = this.comment("(*comment2*)");
+        final EbnfParserToken identifier1 = this.identifier1();
+        final EbnfParserToken comment2 = this.comment2();
 
         final T token = this.createToken(this.text(), identifier1, comment2);
         assertEquals("value", Lists.of(identifier1, comment2), token.value());
@@ -52,7 +52,7 @@ public abstract class EbnfExceptionGroupOptionalRepeatParentParserTokenTestCase<
 
     @Override
     final List<EbnfParserToken> tokens() {
-        return Lists.of(this.identifier("identifier-1"));
+        return Lists.of(this.identifier1());
     }
 
     @Override
@@ -62,7 +62,7 @@ public abstract class EbnfExceptionGroupOptionalRepeatParentParserTokenTestCase<
 
     @Override
     final String text() {
-        return this.openChar() + "identifier1" + this.closeChar();
+        return this.openChar() + this.identifier1().text() + this.closeChar();
     }
 
     abstract String openChar();

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserTokenTest.java
@@ -17,10 +17,79 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
 import java.util.List;
 
 public class EbnfExceptionParserTokenTest extends EbnfExceptionGroupOptionalRepeatParentParserTokenTestCase<EbnfExceptionParserToken> {
 
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final EbnfExceptionParserToken exception = this.createToken();
+        final EbnfIdentifierParserToken identifier1 = this.identifier1();
+
+        new FakeEbnfParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("1");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                b.append("2");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfParserToken t) {
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfParserToken t) {
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfExceptionParserToken t) {
+                assertSame(exception, t);
+                b.append("5");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfExceptionParserToken t) {
+                assertSame(exception, t);
+                b.append("6");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final EbnfIdentifierParserToken t) {
+                b.append("7");
+                visited.add(t);
+            }
+        }.accept(exception);
+        assertEquals("13513742642", b.toString());
+        assertEquals("visited",
+                Lists.of(exception, exception, exception,
+                        identifier1, identifier1, identifier1, identifier1, identifier1,
+                        exception, exception, exception),
+                visited);
+    }
+    
     @Override
     EbnfExceptionParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
         return EbnfExceptionParserToken.with(tokens, text);

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTest.java
@@ -73,7 +73,7 @@ public final class EbnfGrammarParserTest extends EbnfParserTestCase<EbnfGrammarP
     }
 
     private EbnfGrammarParserToken grammar(final String text, final EbnfRuleParserToken...rules) {
-        return new EbnfGrammarParserToken(Lists.of(rules), text);
+        return EbnfGrammarParserToken.with(Lists.of(rules), text);
     }
 
     private EbnfRuleParserToken rule1() {

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTokenTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
+ *
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
@@ -22,9 +23,10 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
+import java.util.Iterator;
 import java.util.List;
 
-public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfRuleParserToken> {
+public final class EbnfGrammarParserTokenTest extends EbnfParentParserTokenTestCase<EbnfGrammarParserToken> {
 
     @Test(expected = NullPointerException.class)
     public final void testWithNullTokenFails() {
@@ -32,23 +34,13 @@ public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfR
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testMissingIdentifierFails() {
-        this.createToken(this.text(), assignment(), terminal1(), terminator());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testMissingIdentifierFails2() {
-        this.createToken(this.text(), terminal1(), assignment(), identifier1(), terminator());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testMissingTokenFails() {
-        this.createToken(this.text(), identifier1(), assignment(), terminator());
+    public void testMissingRuleFails() {
+        this.createToken(this.text(), terminal1());
     }
 
     @Test
     public void testWithoutCommentsSymbolsOrWhitespace() {
-        final EbnfRuleParserToken token = this.createToken();
+        final EbnfGrammarParserToken token = this.createToken();
         assertSame(token, token.withoutCommentsSymbolsOrWhitespace().get());
     }
 
@@ -58,11 +50,14 @@ public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfR
         final List<ParserToken> visited = Lists.array();
 
 
-        final EbnfRuleParserToken range = this.createToken();
-        final EbnfIdentifierParserToken identifier = this.identifier1();
-        final EbnfSymbolParserToken assignment = this.assignment();
-        final EbnfTerminalParserToken terminal = this.terminal1();
-        final EbnfSymbolParserToken terminator = this.terminator();
+        final EbnfGrammarParserToken grammar = this.createToken();
+        final EbnfRuleParserToken range = grammar.value().get(0).cast();
+
+        final Iterator<EbnfParserToken> rangeTokens = range.value().iterator();
+        final EbnfIdentifierParserToken identifier = rangeTokens.next().cast();
+        final EbnfSymbolParserToken assignment = rangeTokens.next().cast();
+        final EbnfTerminalParserToken terminal = rangeTokens.next().cast();
+        final EbnfSymbolParserToken terminator =rangeTokens.next().cast();
 
         new FakeEbnfParserTokenVisitor() {
             @Override
@@ -138,27 +133,33 @@ public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfR
     }
 
     @Override
-    protected EbnfRuleParserToken createDifferentToken() {
-        return this.createToken("xyz=qrs;",
-                identifier("xyz"), assignment(), identifier("qrs"), terminator());
+    protected EbnfGrammarParserToken createDifferentToken() {
+        final String ruleText = "identifier2:'terminal2';";
+        final EbnfParserToken rule = EbnfParserToken.rule(Lists.of(identifier2(), assignment(), terminal1(), terminator()), ruleText);
+
+        return EbnfGrammarParserToken.with(Lists.of(rule), ruleText);
     }
 
     @Override
     final String text() {
-        return "abc123=def456";
+        return "identifier1:'terminal1';";
     }
 
     final List<EbnfParserToken> tokens() {
-        return Lists.of(this.identifier1(), this.assignment(), this.terminal1(), this.terminator());
+        return Lists.of(rule());
+    }
+
+    private EbnfRuleParserToken rule() {
+        return EbnfParserToken.rule(Lists.of(identifier1(), assignment(), terminal1(), terminator()), "identifier1:'terminal1';");
     }
 
     @Override
-    EbnfRuleParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
-        return EbnfRuleParserToken.with(tokens, text);
+    EbnfGrammarParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+        return EbnfGrammarParserToken.with(tokens, text);
     }
 
     @Override
-    protected Class<EbnfRuleParserToken> type() {
-        return EbnfRuleParserToken.class;
+    protected Class<EbnfGrammarParserToken> type() {
+        return EbnfGrammarParserToken.class;
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserTokenTest.java
@@ -16,10 +16,79 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
 import java.util.List;
 
 public class EbnfGroupParserTokenTest extends EbnfExceptionGroupOptionalRepeatParentParserTokenTestCase<EbnfGroupParserToken> {
 
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final EbnfGroupParserToken group = this.createToken();
+        final EbnfIdentifierParserToken identifier1 = this.identifier1();
+
+        new FakeEbnfParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("1");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                b.append("2");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfParserToken t) {
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfParserToken t) {
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfGroupParserToken t) {
+                assertSame(group, t);
+                b.append("5");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfGroupParserToken t) {
+                assertSame(group, t);
+                b.append("6");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final EbnfIdentifierParserToken t) {
+                b.append("7");
+                visited.add(t);
+            }
+        }.accept(group);
+        assertEquals("13513742642", b.toString());
+        assertEquals("visited",
+                Lists.of(group, group, group,
+                        identifier1, identifier1, identifier1, identifier1, identifier1,
+                        group, group, group),
+                visited);
+    }
+    
     @Override
     EbnfGroupParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
         return EbnfGroupParserToken.with(tokens, text);

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserTokenTest.java
@@ -16,7 +16,52 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
 public final class EbnfIdentifierParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfIdentifierParserToken, String> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final EbnfIdentifierParserToken token = this.createToken();
+
+        new FakeEbnfParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final EbnfIdentifierParserToken t) {
+                assertSame(token, t);
+                b.append("5");
+            }
+        }.accept(token);
+        assertEquals("13542", b.toString());
+    }
 
     @Override
     String text() {

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserTokenTest.java
@@ -16,10 +16,79 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
 import java.util.List;
 
 public class EbnfOptionalParserTokenTest extends EbnfExceptionGroupOptionalRepeatParentParserTokenTestCase<EbnfOptionalParserToken> {
 
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final EbnfOptionalParserToken optional = this.createToken();
+        final EbnfIdentifierParserToken identifier1 = this.identifier1();
+
+        new FakeEbnfParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("1");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                b.append("2");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfParserToken t) {
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfParserToken t) {
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfOptionalParserToken t) {
+                assertSame(optional, t);
+                b.append("5");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfOptionalParserToken t) {
+                assertSame(optional, t);
+                b.append("6");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final EbnfIdentifierParserToken t) {
+                b.append("7");
+                visited.add(t);
+            }
+        }.accept(optional);
+        assertEquals("13513742642", b.toString());
+        assertEquals("visited",
+                Lists.of(optional, optional, optional,
+                        identifier1, identifier1, identifier1, identifier1, identifier1,
+                        optional, optional, optional),
+                visited);
+    }
+    
     @Override
     EbnfOptionalParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
         return EbnfOptionalParserToken.with(tokens, text);

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase.java
@@ -24,6 +24,14 @@ import java.util.List;
 
 public abstract class EbnfParentParserTokenTestCase<T extends EbnfParentParserToken> extends EbnfParserTokenTestCase<T> {
 
+    final static String COMMENT1 = "(*comment-1*)";
+    final static String COMMENT2 = "(*comment-2*)";
+
+    final static String TERMINAL_TEXT1 = "terminal-1";
+    final static String TERMINAL_TEXT2 = "terminal-2";
+
+    final static String WHITESPACE = "   ";
+
     @Test(expected = NullPointerException.class)
     public final void testWithNullTokensFails() {
         this.createToken(this.text(), Cast.<List<EbnfParserToken>>to(null));
@@ -70,15 +78,59 @@ public abstract class EbnfParentParserTokenTestCase<T extends EbnfParentParserTo
 
     abstract List<EbnfParserToken> tokens();
 
+    final EbnfCommentParserToken comment1() {
+        return this.comment(COMMENT1);
+    }
+
+    final EbnfCommentParserToken comment2() {
+        return this.comment(COMMENT2);
+    }
+
     final EbnfCommentParserToken comment(final String text) {
         return EbnfParserToken.comment(text, text);
+    }
+
+    final EbnfIdentifierParserToken identifier1() {
+        return this.identifier("identifier1");
+    }
+
+    final EbnfIdentifierParserToken identifier2() {
+        return this.identifier("identifier2");
     }
 
     final EbnfIdentifierParserToken identifier(final String text) {
         return EbnfParserToken.identifier(text, text);
     }
 
+    final EbnfWhitespaceParserToken whitespace() {
+        return EbnfParserToken.whitespace(WHITESPACE, WHITESPACE);
+    }
+
     final EbnfWhitespaceParserToken whitespace(final String text) {
         return EbnfParserToken.whitespace(text, text);
+    }
+
+    final EbnfTerminalParserToken terminal1() {
+        return terminal(TERMINAL_TEXT1);
+    }
+
+    final EbnfTerminalParserToken terminal2() {
+        return terminal(TERMINAL_TEXT2);
+    }
+
+    final EbnfTerminalParserToken terminal(final String text) {
+        return EbnfParserToken.terminal(text, '"' + text + '"');
+    }
+
+    final EbnfSymbolParserToken assignment() {
+        return symbol("=");
+    }
+
+    final EbnfSymbolParserToken between() {
+        return symbol("..");
+    }
+
+    final EbnfSymbolParserToken terminator() {
+        return symbol(";");
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase2.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase2.java
@@ -22,7 +22,7 @@ public abstract class EbnfParentParserTokenTestCase2<T extends EbnfParentParserT
 
     @Test(expected = IllegalArgumentException.class)
     public final void testOnlyCommentsFails() {
-        this.createToken(this.text(), this.comment("(*comment-1*)"), this.comment("(*comment-2*)"));
+        this.createToken(this.text(), this.comment1(), this.comment2());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -37,7 +37,7 @@ public abstract class EbnfParentParserTokenTestCase2<T extends EbnfParentParserT
 
     @Test(expected = IllegalArgumentException.class)
     public final void testOnlyCommentsSymbolsWhitespaceFails() {
-        this.createToken(this.text(), this.comment("(*comment-1*)"), symbol("2"), this.whitespace("   "));
+        this.createToken(this.text(), this.comment1(), symbol("2"), this.whitespace("   "));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatParserTokenTest.java
@@ -16,10 +16,79 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
 import java.util.List;
 
 public class EbnfRepeatParserTokenTest extends EbnfExceptionGroupOptionalRepeatParentParserTokenTestCase<EbnfRepeatedParserToken> {
 
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final EbnfRepeatedParserToken repeated = this.createToken();
+        final EbnfIdentifierParserToken identifier1 = this.identifier1();
+
+        new FakeEbnfParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                b.append("1");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                b.append("2");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfParserToken t) {
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfParserToken t) {
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfRepeatedParserToken t) {
+                assertSame(repeated, t);
+                b.append("5");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfRepeatedParserToken t) {
+                assertSame(repeated, t);
+                b.append("6");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final EbnfIdentifierParserToken t) {
+                b.append("7");
+                visited.add(t);
+            }
+        }.accept(repeated);
+        assertEquals("13513742642", b.toString());
+        assertEquals("visited",
+                Lists.of(repeated, repeated, repeated,
+                        identifier1, identifier1, identifier1, identifier1, identifier1,
+                        repeated, repeated, repeated),
+                visited);
+    }
+    
     @Override
     EbnfRepeatedParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
         return EbnfRepeatedParserToken.with(tokens, text);

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfSymbolParserTokenTest.java
@@ -16,7 +16,52 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
 public final class EbnfSymbolParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfSymbolParserToken, String> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final EbnfSymbolParserToken token = this.createToken();
+
+        new FakeEbnfParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final EbnfSymbolParserToken t) {
+                assertSame(token, t);
+                b.append("5");
+            }
+        }.accept(token);
+        assertEquals("13542", b.toString());
+    }
 
     @Override
     String text() {

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserTokenTest.java
@@ -16,7 +16,52 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
 public final class EbnfTerminalParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfTerminalParserToken, String> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final EbnfTerminalParserToken token = this.createToken();
+
+        new FakeEbnfParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final EbnfTerminalParserToken t) {
+                assertSame(token, t);
+                b.append("5");
+            }
+        }.accept(token);
+        assertEquals("13542", b.toString());
+    }
 
     @Override
     String text() {

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfWhitespaceParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfWhitespaceParserTokenTest.java
@@ -16,7 +16,52 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import org.junit.Test;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
 public final class EbnfWhitespaceParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfWhitespaceParserToken, String> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final EbnfWhitespaceParserToken token = this.createToken();
+
+        new FakeEbnfParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final EbnfParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final EbnfParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final EbnfWhitespaceParserToken t) {
+                assertSame(token, t);
+                b.append("5");
+            }
+        }.accept(token);
+        assertEquals("13542", b.toString());
+    }
 
     @Override
     String text() {

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/FakeEbnfParserTokenVisitor.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/FakeEbnfParserTokenVisitor.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.ebnf;
+
+import walkingkooka.test.Fake;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+abstract class FakeEbnfParserTokenVisitor extends EbnfParserTokenVisitor implements Fake {
+
+    @Override 
+    protected Visiting startVisit(final EbnfGrammarParserToken token) {
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final EbnfGrammarParserToken token) {
+        super.endVisit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final EbnfAlternativeParserToken token) {
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final EbnfAlternativeParserToken token) {
+        super.endVisit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final EbnfConcatenationParserToken token) {
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final EbnfConcatenationParserToken token) {
+        super.endVisit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final EbnfExceptionParserToken token) {
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final EbnfExceptionParserToken token) {
+        super.endVisit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final EbnfGroupParserToken token) {
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final EbnfGroupParserToken token) {
+        super.endVisit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final EbnfOptionalParserToken token) {
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final EbnfOptionalParserToken token) {
+        super.endVisit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final EbnfRangeParserToken token) {
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final EbnfRangeParserToken token) {
+        super.endVisit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final EbnfRepeatedParserToken token) {
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final EbnfRepeatedParserToken token) {
+        super.endVisit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final EbnfRuleParserToken token) {
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final EbnfRuleParserToken token) {
+        super.endVisit(token);
+    }
+
+    @Override
+    protected void visit(final EbnfCommentParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final EbnfIdentifierParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final EbnfSymbolParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final EbnfTerminalParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final EbnfWhitespaceParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override 
+    protected Visiting startVisit(final ParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final ParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Visiting startVisit(final EbnfParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final EbnfParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
- Introduced *.tree.visit
- Updated ParserToken interface added accept(ParserTokenVisitor),
  so all tokens can help their visitor dispatch
- Reworked EbnfGrammarParserToken to extend EbnfParentParserToken
- consolidated many ebnf factory methods and constants in Ebnf***Tests into
 EbnfParentParserTokenTestCase.