### PR TITLE
EbnfParserCombinatorContext.range signature changes.

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorSyntaxTreeTransformer.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorSyntaxTreeTransformer.java
@@ -57,7 +57,7 @@ public interface EbnfParserCombinatorSyntaxTreeTransformer<C extends ParserConte
 
     Parser<ParserToken, C> optional(final EbnfOptionalParserToken token, final Parser<ParserToken, C> parser, final EbnfParserCombinatorContext context);
 
-    Parser<ParserToken, C> range(final EbnfRangeParserToken token, final Parser<ParserToken, C> parser, final EbnfParserCombinatorContext contextd);
+    Parser<ParserToken, C> range(final EbnfRangeParserToken token, final Parser<SequenceParserToken, C> parser, final EbnfParserCombinatorContext contextd);
 
     Parser<RepeatedParserToken, C> repeated(final EbnfRepeatedParserToken token, final Parser<RepeatedParserToken, C> parser, final EbnfParserCombinatorContext context);
 


### PR DESCRIPTION
- now takes SequenceParserToken (previously was ParserToken).
- parser given now matches each range token rather than building a
 match a character in this range.
- added EbnfParserCombinatorContext.parserToken(EbnfIdentifierName)
- changed EbnfParserCombinatorContext.parser(EbnfIdentifierName) to return Optional.