### PR TITLE
Removed type parameter for ParserToken from some Parsers

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/Parser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/Parser.java
@@ -69,17 +69,17 @@ public interface Parser<T extends ParserToken, C extends ParserContext> {
     /**
      * Combines this parser with another.
      */
-    default Parser<T, C> or(final Parser<T, C> parser) {
+    default Parser<ParserToken, C> or(final Parser<? extends T, C> parser) {
         Objects.requireNonNull(parser, "parser");
 
-        return Parsers.alternatives( Lists.of(this, parser));
+        return Parsers.alternatives( Lists.of(this.castTC(), parser.castTC()));
     }
 
     /**
      * Makes this a repeating token.
      */
-    default Parser<RepeatedParserToken<T>, C> repeating(){
-        return Parsers.repeated(this);
+    default Parser<RepeatedParserToken, C> repeating(){
+        return Parsers.repeated(this.castC());
     }
 
 
@@ -100,7 +100,7 @@ public interface Parser<T extends ParserToken, C extends ParserContext> {
     /**
      * Helper that makes casting and working around generics a little less noisy.
      */
-    default <P extends Parser<T, C>, T extends ParserToken> P castTC() {
+    default <PP extends Parser<TT, CC>, TT extends ParserToken, CC extends ParserContext> PP castTC() {
         return Cast.to(this);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTemplateToken2.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTemplateToken2.java
@@ -24,12 +24,12 @@ import java.util.List;
 /**
  * Represents a result of a parser attempt to consume a {@link walkingkooka.text.cursor.TextCursor}
  */
-abstract class ParserTemplateToken2<T extends ParserToken> extends ParserTemplateToken<List<T>> {
+abstract class ParserTemplateToken2 extends ParserTemplateToken<List<ParserToken>> {
 
     /**
      * Private ctor to limit subclassing.
      */
-    ParserTemplateToken2(final List<T> value, final String text) {
+    ParserTemplateToken2(final List<ParserToken> value, final String text) {
         super(value, text);
     }
 
@@ -42,12 +42,12 @@ abstract class ParserTemplateToken2<T extends ParserToken> extends ParserTemplat
     /**
      * Takes the tokens of something that implements {@link SupportsFlat} and flattens them so no tokens that remain are also flattenable.
      */
-    final List<T> flat(final List<T> tokens){
-        final List<T> flat = Lists.array();
+    final List<ParserToken> flat(final List<ParserToken> tokens){
+        final List<ParserToken> flat = Lists.array();
 
-        for(T token : tokens) {
+        for(ParserToken token : tokens) {
             if(token instanceof SupportsFlat) {
-                final SupportsFlat<?, T> has = Cast.to(token);
+                final SupportsFlat<?, ParserToken> has = Cast.to(token);
                 flat.addAll(has.flat().value());
             } else {
                 flat.add(token);

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTestCase.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTestCase.java
@@ -55,7 +55,7 @@ public abstract class ParserTestCase<P extends Parser<T, C>, T extends ParserTok
 
     @Test
     public final void testRepeating() {
-        final Parser<RepeatedParserToken<T>, C> parser = this.createParser().repeating();
+        final Parser<RepeatedParserToken, C> parser = this.createParser().repeating();
         assertEquals("" + parser, RepeatedParser.class, parser.getClass());
     }
 
@@ -68,7 +68,7 @@ public abstract class ParserTestCase<P extends Parser<T, C>, T extends ParserTok
     public void testOr() {
         final P parser = this.createParser();
         final P parser2 = this.createParser();
-        assertEquals(Parsers.alternatives(Lists.of(parser, parser2)), parser.or(parser2));
+        assertEquals(Parsers.alternatives(Lists.of(parser.castTC(), parser2.castTC())), parser.or(parser2));
     }
 
     protected abstract P createParser();

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokens.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokens.java
@@ -63,14 +63,14 @@ public final class ParserTokens implements PublicStaticHelper {
     /**
      * {@see RepeatedParserToken}
      */
-    public static <T extends ParserToken> RepeatedParserToken<T> repeated(final List<T> tokens, final String text) {
+    public static <T extends ParserToken> RepeatedParserToken repeated(final List<ParserToken> tokens, final String text) {
         return RepeatedParserToken.with(tokens, text);
     }
 
     /**
      * {@see SequenceParserToken}
      */
-    public static SequenceParserToken sequence(final List<? super ParserToken> tokens, final String text) {
+    public static SequenceParserToken sequence(final List<? extends ParserToken> tokens, final String text) {
         return SequenceParserToken.with(tokens, text);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/Parsers.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/Parsers.java
@@ -31,7 +31,7 @@ public final class Parsers implements PublicStaticHelper {
     /**
      * {@see AlternativesParser}
      */
-    public static <T extends ParserToken, C extends ParserContext> Parser<T,C> alternatives(final List<Parser<T, C>> parsers){
+    public static <C extends ParserContext> Parser<ParserToken,C> alternatives(final List<Parser<ParserToken, C>> parsers){
         return AlternativesParser.with(parsers);
     }
 
@@ -94,7 +94,7 @@ public final class Parsers implements PublicStaticHelper {
     /**
      * {@see RepeatedParser}
      */
-    public static <T extends ParserToken, C extends ParserContext> Parser<RepeatedParserToken<T>, C> repeated(final Parser<T, C> parser){
+    public static <C extends ParserContext> Parser<RepeatedParserToken, C> repeated(final Parser<ParserToken, C> parser){
         return RepeatedParser.with(parser);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/RepeatedParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/RepeatedParser.java
@@ -27,26 +27,26 @@ import java.util.Optional;
 /**
  * A {@link Parser} that only matches one or more tokens matched by a different provided {@link Parser}.
  */
-final class RepeatedParser<T extends ParserToken, C extends ParserContext> extends ParserTemplate2<RepeatedParserToken<T>, C> {
+final class RepeatedParser<C extends ParserContext> extends ParserTemplate2<RepeatedParserToken, C> {
 
-    static <T extends ParserToken, C extends ParserContext> RepeatedParser<T,C> with(final Parser<T, C> parser){
+    static <T extends ParserToken, C extends ParserContext> RepeatedParser<C> with(final Parser<ParserToken, C> parser){
         Objects.requireNonNull(parser, "parser");
 
         return parser instanceof RepeatedParser ?
                 parser.castTC() :
-                new RepeatedParser<>(parser);
+                new RepeatedParser<C>(parser);
     }
 
-    private RepeatedParser(final Parser<T, C> parser){
+    private RepeatedParser(final Parser<ParserToken, C> parser){
         this.parser = parser;
     }
 
     @Override
-    Optional<RepeatedParserToken<T>> tryParse0(final TextCursor cursor, final C context, final TextCursorSavePoint start) {
-        final List<T> tokens = Lists.array();
+    Optional<RepeatedParserToken> tryParse0(final TextCursor cursor, final C context, final TextCursorSavePoint start) {
+        final List<ParserToken> tokens = Lists.array();
 
         for(;;) {
-            final Optional<T> token = this.parser.parse(cursor, context);
+            final Optional<ParserToken> token = this.parser.parse(cursor, context);
             if(!token.isPresent()){
                 break;
             }
@@ -60,7 +60,7 @@ final class RepeatedParser<T extends ParserToken, C extends ParserContext> exten
                 .success();
     }
 
-    private final Parser<T, C> parser;
+    private final Parser<ParserToken, C> parser;
 
     @Override
     public String toString() {

--- a/src/main/java/walkingkooka/text/cursor/parser/RepeatedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/RepeatedParserToken.java
@@ -25,21 +25,21 @@ import java.util.Objects;
 /**
  * This {@link ParserToken} holds one or more of the tokens of the same type but not equal.
  */
-public final class RepeatedParserToken<T extends ParserToken> extends ParserTemplateToken2<T> implements SupportsFlat<RepeatedParserToken<T>, T> {
+public final class RepeatedParserToken extends ParserTemplateToken2 implements SupportsFlat<RepeatedParserToken, ParserToken> {
 
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(RepeatedParserToken.class);
 
-    static <T extends ParserToken> RepeatedParserToken<T> with(final List<T> tokens, final String text) {
+    static RepeatedParserToken with(final List<ParserToken> tokens, final String text) {
         Objects.requireNonNull(tokens, "tokens");
         Objects.requireNonNull(text, "text");
         if(tokens.isEmpty()) {
             throw new IllegalArgumentException("Tokens must not be empty");
         }
 
-        return new RepeatedParserToken<T>(tokens, text);
+        return new RepeatedParserToken(tokens, text);
     }
     
-    private RepeatedParserToken(final List<T> tokens, final String text) {
+    private RepeatedParserToken(final List<ParserToken> tokens, final String text) {
         super(tokens, text);
     }
 
@@ -54,10 +54,10 @@ public final class RepeatedParserToken<T extends ParserToken> extends ParserTemp
     }
 
     @Override
-    public RepeatedParserToken<T> flat() {
-        final List<T> tokens = this.value();
-        final List<T> flat = this.flat(tokens);
-        return tokens.equals(flat) ? this : new RepeatedParserToken<>(flat, this.text());
+    public RepeatedParserToken flat() {
+        final List<ParserToken> tokens = this.value();
+        final List<ParserToken> flat = this.flat(tokens);
+        return tokens.equals(flat) ? this : new RepeatedParserToken(flat, this.text());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/SequenceParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SequenceParserToken.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 /**
  * This {@link ParserToken} holds a sequence in order of tokens.
  */
-public final class SequenceParserToken extends ParserTemplateToken2<ParserToken> implements SupportsFlat<SequenceParserToken, ParserToken> {
+public final class SequenceParserToken extends ParserTemplateToken2 implements SupportsFlat<SequenceParserToken, ParserToken> {
 
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(SequenceParserToken.class);
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParser.java
@@ -77,7 +77,7 @@ final class EbnfGrammarParser implements Parser<EbnfGrammarParserToken, EbnfPars
      * character = letter | digit |  "_" ;
      * </pre>
      */
-    final static Parser<StringParserToken, EbnfParserContext> CHARACTER = LETTER
+    final static Parser<ParserToken, EbnfParserContext> CHARACTER = LETTER
             .or(DIGIT)
             .or(UNDERSCORE)
             .setToString("character");

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserContext.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserContext.java
@@ -26,7 +26,7 @@ import walkingkooka.text.cursor.parser.StringParserToken;
 
 public final class EbnfParserContext implements ParserContext {
 
-    EbnfParserContext() {
+    public EbnfParserContext() {
     }
 
     static Parser<StringParserToken, EbnfParserContext> string(final char c) {

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserToken.java
@@ -78,7 +78,7 @@ public abstract class EbnfParserToken implements ParserToken {
     /**
      * {@see EbnfIdentifierParserToken}
      */
-    static EbnfIdentifierParserToken identifier(final String value, final String text){
+    public static EbnfIdentifierParserToken identifier(final String value, final String text){
         return EbnfIdentifierParserToken.with(value, text);
     }
 
@@ -257,7 +257,7 @@ public abstract class EbnfParserToken implements ParserToken {
     /**
      * Useful to get help reduce casting noise.
      */
-    final <T extends EbnfParserToken> T cast() {
+    public final <T extends EbnfParserToken> T cast() {
         return Cast.to(this);
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/AlternativesParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/AlternativesParserTest.java
@@ -20,8 +20,8 @@ import org.junit.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 
-public class AlternativesParserTest extends ParserTemplateTestCase<AlternativesParser<StringParserToken, FakeParserContext>,
-        StringParserToken> {
+public class AlternativesParserTest extends ParserTemplateTestCase<AlternativesParser<FakeParserContext>,
+        ParserToken> {
 
     private final static String TEXT1 = "abc";
     private final static String TEXT2 = "xyz";
@@ -40,7 +40,7 @@ public class AlternativesParserTest extends ParserTemplateTestCase<AlternativesP
 
     @Test
     public void testWithOneNeverWrapped() {
-        assertSame(PARSER1, AlternativesParser.with(Lists.of(PARSER1)));
+        assertSame(PARSER1, AlternativesParser.with(Lists.of(PARSER1.castC())));
     }
 
     @Test
@@ -80,7 +80,7 @@ public class AlternativesParserTest extends ParserTemplateTestCase<AlternativesP
 
     @Test
     public void testOr() {
-        final AlternativesParser<StringParserToken, FakeParserContext> parser = createParser();
+        final AlternativesParser<FakeParserContext> parser = createParser();
 
         final Parser<StringParserToken, FakeParserContext> parser3 = Parsers.string("text3");
         assertEquals(this.createParser0(PARSER1, PARSER2, parser3), parser.or(parser3));
@@ -92,12 +92,12 @@ public class AlternativesParserTest extends ParserTemplateTestCase<AlternativesP
     }
 
     @Override
-    protected AlternativesParser<StringParserToken, FakeParserContext> createParser() {
+    protected AlternativesParser<FakeParserContext> createParser() {
         return this.createParser0(PARSER1, PARSER2);
     }
 
-    private AlternativesParser<StringParserToken, FakeParserContext> createParser0(final Parser<StringParserToken, FakeParserContext>...parsers) {
-        return Cast.to(AlternativesParser.with(Lists.of(parsers)));
+    private AlternativesParser<FakeParserContext> createParser0(final Parser<StringParserToken, FakeParserContext>...parsers) {
+        return Cast.to(AlternativesParser.with(Cast.to(Lists.of(parsers))));
     }
 
     private static StringParserToken string(final String s) {
@@ -105,7 +105,7 @@ public class AlternativesParserTest extends ParserTemplateTestCase<AlternativesP
     }
 
     @Override
-    protected Class<AlternativesParser<StringParserToken, FakeParserContext>> type() {
+    protected Class<AlternativesParser<FakeParserContext>> type() {
         return Cast.to(AlternativesParser.class);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/RepeatedParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/RepeatedParserTest.java
@@ -21,11 +21,11 @@ import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.TextCursors;
 
-public class RepeatedParserTest extends ParserTemplateTestCase<RepeatedParser<StringParserToken, FakeParserContext>,
-        RepeatedParserToken<StringParserToken>> {
+public class RepeatedParserTest extends ParserTemplateTestCase<RepeatedParser<FakeParserContext>,
+        RepeatedParserToken> {
 
     private final static String TEXT = "abc";
-    private final static Parser<StringParserToken, FakeParserContext> PARSER = Parsers.string(TEXT);
+    private final static Parser<ParserToken, FakeParserContext> PARSER = Parsers.string(TEXT).castC();
 
     @Test(expected = NullPointerException.class)
     public void testWithNullParserFails() {
@@ -34,8 +34,8 @@ public class RepeatedParserTest extends ParserTemplateTestCase<RepeatedParser<St
 
     @Test
     public void testWrapAnotherRepeatedParser() {
-        final RepeatedParser<StringParserToken, FakeParserContext> parser = this.createParser();
-        assertSame(parser, Parsers.repeated(parser));
+        final RepeatedParser<FakeParserContext> parser = this.createParser();
+        assertSame(parser, Parsers.repeated(parser.castC()));
     }
 
     @Test
@@ -63,7 +63,7 @@ public class RepeatedParserTest extends ParserTemplateTestCase<RepeatedParser<St
         final String all = text1 + text2;
 
         this.parseAndCheck(
-                RepeatedParser.with(Parsers.singleQuoted()),
+                RepeatedParser.with(Parsers.singleQuoted().castC()),
                 this.createContext(),
                 TextCursors.charSequence(all),
                 RepeatedParserToken.with(Lists.of(quoted(text1), quoted(text2)), all),
@@ -85,7 +85,7 @@ public class RepeatedParserTest extends ParserTemplateTestCase<RepeatedParser<St
 
     @Test
     public void testRepeating2() {
-        final RepeatedParser<StringParserToken, FakeParserContext> parser = this.createParser();
+        final RepeatedParser<FakeParserContext> parser = this.createParser();
         assertSame(parser, parser.repeating());
     }
 
@@ -95,7 +95,7 @@ public class RepeatedParserTest extends ParserTemplateTestCase<RepeatedParser<St
     }
 
     @Override
-    protected RepeatedParser<StringParserToken, FakeParserContext> createParser() {
+    protected RepeatedParser<FakeParserContext> createParser() {
         return RepeatedParser.with(PARSER);
     }
 
@@ -114,7 +114,7 @@ public class RepeatedParserTest extends ParserTemplateTestCase<RepeatedParser<St
     }
 
     @Override
-    protected Class<RepeatedParser<StringParserToken, FakeParserContext>> type() {
+    protected Class<RepeatedParser<FakeParserContext>> type() {
         return Cast.to(RepeatedParser.class);
     }
 }


### PR DESCRIPTION
- AlternativeParser: given multiple parsers, return type could be any ParserToken
- RepeatedParser: removed repeated type, simplified things.