### PR TITLE
EbnfParserTokens generic simplification, Ebnf grammar improvements

### DIFF
--- a/src/main/java/walkingkooka/predicate/character/CharPredicateGrammarEbnfParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/predicate/character/CharPredicateGrammarEbnfParserTokenVisitor.java
@@ -74,6 +74,8 @@ final class CharPredicateGrammarEbnfParserTokenVisitor extends EbnfParserTokenVi
         // need this mapping to fetch tokens for a rule by identifier at any stage or walking...
         token.value()
                 .stream()
+                .filter(t -> t instanceof EbnfParserToken)
+                .map(t -> EbnfParserToken.class.cast(t))
                 .filter( t -> t.isRule())
                 .map( t -> EbnfRuleParserToken.class.cast(t))
                 .forEach(this::ruleIdentifier);

--- a/src/main/java/walkingkooka/text/cursor/parser/CharacterParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/CharacterParserToken.java
@@ -16,8 +16,6 @@
  */
 package walkingkooka.text.cursor.parser;
 
-import walkingkooka.Cast;
-
 import java.util.Objects;
 
 /**
@@ -39,7 +37,7 @@ public final class CharacterParserToken extends ParserTemplateToken<Character> {
 
     @Override
     public CharacterParserToken setText(final String text){
-        return Cast.to(this.setText0(text));
+        return this.setText0(text).cast();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/DecimalParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DecimalParserToken.java
@@ -16,8 +16,6 @@
  */
 package walkingkooka.text.cursor.parser;
 
-import walkingkooka.Cast;
-
 import java.math.BigDecimal;
 import java.util.Objects;
 
@@ -41,7 +39,7 @@ public final class DecimalParserToken extends ParserTemplateToken<BigDecimal> im
 
     @Override
     public DecimalParserToken setText(final String text){
-        return Cast.to(this.setText0(text));
+        return this.setText0(text).cast();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/DoubleParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DoubleParserToken.java
@@ -17,8 +17,6 @@
  */
 package walkingkooka.text.cursor.parser;
 
-import walkingkooka.Cast;
-
 import java.util.Objects;
 
 /**
@@ -40,7 +38,7 @@ public final class DoubleParserToken extends ParserTemplateToken<Double> impleme
 
     @Override
     public DoubleParserToken setText(final String text){
-        return Cast.to(this.setText0(text));
+        return this.setText0(text).cast();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/DoubleQuotedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/DoubleQuotedParserToken.java
@@ -16,8 +16,6 @@
  */
 package walkingkooka.text.cursor.parser;
 
-import walkingkooka.Cast;
-
 import java.util.Objects;
 
 /**
@@ -48,7 +46,7 @@ public final class DoubleQuotedParserToken extends QuotedParserToken {
 
     @Override
     public DoubleQuotedParserToken setText(final String text){
-        return Cast.to(this.setText0(text));
+        return this.setText0(text).cast();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/LongParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/LongParserToken.java
@@ -17,8 +17,6 @@
  */
 package walkingkooka.text.cursor.parser;
 
-import walkingkooka.Cast;
-
 import java.util.Objects;
 
 /**
@@ -40,7 +38,7 @@ public final class LongParserToken extends ParserTemplateToken<Long> implements 
 
     @Override
     public LongParserToken setText(final String text){
-        return Cast.to(this.setText0(text));
+        return this.setText0(text).cast();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/MissingParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/MissingParserToken.java
@@ -16,8 +16,6 @@
  */
 package walkingkooka.text.cursor.parser;
 
-import walkingkooka.Cast;
-
 import java.util.Objects;
 
 /**
@@ -40,7 +38,7 @@ public final class MissingParserToken extends ParserTemplateToken<ParserTokenNod
 
     @Override
     public MissingParserToken setText(final String text){
-        return Cast.to(this.setText0(text));
+        return this.setText0(text).cast();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/NumberParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/NumberParserToken.java
@@ -16,8 +16,6 @@
  */
 package walkingkooka.text.cursor.parser;
 
-import walkingkooka.Cast;
-
 import java.math.BigInteger;
 import java.util.Objects;
 
@@ -41,7 +39,7 @@ public final class NumberParserToken extends ParserTemplateToken<BigInteger> imp
 
     @Override
     public NumberParserToken setText(final String text){
-        return Cast.to(this.setText0(text));
+        return this.setText0(text).cast();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.text.cursor.parser;
 
+import walkingkooka.Cast;
+
 /**
  * Represents a result of a parser attempt to consume a {@link walkingkooka.text.cursor.TextCursor}
  */
@@ -63,4 +65,11 @@ public interface ParserToken {
      * The token must then call the appropriate visit or start/end visit and also visit any child token values as appropriate.
      */
     void accept(final ParserTokenVisitor visitor);
+
+    /**
+     * Useful to get help reduce casting noise.
+     */
+    public default <T extends ParserToken> T cast() {
+        return Cast.to(this);
+    }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokenNode.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokenNode.java
@@ -70,7 +70,7 @@ public abstract class ParserTokenNode implements Node<ParserTokenNode, ParserTok
     }
 
     final SequenceParserToken asSequenceParserToken() {
-        return Cast.to(this.token);
+        return this.token.cast();
     }
 
     // Node ...........................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/RepeatedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/RepeatedParserToken.java
@@ -16,7 +16,6 @@
  */
 package walkingkooka.text.cursor.parser;
 
-import walkingkooka.Cast;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -45,7 +44,7 @@ public final class RepeatedParserToken extends ParserTemplateToken2 implements S
 
     @Override
     public RepeatedParserToken setText(final String text){
-        return Cast.to(this.setText0(text));
+        return this.setText0(text).cast();
     }
 
     @Override
@@ -54,7 +53,7 @@ public final class RepeatedParserToken extends ParserTemplateToken2 implements S
     }
 
     public RepeatedParserToken setValue(final List<ParserToken> value) {
-        return Cast.to(this.setValue0(value));
+        return this.setValue0(value).cast();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/SequenceParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SequenceParserToken.java
@@ -16,7 +16,6 @@
  */
 package walkingkooka.text.cursor.parser;
 
-import walkingkooka.Cast;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -52,7 +51,7 @@ public final class SequenceParserToken extends ParserTemplateToken2 implements S
 
     @Override
     public SequenceParserToken setText(final String text){
-        return Cast.to(this.setText0(text));
+        return this.setText0(text).cast();
     }
 
     @Override
@@ -66,7 +65,7 @@ public final class SequenceParserToken extends ParserTemplateToken2 implements S
     }
 
     public SequenceParserToken setValue(final List<ParserToken> value) {
-        return Cast.to(this.setValue0(value));
+        return this.setValue0(value).cast();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/SignParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SignParserToken.java
@@ -18,8 +18,6 @@
  */
 package walkingkooka.text.cursor.parser;
 
-import walkingkooka.Cast;
-
 import java.util.Objects;
 
 /**
@@ -41,7 +39,7 @@ public final class SignParserToken extends ParserTemplateToken<Boolean> {
 
     @Override
     public SignParserToken setText(final String text){
-        return Cast.to(this.setText0(text));
+        return this.setText0(text).cast();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/SingleQuotedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/SingleQuotedParserToken.java
@@ -16,8 +16,6 @@
  */
 package walkingkooka.text.cursor.parser;
 
-import walkingkooka.Cast;
-
 import java.util.Objects;
 
 /**
@@ -48,7 +46,7 @@ public final class SingleQuotedParserToken extends QuotedParserToken {
 
     @Override
     public SingleQuotedParserToken setText(final String text){
-        return Cast.to(this.setText0(text));
+        return this.setText0(text).cast();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/StringParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/StringParserToken.java
@@ -16,8 +16,6 @@
  */
 package walkingkooka.text.cursor.parser;
 
-import walkingkooka.Cast;
-
 import java.util.Objects;
 
 /**
@@ -40,7 +38,7 @@ public final class StringParserToken extends ParserTemplateToken<String> {
 
     @Override
     public StringParserToken setText(final String text){
-        return Cast.to(this.setText0(text));
+        return this.setText0(text).cast();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserToken.java
@@ -16,6 +16,7 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 import walkingkooka.tree.visit.Visiting;
 
@@ -28,11 +29,11 @@ final public class EbnfAlternativeParserToken extends EbnfParentParserToken {
 
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfAlternativeParserToken.class);
 
-    static EbnfAlternativeParserToken with(final List<EbnfParserToken> tokens, final String text) {
+    static EbnfAlternativeParserToken with(final List<ParserToken> tokens, final String text) {
         return new EbnfAlternativeParserToken(copyAndCheckTokens(tokens), checkText(text), WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private EbnfAlternativeParserToken(final List<EbnfParserToken> tokens, final String text, final boolean computeWithout) {
+    private EbnfAlternativeParserToken(final List<ParserToken> tokens, final String text, final boolean computeWithout) {
         super(tokens, text, computeWithout);
         this.checkAtLeastTwoTokens();
     }
@@ -48,7 +49,7 @@ final public class EbnfAlternativeParserToken extends EbnfParentParserToken {
     }
 
     @Override
-    EbnfAlternativeParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+    EbnfAlternativeParserToken replaceTokens(final List<ParserToken> tokens) {
         return new EbnfAlternativeParserToken(tokens, this.text(), WITHOUT_USE_THIS);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserToken.java
@@ -16,6 +16,7 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 import walkingkooka.tree.visit.Visiting;
 
@@ -28,11 +29,11 @@ public final class EbnfConcatenationParserToken extends EbnfParentParserToken {
 
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfConcatenationParserToken.class);
 
-    static EbnfConcatenationParserToken with(final List<EbnfParserToken> tokens, final String text) {
+    static EbnfConcatenationParserToken with(final List<ParserToken> tokens, final String text) {
         return new EbnfConcatenationParserToken(copyAndCheckTokens(tokens), checkText(text), WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private EbnfConcatenationParserToken(final List<EbnfParserToken> tokens, final String text, final boolean computeWithout) {
+    private EbnfConcatenationParserToken(final List<ParserToken> tokens, final String text, final boolean computeWithout) {
         super(tokens, text, computeWithout);
         this.checkAtLeastTwoTokens();
     }
@@ -48,7 +49,7 @@ public final class EbnfConcatenationParserToken extends EbnfParentParserToken {
     }
 
     @Override
-    EbnfConcatenationParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+    EbnfConcatenationParserToken replaceTokens(final List<ParserToken> tokens) {
         return new EbnfConcatenationParserToken(tokens, text(), WITHOUT_USE_THIS);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserToken.java
@@ -17,6 +17,7 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 import walkingkooka.tree.visit.Visiting;
 
@@ -29,18 +30,18 @@ public final class EbnfExceptionParserToken extends EbnfParentParserToken {
 
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfExceptionParserToken.class);
 
-    static EbnfExceptionParserToken with(final List<EbnfParserToken> tokens, final String text) {
+    static EbnfExceptionParserToken with(final List<ParserToken> tokens, final String text) {
         return new EbnfExceptionParserToken(copyAndCheckTokens(tokens), checkText(text), WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private EbnfExceptionParserToken(final List<EbnfParserToken> tokens, final String text, final boolean computeWithout) {
+    private EbnfExceptionParserToken(final List<ParserToken> tokens, final String text, final boolean computeWithout) {
         super(tokens, text, computeWithout);
         this.checkOnlyTwoTokens();
 
         final EbnfExceptionParserToken without = this.withoutCommentsSymbolsOrWhitespace().get().cast();
-        final List<EbnfParserToken> withoutTokens = without.value();
-        this.token = withoutTokens.get(0);
-        this.exception = withoutTokens.get(1);
+        final List<ParserToken> withoutTokens = without.value();
+        this.token = withoutTokens.get(0).cast();
+        this.exception = withoutTokens.get(1).cast();
     }
 
     @Override
@@ -54,7 +55,7 @@ public final class EbnfExceptionParserToken extends EbnfParentParserToken {
     }
 
     @Override
-    EbnfExceptionParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+    EbnfExceptionParserToken replaceTokens(final List<ParserToken> tokens) {
         return new EbnfExceptionParserToken(tokens, this.text(), WITHOUT_USE_THIS);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParser.java
@@ -331,11 +331,11 @@ final class EbnfGrammarParser implements Parser<EbnfGrammarParserToken, EbnfPars
      */
     private static Parser<ParserToken, EbnfParserContext> rhs() {
         if(null==RHS_CACHE) {
-            RHS_CACHE = OPTIONAL
+            RHS_CACHE = ALTERNATIVE
+                    .or(CONCATENATION)
+                    .or(OPTIONAL)
                     .or(REPETITION)
                     .or(GROUPING)
-                    .or(ALTERNATIVE) // longer before shorter.
-                    .or(CONCATENATION)
                     .or(RANGE) // must be before TERMINAL
                     .or(EXCEPTION)
                     .or(IDENTIFIER) // identifier & terminal are atoms of range, exception, alt and concat and must come after
@@ -379,13 +379,13 @@ final class EbnfGrammarParser implements Parser<EbnfGrammarParserToken, EbnfPars
                 .stream()
                 .filter(t -> t instanceof StringParserToken)
                 .forEach(t -> {
-                    StringParserToken stringParserToken = Cast.to(t);
+                    StringParserToken stringParserToken = t.cast();
                     string.append(stringParserToken.value());
                 });
         return string.toString();
     }
 
-    private static final BiFunction<SequenceParserToken, EbnfParserContext, ParserToken> filterAndWrapMany(final BiFunction<List<EbnfParserToken>, String, EbnfParserToken> wrapper) {
+    private static final BiFunction<SequenceParserToken, EbnfParserContext, ParserToken> filterAndWrapMany(final BiFunction<List<ParserToken>, String, EbnfParserToken> wrapper) {
         return (sequence, context) -> {
             final List<EbnfParserToken> many = filterNonEbnfParserTokens(sequence);
             return wrapper.apply(Cast.to(many), sequence.text());

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserToken.java
@@ -39,14 +39,14 @@ public final class EbnfGrammarParserToken extends EbnfParentParserToken {
 
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfGrammarParserToken.class);
 
-    static EbnfGrammarParserToken with(final List<EbnfParserToken> tokens, final String text) {
+    static EbnfGrammarParserToken with(final List<ParserToken> tokens, final String text) {
         Objects.requireNonNull(tokens, "rules");
         checkText(text);
 
-        final List<EbnfParserToken> copy = Lists.array();
+        final List<ParserToken> copy = Lists.array();
         copy.addAll(tokens);
 
-        final List<EbnfParserToken> onlyRules = copy.stream()
+        final List<ParserToken> onlyRules = copy.stream()
                 .filter(t -> t instanceof EbnfRuleParserToken)
                 .collect(Collectors.toList());
         if(onlyRules.isEmpty()){
@@ -56,7 +56,7 @@ public final class EbnfGrammarParserToken extends EbnfParentParserToken {
         return new EbnfGrammarParserToken(copy, text, WITHOUT_COMPUTE_REQUIRED);
     }
 
-    EbnfGrammarParserToken(final List<EbnfParserToken> tokens, final String text, final boolean computeWithout) {
+    EbnfGrammarParserToken(final List<ParserToken> tokens, final String text, final boolean computeWithout) {
         super(tokens, text, computeWithout);
         this.checkAtLeastOneRule();
     }
@@ -72,7 +72,7 @@ public final class EbnfGrammarParserToken extends EbnfParentParserToken {
     }
 
     @Override
-    EbnfGrammarParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+    EbnfGrammarParserToken replaceTokens(final List<ParserToken> tokens) {
         return new EbnfGrammarParserToken(tokens, this.text(), WITHOUT_USE_THIS);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserToken.java
@@ -16,6 +16,7 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 import walkingkooka.tree.visit.Visiting;
 
@@ -28,11 +29,11 @@ public final class EbnfGroupParserToken extends EbnfParentParserToken {
 
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfGroupParserToken.class);
 
-    static EbnfGroupParserToken with(final List<EbnfParserToken> tokens, final String text) {
+    static EbnfGroupParserToken with(final List<ParserToken> tokens, final String text) {
         return new EbnfGroupParserToken(copyAndCheckTokens(tokens), checkText(text), WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private EbnfGroupParserToken(final List<EbnfParserToken> tokens, final String text, final boolean computeWithout) {
+    private EbnfGroupParserToken(final List<ParserToken> tokens, final String text, final boolean computeWithout) {
         super(tokens, text, computeWithout);
         this.checkOnlyOneToken();
     }
@@ -48,7 +49,7 @@ public final class EbnfGroupParserToken extends EbnfParentParserToken {
     }
 
     @Override
-    EbnfGroupParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+    EbnfGroupParserToken replaceTokens(final List<ParserToken> tokens) {
         return new EbnfGroupParserToken(tokens, this.text(), WITHOUT_USE_THIS);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserToken.java
@@ -16,6 +16,7 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 import walkingkooka.tree.visit.Visiting;
 
@@ -28,11 +29,11 @@ public final class EbnfOptionalParserToken extends EbnfParentParserToken {
 
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfOptionalParserToken.class);
 
-    static EbnfOptionalParserToken with(final List<EbnfParserToken> tokens, final String text) {
+    static EbnfOptionalParserToken with(final List<ParserToken> tokens, final String text) {
         return new EbnfOptionalParserToken(copyAndCheckTokens(tokens), checkText(text), WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private EbnfOptionalParserToken(final List<EbnfParserToken> tokens, final String text, final boolean computeWithout) {
+    private EbnfOptionalParserToken(final List<ParserToken> tokens, final String text, final boolean computeWithout) {
         super(tokens, text, computeWithout);
         this.checkOnlyOneToken();
     }
@@ -48,7 +49,7 @@ public final class EbnfOptionalParserToken extends EbnfParentParserToken {
     }
 
     @Override
-    EbnfOptionalParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+    EbnfOptionalParserToken replaceTokens(final List<ParserToken> tokens) {
         return new EbnfOptionalParserToken(tokens, this.text(), WITHOUT_USE_THIS);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserToken.java
@@ -19,6 +19,7 @@ package walkingkooka.text.cursor.parser.ebnf;
 import walkingkooka.Cast;
 import walkingkooka.Value;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,25 +27,30 @@ import java.util.Optional;
 /**
  * Base class for a token that contain another child token, with the class knowing the cardinality.
  */
-abstract class EbnfParentParserToken extends EbnfParserToken implements Value<List<EbnfParserToken>> {
+abstract class EbnfParentParserToken extends EbnfParserToken implements Value<List<ParserToken>> {
 
     final static boolean WITHOUT_COMPUTE_REQUIRED = true;
     final static boolean WITHOUT_USE_THIS = !WITHOUT_COMPUTE_REQUIRED;
 
-    EbnfParentParserToken(final List<EbnfParserToken> value, final String text, final boolean computeWithout) {
+    EbnfParentParserToken(final List<ParserToken> value, final String text, final boolean computeWithout) {
         super(text);
         this.value = value;
         this.without = computeWithout ? computeWithout(value) : Optional.of(this);
     }
 
-    private Optional<EbnfParserToken> computeWithout(final List<EbnfParserToken> value){
-        final List<EbnfParserToken> without = Lists.array();
+    private Optional<EbnfParserToken> computeWithout(final List<ParserToken> value){
+        final List<ParserToken> without = Lists.array();
 
         value.stream()
                 .forEach(t -> {
-                    final Optional<EbnfParserToken> maybeWithout = t.withoutCommentsSymbolsOrWhitespace();
-                    if (maybeWithout.isPresent()) {
-                        without.add(maybeWithout.get());
+                    if(t instanceof EbnfParserToken){
+                        final EbnfParserToken ebnfParserToken = t.cast();
+                        final Optional<EbnfParserToken> maybeWithout = ebnfParserToken.withoutCommentsSymbolsOrWhitespace();
+                        if (maybeWithout.isPresent()) {
+                            without.add(maybeWithout.get());
+                        }
+                    } else {
+                        without.add(t);
                     }
                 });
         Lists.array();
@@ -111,11 +117,11 @@ abstract class EbnfParentParserToken extends EbnfParserToken implements Value<Li
     }
 
     @Override
-    public final List<EbnfParserToken> value() {
+    public final List<ParserToken> value() {
         return this.value;
     }
 
-    final List<EbnfParserToken> value;
+    final List<ParserToken> value;
 
     @Override
     public final Optional<EbnfParserToken> withoutCommentsSymbolsOrWhitespace(){
@@ -130,10 +136,10 @@ abstract class EbnfParentParserToken extends EbnfParserToken implements Value<Li
     /**
      * Factory that creates a new {@link EbnfParentParserToken} with the same text but new tokens.
      */
-    abstract EbnfParentParserToken replaceTokens(final List<EbnfParserToken> tokens);
+    abstract EbnfParentParserToken replaceTokens(final List<ParserToken> tokens);
 
     final void acceptValues(final EbnfParserTokenVisitor visitor){
-        for(EbnfParserToken token: this.value()){
+        for(ParserToken token: this.value()){
             visitor.accept(token);
         }
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserToken.java
@@ -36,7 +36,7 @@ public abstract class EbnfParserToken implements ParserToken {
     /**
      * {@see EbnfAlternativeParserToken}
      */
-    public static EbnfAlternativeParserToken alternative(final List<EbnfParserToken> tokens, final String text) {
+    public static EbnfAlternativeParserToken alternative(final List<ParserToken> tokens, final String text) {
         return EbnfAlternativeParserToken.with(tokens, text);
     }
 
@@ -50,28 +50,28 @@ public abstract class EbnfParserToken implements ParserToken {
     /**
      * {@see EbnfConcatenationParserToken}
      */
-    public static EbnfConcatenationParserToken concatenation(final List<EbnfParserToken> tokens, final String text) {
+    public static EbnfConcatenationParserToken concatenation(final List<ParserToken> tokens, final String text) {
         return EbnfConcatenationParserToken.with(tokens, text);
     }
 
     /**
      * {@see EbnfExceptionParserToken}
      */
-    public static EbnfExceptionParserToken exception(final List<EbnfParserToken> tokens, final String text) {
+    public static EbnfExceptionParserToken exception(final List<ParserToken> tokens, final String text) {
         return EbnfExceptionParserToken.with(tokens, text);
     }
 
     /**
      * {@see EbnfGrammarParserToken}
      */
-    public static EbnfGrammarParserToken grammar(final List<EbnfParserToken> tokens, final String text) {
+    public static EbnfGrammarParserToken grammar(final List<ParserToken> tokens, final String text) {
         return EbnfGrammarParserToken.with(tokens, text);
     }
 
     /**
      * {@see EbnfGroupingParserToken}
      */
-    public static EbnfGroupParserToken grouping(final List<EbnfParserToken> tokens, final String text) {
+    public static EbnfGroupParserToken grouping(final List<ParserToken> tokens, final String text) {
         return EbnfGroupParserToken.with(tokens, text);
     }
 
@@ -85,28 +85,28 @@ public abstract class EbnfParserToken implements ParserToken {
     /**
      * {@see EbnfOptionalParserToken}
      */
-    public static EbnfOptionalParserToken optional(final List<EbnfParserToken> tokens, final String text) {
+    public static EbnfOptionalParserToken optional(final List<ParserToken> tokens, final String text) {
         return EbnfOptionalParserToken.with(tokens, text);
     }
 
     /**
      * {@see EbnfRangeParserToken}
      */
-    public static EbnfRangeParserToken range(final List<EbnfParserToken> tokens, final String text) {
+    public static EbnfRangeParserToken range(final List<ParserToken> tokens, final String text) {
         return EbnfRangeParserToken.with(tokens, text);
     }
     
     /**
      * {@see EbnfRepeatedParserToken}
      */
-    public static EbnfRepeatedParserToken repeated(final List<EbnfParserToken> tokens, final String text) {
+    public static EbnfRepeatedParserToken repeated(final List<ParserToken> tokens, final String text) {
         return EbnfRepeatedParserToken.with(tokens, text);
     }
 
     /**
      * {@see EbnfRuleParserToken}
      */
-    public static EbnfRuleParserToken rule(final List<EbnfParserToken> tokens, final String text) {
+    public static EbnfRuleParserToken rule(final List<ParserToken> tokens, final String text) {
        return EbnfRuleParserToken.with(tokens, text);
     }
 
@@ -131,10 +131,10 @@ public abstract class EbnfParserToken implements ParserToken {
         return EbnfWhitespaceParserToken.with(value, text);
     }
 
-    static List<EbnfParserToken> copyAndCheckTokens(final List<EbnfParserToken> tokens) {
+    static List<ParserToken> copyAndCheckTokens(final List<ParserToken> tokens) {
         Objects.requireNonNull(tokens, "tokens");
 
-        final List<EbnfParserToken> copy = Lists.array();
+        final List<ParserToken> copy = Lists.array();
         copy.addAll(tokens);
 
         if(copy.isEmpty()) {
@@ -254,13 +254,6 @@ public abstract class EbnfParserToken implements ParserToken {
      */
     public abstract boolean isWhitespace();
 
-    /**
-     * Useful to get help reduce casting noise.
-     */
-    public final <T extends EbnfParserToken> T cast() {
-        return Cast.to(this);
-    }
-
     public final void accept(final ParserTokenVisitor visitor) {
         final EbnfParserTokenVisitor ebnfParserTokenVisitor = Cast.to(visitor);
         final EbnfParserToken token = this;
@@ -276,12 +269,12 @@ public abstract class EbnfParserToken implements ParserToken {
     // Object ...........................................................................................................
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         return this.text().hashCode();
     }
 
     @Override
-    public boolean equals(final Object other) {
+    public final boolean equals(final Object other) {
         return this == other ||
                this.canBeEqual(other) &&
                this.equals0(Cast.to(other));

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserToken.java
@@ -16,6 +16,7 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 import walkingkooka.tree.visit.Visiting;
 
@@ -28,13 +29,14 @@ final public class EbnfRangeParserToken extends EbnfParentParserToken {
 
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfRangeParserToken.class);
 
-    static EbnfRangeParserToken with(final List<EbnfParserToken> tokens, final String text) {
-        final List<EbnfParserToken> copy = copyAndCheckTokens(tokens);
+    static EbnfRangeParserToken with(final List<ParserToken> tokens, final String text) {
+        final List<ParserToken> copy = copyAndCheckTokens(tokens);
         checkText(text);
 
         final EbnfRangeParserTokenConsumer checker = new EbnfRangeParserTokenConsumer();
         tokens.stream()
                 .filter(t -> t instanceof EbnfParserToken)
+                .map(t -> EbnfParserToken.class.cast(t))
                 .forEach(checker);
 
         final EbnfParserToken begin = checker.begin;
@@ -49,7 +51,7 @@ final public class EbnfRangeParserToken extends EbnfParentParserToken {
         return new EbnfRangeParserToken(copy, text, begin, end, WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private EbnfRangeParserToken(final List<EbnfParserToken> tokens,
+    private EbnfRangeParserToken(final List<ParserToken> tokens,
                                  final String text,
                                  final EbnfParserToken begin,
                                  final EbnfParserToken end,
@@ -72,7 +74,7 @@ final public class EbnfRangeParserToken extends EbnfParentParserToken {
     }
 
     @Override
-    EbnfRangeParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+    EbnfRangeParserToken replaceTokens(final List<ParserToken> tokens) {
         return new EbnfRangeParserToken(tokens, this.text(), this.begin, this.end, WITHOUT_USE_THIS);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatedParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatedParserToken.java
@@ -16,6 +16,7 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 import walkingkooka.tree.visit.Visiting;
 
@@ -28,11 +29,11 @@ public final class EbnfRepeatedParserToken extends EbnfParentParserToken {
 
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfRepeatedParserToken.class);
 
-    static EbnfRepeatedParserToken with(final List<EbnfParserToken> tokens, final String text) {
+    static EbnfRepeatedParserToken with(final List<ParserToken> tokens, final String text) {
         return new EbnfRepeatedParserToken(copyAndCheckTokens(tokens), checkText(text), WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private EbnfRepeatedParserToken(final List<EbnfParserToken> tokens, final String text, final boolean computeWithout) {
+    private EbnfRepeatedParserToken(final List<ParserToken> tokens, final String text, final boolean computeWithout) {
         super(tokens, text, computeWithout);
         this.checkOnlyOneToken();
     }
@@ -48,7 +49,7 @@ public final class EbnfRepeatedParserToken extends EbnfParentParserToken {
     }
 
     @Override
-    EbnfRepeatedParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+    EbnfRepeatedParserToken replaceTokens(final List<ParserToken> tokens) {
         return new EbnfRepeatedParserToken(tokens, this.text(), WITHOUT_USE_THIS);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserToken.java
@@ -16,6 +16,7 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 import walkingkooka.tree.visit.Visiting;
 
@@ -28,13 +29,14 @@ public final class EbnfRuleParserToken extends EbnfParentParserToken {
 
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfRuleParserToken.class);
 
-    static EbnfRuleParserToken with(final List<EbnfParserToken> tokens, final String text) {
-        final List<EbnfParserToken> copy = copyAndCheckTokens(tokens);
+    static EbnfRuleParserToken with(final List<ParserToken> tokens, final String text) {
+        final List<ParserToken> copy = copyAndCheckTokens(tokens);
         checkText(text);
 
         final EbnfRuleParserTokenConsumer checker = new EbnfRuleParserTokenConsumer();
         tokens.stream()
                 .filter(t -> t instanceof EbnfParserToken)
+                .map(t -> EbnfParserToken.class.cast(t))
                 .forEach(checker);
 
         final EbnfIdentifierParserToken identifier = checker.identifier;
@@ -53,7 +55,7 @@ public final class EbnfRuleParserToken extends EbnfParentParserToken {
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private EbnfRuleParserToken(final List<EbnfParserToken> tokens,
+    private EbnfRuleParserToken(final List<ParserToken> tokens,
                         final String text,
                         final EbnfIdentifierParserToken identifier,
                         final EbnfParserToken token,
@@ -86,12 +88,12 @@ public final class EbnfRuleParserToken extends EbnfParentParserToken {
     private final EbnfParserToken token;
 
     @Override
-    EbnfRuleParserToken replaceTokens(final List<EbnfParserToken> tokens) {
+    EbnfRuleParserToken replaceTokens(final List<ParserToken> tokens) {
         // cant use this.identifier and this.tokens because they wont be initialized yet
         return new EbnfRuleParserToken(tokens,
                 this.text(),
-                tokens.get(0).cast(),
-                tokens.get(1),
+                EbnfIdentifierParserToken.class.cast(tokens.get(0)),
+                EbnfParserToken.class.cast(tokens.get(1)),
                 WITHOUT_USE_THIS);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorContext.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorContext.java
@@ -109,6 +109,8 @@ final public class EbnfParserCombinatorContext<C extends ParserContext> implemen
             final Map<EbnfIdentifierName, EbnfParserToken> identifierToToken = Maps.sorted();
             this.grammar.value()
                     .stream()
+                    .filter(t -> t instanceof EbnfParserToken)
+                    .map(t -> EbnfParserToken.class.cast(t))
                     .filter(t -> t.isRule())
                     .map(t -> EbnfRuleParserToken.class.cast(t))
                     .forEach(rule -> {

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorParserCompilingEbnfParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorParserCompilingEbnfParserTokenVisitor.java
@@ -69,6 +69,8 @@ final class EbnfParserCombinatorParserCompilingEbnfParserTokenVisitor<T extends 
         // need this mapping to fetch tokens for a rule by identifier at any stage or walking...
         token.value()
                 .stream()
+                .filter(t -> t instanceof EbnfParserToken)
+                .map(t -> EbnfParserToken.class.cast(t))
                 .filter( t -> t.isRule())
                 .map( t -> EbnfRuleParserToken.class.cast(t))
                 .forEach( r -> {

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserToken.java
@@ -338,13 +338,6 @@ public abstract class SpreadsheetParserToken implements ParserToken {
      */
     public abstract boolean isWhitespace();
 
-    /**
-     * Useful to get help reduce casting noise.
-     */
-    public final <T extends SpreadsheetParserToken> T cast() {
-        return Cast.to(this);
-    }
-
     public final void accept(final ParserTokenVisitor visitor) {
         final SpreadsheetParserTokenVisitor ebnfParserTokenVisitor = Cast.to(visitor);
         final SpreadsheetParserToken token = this;

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeConcatenationParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeConcatenationParentParserTokenTestCase.java
@@ -18,6 +18,7 @@ package walkingkooka.text.cursor.parser.ebnf;
 
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
 
 import java.util.List;
 
@@ -45,7 +46,7 @@ public abstract class EbnfAlternativeConcatenationParentParserTokenTestCase<T ex
     }
 
     @Override
-    final List<EbnfParserToken> tokens() {
+    final List<ParserToken> tokens() {
         return Lists.of(this.identifier1(), this.identifier2());
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeOrConcatenationParserTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeOrConcatenationParserTestCase.java
@@ -18,6 +18,7 @@ package walkingkooka.text.cursor.parser.ebnf;
 
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
 
 import java.util.List;
 
@@ -164,9 +165,9 @@ public abstract class EbnfAlternativeOrConcatenationParserTestCase<T extends Ebn
                 identifier2());
     }
 
-    final T token(final String text, final EbnfParserToken...tokens) {
+    final T token(final String text, final ParserToken...tokens) {
         return this.token(text, Lists.of(tokens));
     }
 
-    abstract T token(final String text, final List<EbnfParserToken> tokens);
+    abstract T token(final String text, final List<ParserToken> tokens);
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserTest.java
@@ -34,7 +34,7 @@ public final class EbnfAlternativeParserTest extends EbnfAlternativeOrConcatenat
     }
 
     @Override
-    EbnfAlternativeParserToken token(final String text, final List<EbnfParserToken> tokens) {
+    EbnfAlternativeParserToken token(final String text, final List<ParserToken> tokens) {
         return EbnfParserToken.alternative(tokens, text);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserTokenTest.java
@@ -92,7 +92,7 @@ public final class EbnfAlternativeParserTokenTest extends EbnfAlternativeConcate
     }
 
     @Override
-    EbnfAlternativeParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+    EbnfAlternativeParserToken createToken(final String text, final List<ParserToken> tokens) {
         return EbnfAlternativeParserToken.with(tokens, text);
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserTest.java
@@ -34,7 +34,7 @@ public final class EbnfConcatenationParserTest extends EbnfAlternativeOrConcaten
     }
 
     @Override
-    EbnfConcatenationParserToken token(final String text, final List<EbnfParserToken> tokens) {
+    EbnfConcatenationParserToken token(final String text, final List<ParserToken> tokens) {
         return EbnfParserToken.concatenation(tokens, text);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserTokenTest.java
@@ -92,7 +92,7 @@ public final class EbnfConcatenationParserTokenTest extends EbnfAlternativeConca
     }
     
     @Override
-    EbnfConcatenationParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+    EbnfConcatenationParserToken createToken(final String text, final List<ParserToken> tokens) {
         return EbnfConcatenationParserToken.with(tokens, text);
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserTest.java
@@ -94,7 +94,7 @@ public final class EbnfExceptionParserTest extends EbnfParserTestCase2<EbnfExcep
         return token(text, this.exceptionToken(), this.identifier1());
     }
 
-    private EbnfExceptionParserToken token(final String text, final EbnfParserToken...tokens) {
+    private EbnfExceptionParserToken token(final String text, final ParserToken...tokens) {
         return EbnfParserToken.exception(Lists.of(tokens), text);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserTokenTest.java
@@ -18,7 +18,6 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import org.junit.Test;
-import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
@@ -28,11 +27,6 @@ import java.util.List;
 import static org.junit.Assert.assertNotSame;
 
 public class EbnfExceptionParserTokenTest extends EbnfParentParserTokenTestCase2<EbnfExceptionParserToken> {
-
-    @Test(expected = NullPointerException.class)
-    public final void testWithNullTokenFails() {
-        this.createToken(this.text(), Cast.<List<EbnfParserToken>>to(null));
-    }
 
     @Test(expected = IllegalArgumentException.class)
     public final void testIncorrectTokenCountFails() {
@@ -120,12 +114,12 @@ public class EbnfExceptionParserTokenTest extends EbnfParentParserTokenTestCase2
     }
     
     @Override
-    EbnfExceptionParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+    EbnfExceptionParserToken createToken(final String text, final List<ParserToken> tokens) {
         return EbnfExceptionParserToken.with(tokens, text);
     }
 
     @Override
-    final List<EbnfParserToken> tokens() {
+    final List<ParserToken> tokens() {
         return Lists.of(this.identifier1(), this.identifier2());
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTokenTest.java
@@ -29,11 +29,6 @@ import java.util.List;
 
 public final class EbnfGrammarParserTokenTest extends EbnfParentParserTokenTestCase<EbnfGrammarParserToken> {
 
-    @Test(expected = NullPointerException.class)
-    public final void testWithNullTokenFails() {
-        this.createToken(this.text(), Cast.<List<EbnfParserToken>>to(null));
-    }
-
     @Test(expected = IllegalArgumentException.class)
     public void testMissingRuleFails() {
         this.createToken(this.text(), terminal1());
@@ -52,13 +47,13 @@ public final class EbnfGrammarParserTokenTest extends EbnfParentParserTokenTestC
 
 
         final EbnfGrammarParserToken grammar = this.createToken();
-        final EbnfRuleParserToken range = grammar.value().get(0).cast();
+        final EbnfRuleParserToken range = Cast.to(grammar.value().get(0));
 
-        final Iterator<EbnfParserToken> rangeTokens = range.value().iterator();
-        final EbnfIdentifierParserToken identifier = rangeTokens.next().cast();
-        final EbnfSymbolParserToken assignment = rangeTokens.next().cast();
-        final EbnfTerminalParserToken terminal = rangeTokens.next().cast();
-        final EbnfSymbolParserToken terminator =rangeTokens.next().cast();
+        final Iterator<ParserToken> rangeTokens = range.value().iterator();
+        final EbnfIdentifierParserToken identifier = Cast.to(rangeTokens.next());
+        final EbnfSymbolParserToken assignment = Cast.to(rangeTokens.next());
+        final EbnfTerminalParserToken terminal = Cast.to(rangeTokens.next());
+        final EbnfSymbolParserToken terminator = Cast.to(rangeTokens.next());
 
         new FakeEbnfParserTokenVisitor() {
             @Override
@@ -210,7 +205,7 @@ public final class EbnfGrammarParserTokenTest extends EbnfParentParserTokenTestC
         return "identifier1:'terminal1';";
     }
 
-    final List<EbnfParserToken> tokens() {
+    final List<ParserToken> tokens() {
         return Lists.of(rule());
     }
 
@@ -223,7 +218,7 @@ public final class EbnfGrammarParserTokenTest extends EbnfParentParserTokenTestC
     }
 
     @Override
-    EbnfGrammarParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+    EbnfGrammarParserToken createToken(final String text, final List<ParserToken> tokens) {
         return EbnfGrammarParserToken.with(tokens, text);
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupOptionalRepeatParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupOptionalRepeatParentParserTokenTestCase.java
@@ -17,19 +17,14 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import org.junit.Test;
-import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
 
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
 
 public abstract class EbnfGroupOptionalRepeatParentParserTokenTestCase<T extends EbnfParentParserToken> extends EbnfParentParserTokenTestCase2<T> {
-
-    @Test(expected = NullPointerException.class)
-    public final void testWithNullTokenFails() {
-        this.createToken(this.text(), Cast.<List<EbnfParserToken>>to(null));
-    }
 
     @Test(expected = IllegalArgumentException.class)
     public final void testTooManyTokensIgnoringCommentsSymbolsWhitespaceFails() {
@@ -51,7 +46,7 @@ public abstract class EbnfGroupOptionalRepeatParentParserTokenTestCase<T extends
 
 
     @Override
-    final List<EbnfParserToken> tokens() {
+    final List<ParserToken> tokens() {
         return Lists.of(this.identifier1());
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserTokenTest.java
@@ -90,7 +90,7 @@ public class EbnfGroupParserTokenTest extends EbnfGroupOptionalRepeatParentParse
     }
     
     @Override
-    EbnfGroupParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+    EbnfGroupParserToken createToken(final String text, final List<ParserToken> tokens) {
         return EbnfGroupParserToken.with(tokens, text);
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupingParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupingParserTest.java
@@ -39,7 +39,7 @@ public final class EbnfGroupingParserTest extends EbnfParserTestCase4<EbnfGroupP
     }
 
     @Override
-    EbnfGroupParserToken token(final String text, final List<EbnfParserToken> tokens) {
+    EbnfGroupParserToken token(final String text, final List<ParserToken> tokens) {
         return EbnfParserToken.grouping(tokens, text);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserTest.java
@@ -39,7 +39,7 @@ public final class EbnfOptionalParserTest extends EbnfParserTestCase4<EbnfOption
     }
 
     @Override
-    EbnfOptionalParserToken token(final String text, final List<EbnfParserToken> tokens) {
+    EbnfOptionalParserToken token(final String text, final List<ParserToken> tokens) {
         return EbnfParserToken.optional(tokens, text);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserTokenTest.java
@@ -90,7 +90,7 @@ public class EbnfOptionalParserTokenTest extends EbnfGroupOptionalRepeatParentPa
     }
     
     @Override
-    EbnfOptionalParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+    EbnfOptionalParserToken createToken(final String text, final List<ParserToken> tokens) {
         return EbnfOptionalParserToken.with(tokens, text);
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase.java
@@ -19,6 +19,7 @@ package walkingkooka.text.cursor.parser.ebnf;
 import org.junit.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
 
 import java.util.List;
 
@@ -34,7 +35,7 @@ public abstract class EbnfParentParserTokenTestCase<T extends EbnfParentParserTo
 
     @Test(expected = NullPointerException.class)
     public final void testWithNullTokensFails() {
-        this.createToken(this.text(), Cast.<List<EbnfParserToken>>to(null));
+        this.createToken(this.text(), Cast.<List<ParserToken>>to(null));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -44,7 +45,7 @@ public abstract class EbnfParentParserTokenTestCase<T extends EbnfParentParserTo
 
     @Test
     public final void testWithCopiesTokens() {
-        final List<EbnfParserToken> tokens = this.tokens();
+        final List<ParserToken> tokens = this.tokens();
         final String text = this.text();
         final T token = this.createToken(text, tokens);
         this.checkText(token, text);
@@ -70,13 +71,13 @@ public abstract class EbnfParentParserTokenTestCase<T extends EbnfParentParserTo
         return this.createToken(text, this.tokens());
     }
 
-    final T createToken(final String text, final EbnfParserToken...tokens) {
+    final T createToken(final String text, final ParserToken...tokens) {
         return this.createToken(text, Lists.of(tokens));
     }
 
-    abstract T createToken(final String text, final List<EbnfParserToken> tokens);
+    abstract T createToken(final String text, final List<ParserToken> tokens);
 
-    abstract List<EbnfParserToken> tokens();
+    abstract List<ParserToken> tokens();
 
     final EbnfCommentParserToken comment1() {
         return this.comment(COMMENT1);

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase.java
@@ -53,6 +53,15 @@ public abstract class EbnfParserTestCase<T extends EbnfParserToken> extends Pars
 
     final static String EXCEPTION = "-";
 
+    final static String OPEN_GROUP = "(";
+    final static String CLOSE_GROUP = ")";
+
+    final static String OPEN_OPTIONAL = "[";
+    final static String CLOSE_OPTIONAL = "]";
+
+    final static String OPEN_REPEAT = "{";
+    final static String CLOSE_REPEAT = "}";
+
     @Test
     public void testOrphanedAssignmentFail() {
         this.parseFailAndCheck("=");
@@ -112,6 +121,10 @@ public abstract class EbnfParserTestCase<T extends EbnfParserToken> extends Pars
         return symbol(ASSIGNMENT);
     }
 
+    static EbnfSymbolParserToken altToken() {
+        return symbol(ALTERNATIVE);
+    }
+
     static EbnfSymbolParserToken concatToken() {
         return symbol(CONCAT);
     }
@@ -133,6 +146,30 @@ public abstract class EbnfParserTestCase<T extends EbnfParserToken> extends Pars
     }
 
     static EbnfSymbolParserToken between() {
-        return symbol("..");
+        return symbol(BETWEEN);
+    }
+
+    static EbnfSymbolParserToken openGroupToken() {
+        return symbol(OPEN_GROUP);
+    }
+
+    static EbnfSymbolParserToken closeGroupToken() {
+        return symbol(CLOSE_GROUP);
+    }
+
+    static EbnfSymbolParserToken openOptionalToken() {
+        return symbol(OPEN_OPTIONAL);
+    }
+
+    static EbnfSymbolParserToken closeOptionalToken() {
+        return symbol(CLOSE_OPTIONAL);
+    }
+
+    static EbnfSymbolParserToken openRepeatToken() {
+        return symbol(OPEN_REPEAT);
+    }
+
+    static EbnfSymbolParserToken closeRepeatToken() {
+        return symbol(CLOSE_REPEAT);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase4.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase4.java
@@ -18,6 +18,7 @@ package walkingkooka.text.cursor.parser.ebnf;
 
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
 
 import java.util.List;
 
@@ -88,9 +89,9 @@ public abstract class EbnfParserTestCase4<T extends EbnfParserToken> extends Ebn
         return this.token(text, identifier1());
     }
 
-    final T token(final String text, final EbnfParserToken...tokens) {
+    final T token(final String text, final ParserToken...tokens) {
         return this.token(text, Lists.of(tokens));
     }
 
-    abstract T token(final String text, final List<EbnfParserToken> tokens);
+    abstract T token(final String text, final List<ParserToken> tokens);
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserTest.java
@@ -118,7 +118,7 @@ public final class EbnfRangeParserTest extends EbnfParserTestCase2<EbnfRangePars
                 terminal2());
     }
 
-    private EbnfRangeParserToken token(final String text, final EbnfParserToken...tokens) {
+    private EbnfRangeParserToken token(final String text, final ParserToken...tokens) {
         return EbnfRangeParserToken.with(Lists.of(tokens), text);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserTokenTest.java
@@ -17,7 +17,6 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import org.junit.Test;
-import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
@@ -29,11 +28,6 @@ public final class EbnfRangeParserTokenTest extends EbnfParentParserTokenTestCas
     private final static String BETWEEN = "..";
 
     private final static String WHITESPACE = "   ";
-
-    @Test(expected = NullPointerException.class)
-    public final void testWithNullTokenFails() {
-        this.createToken(this.text(), Cast.<List<EbnfParserToken>>to(null));
-    }
 
     @Test(expected = IllegalArgumentException.class)
     public void testMissingBeginTokenFails() {
@@ -209,12 +203,13 @@ public final class EbnfRangeParserTokenTest extends EbnfParentParserTokenTestCas
         return "'terminal-1'..'terminal2'";
     }
 
-    final List<EbnfParserToken> tokens() {
+    @Override
+    final List<ParserToken> tokens() {
         return Lists.of(terminal1(), between(), terminal2());
     }
 
     @Override
-    EbnfRangeParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+    EbnfRangeParserToken createToken(final String text, final List<ParserToken> tokens) {
         return EbnfRangeParserToken.with(tokens, text);
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatParserTokenTest.java
@@ -90,7 +90,7 @@ public class EbnfRepeatParserTokenTest extends EbnfGroupOptionalRepeatParentPars
     }
     
     @Override
-    EbnfRepeatedParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+    EbnfRepeatedParserToken createToken(final String text, final List<ParserToken> tokens) {
         return EbnfRepeatedParserToken.with(tokens, text);
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepetitionParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepetitionParserTest.java
@@ -39,7 +39,7 @@ public final class EbnfRepetitionParserTest extends EbnfParserTestCase4<EbnfRepe
     }
 
     @Override
-    EbnfRepeatedParserToken token(final String text, final List<EbnfParserToken> tokens) {
+    EbnfRepeatedParserToken token(final String text, final List<ParserToken> tokens) {
         return EbnfParserToken.repeated(tokens, text);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTest.java
@@ -162,13 +162,174 @@ public final class EbnfRuleParserTest extends EbnfParserTestCase2<EbnfRuleParser
     }
 
     @Test
+    public void testAlternatives() {
+        final String altText = TERMINAL1_TEXT + ALTERNATIVE + TERMINAL2_TEXT;
+        final String text = IDENTIFIER1_TEXT +ASSIGNMENT + altText + TERMINATOR;
+
+        final EbnfParserToken alt = EbnfParserToken.alternative(Lists.of(terminal1(), altToken(), terminal2()), altText);
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), alt, terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testAlternativesGroup() {
+        final String altText = openGroupToken() + TERMINAL1_TEXT + closeGroupToken() + ALTERNATIVE + TERMINAL2_TEXT;
+        final String text = IDENTIFIER1_TEXT +ASSIGNMENT + altText + TERMINATOR;
+
+        final ParserToken group = EbnfParserToken.grouping(Lists.of(openGroupToken(), terminal1(), closeGroupToken()), OPEN_GROUP + TERMINAL1_TEXT + CLOSE_GROUP);
+        final EbnfParserToken alt = EbnfParserToken.alternative(Lists.of(group, altToken(), terminal2()), altText);
+
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), alt, terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testAlternativesOptional() {
+        final String altText = openOptionalToken() + TERMINAL1_TEXT + closeOptionalToken() + ALTERNATIVE + TERMINAL2_TEXT;
+        final String text = IDENTIFIER1_TEXT + ASSIGNMENT + altText + TERMINATOR;
+
+        final ParserToken opt = EbnfParserToken.optional(Lists.of(openOptionalToken(), terminal1(), closeOptionalToken()), OPEN_OPTIONAL + TERMINAL1_TEXT + CLOSE_OPTIONAL);
+        final EbnfParserToken alt = EbnfParserToken.alternative(Lists.of(opt, altToken(), terminal2()), altText);
+
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), alt, terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testAlternativesRepeat() {
+        final String altText = openRepeatToken() + TERMINAL1_TEXT + closeRepeatToken() + ALTERNATIVE + TERMINAL2_TEXT;
+        final String text = IDENTIFIER1_TEXT +ASSIGNMENT + altText + TERMINATOR;
+
+        final ParserToken repeated = EbnfParserToken.repeated(Lists.of(openRepeatToken(), terminal1(), closeRepeatToken()), OPEN_REPEAT + TERMINAL1_TEXT + CLOSE_REPEAT);
+        final EbnfParserToken alt = EbnfParserToken.alternative(Lists.of(repeated, altToken(), terminal2()), altText);
+
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), alt, terminatorToken()),
+                text);
+    }
+
+    @Test
     public void testConcatenation() {
-        final String concatText = TERMINAL1_TEXT + "," + TERMINAL2_TEXT;
+        final String concatText = TERMINAL1_TEXT + CONCAT + TERMINAL2_TEXT;
         final String text = IDENTIFIER1_TEXT +ASSIGNMENT + concatText + TERMINATOR;
 
         final EbnfParserToken concat = EbnfParserToken.concatenation(Lists.of(terminal1(), concatToken(), terminal2()), concatText);
         this.parseAndCheck(text,
                 rule(text, identifier1(), assignmentToken(), concat, terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testConcatenationsGroup() {
+        final String concatText = openGroupToken() + TERMINAL1_TEXT + closeGroupToken() + CONCAT + TERMINAL2_TEXT;
+        final String text = IDENTIFIER1_TEXT +ASSIGNMENT + concatText + TERMINATOR;
+
+        final ParserToken group = EbnfParserToken.grouping(Lists.of(openGroupToken(), terminal1(), closeGroupToken()), OPEN_GROUP + TERMINAL1_TEXT + CLOSE_GROUP);
+        final EbnfParserToken concat = EbnfParserToken.concatenation(Lists.of(group, concatToken(), terminal2()), concatText);
+
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), concat, terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testConcatenationsOptional() {
+        final String concatText = openOptionalToken() + TERMINAL1_TEXT + closeOptionalToken() + CONCAT + TERMINAL2_TEXT;
+        final String text = IDENTIFIER1_TEXT +ASSIGNMENT + concatText + TERMINATOR;
+
+        final ParserToken opt = EbnfParserToken.optional(Lists.of(openOptionalToken(), terminal1(), closeOptionalToken()), OPEN_OPTIONAL + TERMINAL1_TEXT + CLOSE_OPTIONAL);
+
+        final EbnfParserToken concat = EbnfParserToken.concatenation(Lists.of(opt, concatToken(), terminal2()), concatText);
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), concat, terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testConcatenationsRepeat() {
+        final String concatText = openRepeatToken() + TERMINAL1_TEXT + closeRepeatToken() + CONCAT + TERMINAL2_TEXT;
+        final String text = IDENTIFIER1_TEXT +ASSIGNMENT + concatText + TERMINATOR;
+
+        final ParserToken repeated = EbnfParserToken.repeated(Lists.of(openRepeatToken(), terminal1(), closeRepeatToken()), OPEN_REPEAT + TERMINAL1_TEXT + CLOSE_REPEAT);
+        final EbnfParserToken concat = EbnfParserToken.concatenation(Lists.of(repeated, concatToken(), terminal2()), concatText);
+
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), concat, terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testGroup() {
+        final String groupText = OPEN_GROUP + TERMINAL1_TEXT + CLOSE_GROUP;
+        final String text = IDENTIFIER1_TEXT +ASSIGNMENT + groupText + TERMINATOR;
+
+        final EbnfParserToken terminal = terminal1();
+        final EbnfParserToken group = EbnfParserToken.grouping(Lists.of(openGroupToken(), terminal, closeGroupToken()), groupText);
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), group, terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testWhitespaceGroup() {
+        final String groupText = OPEN_GROUP + TERMINAL1_TEXT + CLOSE_GROUP;
+        final String text = IDENTIFIER1_TEXT +ASSIGNMENT + WHITESPACE1 + groupText + TERMINATOR;
+
+        final EbnfParserToken terminal = terminal1();
+        final EbnfParserToken group = EbnfParserToken.grouping(Lists.of(openGroupToken(), terminal, closeGroupToken()), groupText);
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), whitespace1(), group, terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testOptional() {
+        final String optionalText = OPEN_OPTIONAL + TERMINAL1_TEXT + CLOSE_OPTIONAL;
+        final String text = IDENTIFIER1_TEXT +ASSIGNMENT + optionalText + TERMINATOR;
+
+        final EbnfParserToken terminal = terminal1();
+        final EbnfParserToken optional = EbnfParserToken.optional(Lists.of(openOptionalToken(), terminal, closeOptionalToken()), optionalText);
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), optional, terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testWhitespaceOptional() {
+        final String optionalText = OPEN_OPTIONAL + TERMINAL1_TEXT + CLOSE_OPTIONAL;
+        final String text = IDENTIFIER1_TEXT +ASSIGNMENT + WHITESPACE1 + optionalText + TERMINATOR;
+
+        final EbnfParserToken terminal = terminal1();
+        final EbnfParserToken optional = EbnfParserToken.optional(Lists.of(openOptionalToken(), terminal, closeOptionalToken()), optionalText);
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), whitespace1(), optional, terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testRepeat() {
+        final String repeatText = OPEN_REPEAT + TERMINAL1_TEXT + CLOSE_REPEAT;
+        final String text = IDENTIFIER1_TEXT +ASSIGNMENT + repeatText + TERMINATOR;
+
+        final EbnfParserToken terminal = terminal1();
+        final EbnfParserToken repeat = EbnfParserToken.repeated(Lists.of(openRepeatToken(), terminal, closeRepeatToken()), repeatText);
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), repeat, terminatorToken()),
+                text);
+    }
+
+    @Test
+    public void testWhitespaceRepeat() {
+        final String repeatText = OPEN_REPEAT + TERMINAL1_TEXT + CLOSE_REPEAT;
+        final String text = IDENTIFIER1_TEXT +ASSIGNMENT + WHITESPACE1 + repeatText + TERMINATOR;
+
+        final EbnfParserToken terminal = terminal1();
+        final EbnfParserToken repeat = EbnfParserToken.repeated(Lists.of(openRepeatToken(), terminal, closeRepeatToken()), repeatText);
+        this.parseAndCheck(text,
+                rule(text, identifier1(), assignmentToken(), whitespace1(), repeat, terminatorToken()),
                 text);
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTokenTest.java
@@ -17,7 +17,6 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import org.junit.Test;
-import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
@@ -25,11 +24,6 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfRuleParserToken> {
-
-    @Test(expected = NullPointerException.class)
-    public final void testWithNullTokenFails() {
-        this.createToken(this.text(), Cast.<List<EbnfParserToken>>to(null));
-    }
 
     @Test(expected = IllegalArgumentException.class)
     public void testMissingIdentifierFails() {
@@ -148,12 +142,12 @@ public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfR
         return "abc123=def456";
     }
 
-    final List<EbnfParserToken> tokens() {
+    final List<ParserToken> tokens() {
         return Lists.of(this.identifier1(), this.assignment(), this.terminal1(), this.terminator());
     }
 
     @Override
-    EbnfRuleParserToken createToken(final String text, final List<EbnfParserToken> tokens) {
+    EbnfRuleParserToken createToken(final String text, final List<ParserToken> tokens) {
         return EbnfRuleParserToken.with(tokens, text);
     }
 


### PR DESCRIPTION
- Additional EbnfRuleParserTokenTests.
- Changed List<EbnfParserToken> to List<ParserToken> for all EbnfParentParserToken.
- pushed EbnfParserToken.cast to ParserToken, replacing Cast.to() with .cast().