### PR TITLE
Added Observer to NodeSelector.accept(Node, Consumer<Node>)

### DIFF
--- a/src/main/java/walkingkooka/tree/NodeTestCase.java
+++ b/src/main/java/walkingkooka/tree/NodeTestCase.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.naming.Name;
 import walkingkooka.test.ClassTestCase;
+import walkingkooka.tree.select.NodeSelector;
 
 import java.util.List;
 import java.util.Optional;
@@ -94,8 +95,16 @@ abstract public class NodeTestCase<N extends Node<N, NAME, ANAME, AVALUE>,
     @Test
     public final void testSelector() {
         final N node = this.createNode();
-        final Set<N> matches = node.selector().accept(node);
+        final NodeSelector<N, NAME, ANAME, AVALUE> selector = node.selector();
+        final Set<N> matches = selector.accept(node, selector.nulObserver());
         assertEquals("Node's own selector should have matched only itself", Sets.of(node), matches);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public final void testSelectorObserverThrow() {
+        final N node = this.createNode();
+        final NodeSelector<N, NAME, ANAME, AVALUE> selector = node.selector();
+        selector.accept(node, (n) -> { throw new UnsupportedOperationException();});
     }
 
     @Test

--- a/src/main/java/walkingkooka/tree/select/AbsoluteNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/AbsoluteNodeSelector.java
@@ -22,6 +22,7 @@ import walkingkooka.tree.Node;
 
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 
 
 /**
@@ -67,12 +68,13 @@ final class AbsoluteNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
     }
 
     @Override
-    public Set<N> accept(final N node) {
-        return this.accept0(node.root());
+    public Set<N> accept(final N node, final Consumer<N> observer) {
+        observer.accept(node);
+        return this.accept1(node.root(), observer);
     }
 
     @Override
-    final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         this.match(node, context);
     }
 

--- a/src/main/java/walkingkooka/tree/select/AncestorNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/AncestorNodeSelector.java
@@ -61,7 +61,8 @@ final class AncestorNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
                 new AncestorNodeSelector(selector);
     }
 
-    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    @Override
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         this.matchParent(node, context);
     }
 

--- a/src/main/java/walkingkooka/tree/select/AndNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/AndNodeSelector.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * A {@link NodeSelector} that continues to walking the tree, continuously trying the next selector.
@@ -54,12 +55,13 @@ final class AndNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends
         super(selectors);
     }
 
-    @Override public Set<N> accept(final N node) {
+    @Override
+    public Set<N> accept(final N node, final Consumer<N> observer) {
         Set<N> all = null;
 
         for(NodeSelector<N, NAME, ANAME, AVALUE> selector : this.selectors) {
             final Set<N> current = Sets.ordered();
-            selector.accept(node, new NodeSelectorNodeSelectorContext<>(current));
+            selector.accept(node, new NodeSelectorNodeSelectorContext<>(observer, current));
 
             if(null==all) {
                 all = current;
@@ -74,8 +76,9 @@ final class AndNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends
         return all;
     }
 
-    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        for(N match : this.accept(node)) {
+    @Override
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        for(N match : this.accept(node, context.observer())) {
             context.match(match);
         }
     }

--- a/src/main/java/walkingkooka/tree/select/ChildrenNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/ChildrenNodeSelector.java
@@ -60,7 +60,8 @@ final class ChildrenNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
 
     // NodeSelector
 
-    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    @Override
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         this.matchChildren(node, context);
     }
 

--- a/src/main/java/walkingkooka/tree/select/DescendantNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/DescendantNodeSelector.java
@@ -23,6 +23,7 @@ import walkingkooka.tree.Node;
 
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 
 
 /**
@@ -66,12 +67,12 @@ final class DescendantNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
     }
 
     @Override
-    public Set<N> accept(final N node) {
-        return this.accept0(node.root());
+    public Set<N> accept(final N node, final Consumer<N> observer) {
+        return this.accept1(node.root(), observer);
     }
 
     @Override
-    final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         this.matchChildren(node, context);
     }
 

--- a/src/main/java/walkingkooka/tree/select/FirstChildNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/FirstChildNodeSelector.java
@@ -63,7 +63,7 @@ final class FirstChildNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
     // NodeSelector
 
     @Override
-    final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         this.match(node.firstChild(), context);
     }
 

--- a/src/main/java/walkingkooka/tree/select/FollowingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/FollowingNodeSelector.java
@@ -65,7 +65,7 @@ final class FollowingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
     }
 
     @Override
-    void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         this.matchChildren(node, context);
         this.matchFollowingSiblings(node, context);
 

--- a/src/main/java/walkingkooka/tree/select/FollowingSiblingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/FollowingSiblingNodeSelector.java
@@ -61,7 +61,8 @@ final class FollowingSiblingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
                 new FollowingSiblingNodeSelector(selector);
     }
 
-    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    @Override
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         this.matchFollowingSiblings(node, context);
     }
 

--- a/src/main/java/walkingkooka/tree/select/IndexedChildNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/IndexedChildNodeSelector.java
@@ -66,7 +66,7 @@ final class IndexedChildNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAM
     }
 
     @Override
-    void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         final List<N> children = node.children();
         final int index = this.index-INDEX_BIAS;
         if (index < children.size()) {

--- a/src/main/java/walkingkooka/tree/select/LastChildNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/LastChildNodeSelector.java
@@ -63,7 +63,7 @@ final class LastChildNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
     // NodeSelector
 
     @Override
-    final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         this.match(node.lastChild(), context);
     }
 

--- a/src/main/java/walkingkooka/tree/select/NamedNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/NamedNodeSelector.java
@@ -22,7 +22,6 @@ import walkingkooka.naming.PathSeparator;
 import walkingkooka.tree.Node;
 
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * A {@link NodeSelector} that selects all the ancestors of a given {@link Node} until the root of the graph is reached.
@@ -69,7 +68,7 @@ final class NamedNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME exten
     }
 
     @Override
-    final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         if (this.name.equals(node.name())) {
             this.match(node, context);
         }

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorNodeSelectorContext.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorNodeSelectorContext.java
@@ -21,15 +21,24 @@ import walkingkooka.naming.Name;
 import walkingkooka.tree.Node;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 class NodeSelectorNodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
         extends NodeSelectorContext<N, NAME, ANAME, AVALUE> {
 
-    NodeSelectorNodeSelectorContext(final Set<N> matched) {
+    NodeSelectorNodeSelectorContext(final Consumer<N> observer, final Set<N> matched) {
+        this.observer = observer;
         this.matched = matched;
     }
 
-    @Override void match(final N node) {
+    Consumer<N> observer() {
+        return this.observer;
+    }
+
+    private final Consumer<N> observer;
+
+    @Override
+    void match(final N node) {
         this.matched.add(node);
     }
 

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorNulObserverConsumer.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorNulObserverConsumer.java
@@ -13,32 +13,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
+ *
  */
 
 package walkingkooka.tree.select;
 
+import walkingkooka.Cast;
 import walkingkooka.naming.Name;
 import walkingkooka.tree.Node;
 
-import java.util.Set;
 import java.util.function.Consumer;
 
 /**
- * Base class for all non logical (binary) selectors without any additional properties.
+ * A {@link Consumer} that may be passed to {@link NodeSelector#accept(Node, Consumer)}
  */
-abstract class UnaryRelativeNodeSelector2<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE>
-    extends UnaryNodeSelector2<N, NAME, ANAME, AVALUE> {
+final class NodeSelectorNulObserverConsumer<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> implements Consumer<N> {
 
-    UnaryRelativeNodeSelector2() {
+    /**
+     * Type safe getter.
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodeSelectorNulObserverConsumer<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(INSTANCE);
+    }
+
+    final static NodeSelectorNulObserverConsumer INSTANCE = new NodeSelectorNulObserverConsumer();
+
+    private NodeSelectorNulObserverConsumer(){
         super();
     }
 
-    UnaryRelativeNodeSelector2(final NodeSelector<N, NAME, ANAME, AVALUE> next) {
-        super(next);
+    @Override
+    public void accept(final N n) {
+
     }
 
-    @Override
-    public final Set<N> accept(final N node, final Consumer<N> observer) {
-        return this.accept1(node, observer);
+    public String toString() {
+        return "";
     }
 }

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorPredicate.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorPredicate.java
@@ -35,7 +35,7 @@ final class NodeSelectorPredicate<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
 
     @Override
     public boolean test(final N node) {
-        return this.selector.accept(node).size() > 0;
+        return this.selector.accept(node, this.selector.nulObserver()).size() > 0;
     }
 
     private final NodeSelector<N, NAME, ANAME, AVALUE> selector;

--- a/src/main/java/walkingkooka/tree/select/OrNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/OrNodeSelector.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * A {@link NodeSelector} that continues to walking the tree, continuously trying the next selector.
@@ -56,13 +57,15 @@ final class OrNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends 
 
     // LogicalNodeSelector
 
-    @Override public Set<N> accept(final N node) {
+    @Override
+    public Set<N> accept(final N node, final Consumer<N> observer) {
         final Set<N> matches = Sets.ordered();
-        this.accept(node, new NodeSelectorNodeSelectorContext<>(matches));
+        this.accept(node, new NodeSelectorNodeSelectorContext<>(observer, matches));
         return matches;
     }
 
-    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    @Override
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         for(NodeSelector<N, NAME, ANAME, AVALUE> selector : this.selectors) {
             selector.accept(node, context);
         }

--- a/src/main/java/walkingkooka/tree/select/ParentNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/ParentNodeSelector.java
@@ -59,7 +59,7 @@ final class ParentNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME exte
     }
 
     @Override
-    public void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    public void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         this.matchParent(node, context);
     }
 

--- a/src/main/java/walkingkooka/tree/select/PathNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PathNodeSelector.java
@@ -24,7 +24,6 @@ import walkingkooka.tree.Node;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -52,7 +51,7 @@ final class PathNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extend
     }
 
     @Override
-    void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         boolean abort = false;
 
         N current = node;

--- a/src/main/java/walkingkooka/tree/select/PrecedingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PrecedingNodeSelector.java
@@ -65,7 +65,7 @@ final class PrecedingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
     }
 
     @Override
-    void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         this.matchChildren(node, context);
         this.matchPrecedingSiblings(node, context);
 

--- a/src/main/java/walkingkooka/tree/select/PrecedingSiblingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PrecedingSiblingNodeSelector.java
@@ -60,7 +60,8 @@ final class PrecedingSiblingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
                 new PrecedingSiblingNodeSelector(selector);
     }
 
-    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    @Override
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         this.matchPrecedingSiblings(node, context);
     }
 

--- a/src/main/java/walkingkooka/tree/select/PredicateNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PredicateNodeSelector.java
@@ -68,7 +68,7 @@ final class PredicateNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
     }
 
     @Override
-    final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         if(this.predicate.test(node)){
             context.match(node);
         }

--- a/src/main/java/walkingkooka/tree/select/SelfNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/SelfNodeSelector.java
@@ -63,7 +63,7 @@ final class SelfNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extend
     }
 
     @Override
-    void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         this.match(node, context);
     }
 

--- a/src/main/java/walkingkooka/tree/select/TerminalNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/TerminalNodeSelector.java
@@ -23,6 +23,7 @@ import walkingkooka.naming.Name;
 import walkingkooka.tree.Node;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * A {@link NodeSelector} that selects and does nothing.
@@ -55,11 +56,13 @@ final class TerminalNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
         return selector;
     }
 
-    @Override public Set<N> accept(N node) {
+    @Override
+    public Set<N> accept(final N node, final Consumer<N> observer) {
         throw new ShouldNeverHappenError(this.getClass() + ".accept(Node)");
     }
 
-    @Override final void accept(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    @Override
+    final void accept0(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         context.match(node);
     }
 

--- a/src/main/java/walkingkooka/tree/select/UnaryNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/UnaryNodeSelector.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.Node;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * Base class for all non logical (binary) selectors.
@@ -49,9 +50,9 @@ abstract class UnaryNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
     
     abstract NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector);
 
-    final Set<N> accept0(final N node) {
+    final Set<N> accept1(final N node, final Consumer<N> observer) {
         final Set<N> matches = Sets.ordered();
-        this.accept(node, new NodeSelectorNodeSelectorContext<>(matches));
+        this.accept(node, new NodeSelectorNodeSelectorContext<>(observer, matches));
         return matches;
     }
 

--- a/src/main/java/walkingkooka/tree/select/UnaryRelativeNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/UnaryRelativeNodeSelector.java
@@ -23,6 +23,7 @@ import walkingkooka.naming.Name;
 import walkingkooka.tree.Node;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * Base class for all non logical (binary) selectors.
@@ -39,7 +40,7 @@ abstract class UnaryRelativeNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
     }
 
     @Override
-    public final Set<N> accept(final N node) {
-        return this.accept0(node);
+    public final Set<N> accept(final N node, final Consumer<N> observer) {
+        return this.accept1(node, observer);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenNodeTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenNodeTest.java
@@ -137,7 +137,7 @@ public class SequenceParserTokenNodeTest extends ParserTokenNodeTestCase<Sequenc
                 STRING4);
 
         assertEquals(Lists.of("a1", "b2", "c3", "d4"),
-                selector.accept(root)
+                selector.accept(root, selector.nulObserver())
                         .stream()
                         .map(n -> n.value().text())
                         .collect(Collectors.toList()));

--- a/src/test/java/walkingkooka/tree/pojo/PojoNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoNodeTest.java
@@ -42,7 +42,8 @@ public final class PojoNodeTest extends PublicClassTestCase<PojoNode> {
                 new ReflectionPojoNodeContext());
 
         assertEquals(Sets.of("1", "2", "3"),
-                        selector.accept(node).stream().map(n -> n.value()).collect(Collectors.toCollection(TreeSet::new)));
+                        selector.accept(node, selector.nulObserver())
+                                .stream().map(n -> n.value()).collect(Collectors.toCollection(TreeSet::new)));
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/select/FakeNodeSelector.java
+++ b/src/test/java/walkingkooka/tree/select/FakeNodeSelector.java
@@ -21,6 +21,7 @@ import walkingkooka.naming.StringName;
 import walkingkooka.test.Fake;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 class FakeNodeSelector extends NodeSelector<TestFakeNode, StringName, StringName, Object> implements Fake {
 
@@ -29,12 +30,12 @@ class FakeNodeSelector extends NodeSelector<TestFakeNode, StringName, StringName
         throw new UnsupportedOperationException();
     }
 
-    @Override public Set<TestFakeNode> accept(TestFakeNode node) {
+    @Override public Set<TestFakeNode> accept(final TestFakeNode node, final Consumer<TestFakeNode> observer) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    void accept(TestFakeNode node, NodeSelectorContext<TestFakeNode, StringName, StringName, Object> context) {
+    void accept0(final TestFakeNode node, final NodeSelectorContext<TestFakeNode, StringName, StringName, Object> context) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorBuilderTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorBuilderTest.java
@@ -271,7 +271,7 @@ public final class NodeSelectorBuilderTest extends BuilderTestCase<NodeSelectorB
                                           final TestFakeNode start,
                                           final String... nodes) {
         final NodeSelector<TestFakeNode, StringName, StringName, Object> selector = builder.build();
-        final Set<TestFakeNode> matched = selector.accept(start);
+        final Set<TestFakeNode> matched = selector.accept(start, selector.nulObserver());
         final List<String> matchedNodes = matched.stream()
                 .map(n -> n.name().value())
                 .collect(Collectors.toList());

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNulObserverConsumerTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNulObserverConsumerTest.java
@@ -13,18 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
+ *
  */
 
 package walkingkooka.tree.select;
 
-import walkingkooka.naming.Name;
-import walkingkooka.tree.Node;
+import walkingkooka.Cast;
+import walkingkooka.test.PackagePrivateClassTestCase;
 
-import java.util.function.Consumer;
-
-abstract class NodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> {
-
-    abstract Consumer<N> observer();
-
-    abstract void match(final N node);
+public final class NodeSelectorNulObserverConsumerTest extends PackagePrivateClassTestCase<NodeSelectorNulObserverConsumer<?, ?, ?, ?>> {
+    @Override
+    protected Class<NodeSelectorNulObserverConsumer<?, ?, ?, ?>> type() {
+        return Cast.to(NodeSelectorNulObserverConsumer.class);
+    }
 }

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase.java
@@ -20,6 +20,7 @@ package walkingkooka.tree.select;
 import org.junit.Before;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.set.Sets;
 import walkingkooka.naming.PathSeparator;
 import walkingkooka.naming.StringName;
 import walkingkooka.test.PackagePrivateClassTestCase;
@@ -27,7 +28,10 @@ import walkingkooka.test.PackagePrivateClassTestCase;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
 
 abstract public class NodeSelectorTestCase<S extends NodeSelector<TestFakeNode, StringName, StringName, Object>> extends PackagePrivateClassTestCase<S> {
 
@@ -78,10 +82,20 @@ abstract public class NodeSelectorTestCase<S extends NodeSelector<TestFakeNode, 
     final void acceptAndCheckUsingContext(final NodeSelector<TestFakeNode, StringName, StringName, Object> selector,
                                           final TestFakeNode start,
                                           final String... nodes) {
-        final Set<TestFakeNode> matched = selector.accept(start);
+        final Set<TestFakeNode> observed = Sets.ordered();
+        final Consumer<TestFakeNode> observer = new Consumer<TestFakeNode>() {
+            @Override
+            public void accept(final TestFakeNode node) {
+                assertNotEquals(null, node);
+                observed.add(node);
+            }
+        };
+        final Set<TestFakeNode> matched = selector.accept(start, observer);
         final List<String> matchedNodes = matched.stream()
                 .map(n -> n.name().value())
                 .collect(Collectors.toList());
         assertEquals("Selector.accept\n" + start, Lists.of(nodes), matchedNodes);
+        assertNotEquals("observer must not be empty", Sets.empty(), observed);
+        assertTrue("observer must include initial node=" + observed, observed.contains(start));
     }
 }

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase2.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase2.java
@@ -22,6 +22,7 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.naming.StringName;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 public abstract class NodeSelectorTestCase2<S extends NodeSelector<TestFakeNode, StringName, StringName, Object>>
 extends NodeSelectorTestCase<S>{
@@ -43,9 +44,16 @@ extends NodeSelectorTestCase<S>{
 
         selector.accept(start, new NodeSelectorContext<TestFakeNode, StringName, StringName, Object>() {
 
+            private final Consumer<TestFakeNode> observer = NodeSelectorNulObserverConsumer.get();
+
+            Consumer<TestFakeNode> observer() {
+                return observer;
+            }
+
             int i = 0;
 
-            @Override void match(final TestFakeNode node) {
+            @Override
+            void match(final TestFakeNode node) {
                 if(i == nodes.length) {
                     Assert.fail("Unexpected matching node: " + node);
                 }

--- a/src/test/java/walkingkooka/tree/select/UnaryNodeSelectorTestCase.java
+++ b/src/test/java/walkingkooka/tree/select/UnaryNodeSelectorTestCase.java
@@ -40,7 +40,7 @@ extends NodeSelectorTestCase<S>{
     final void acceptAndCheckRequiringOrder(final NodeSelector<TestFakeNode, StringName, StringName, Object> selector,
                                             final TestFakeNode start,
                                             final String[] nodes) {
-        final List<String> actual = selector.accept(start)
+        final List<String> actual = selector.accept(start, selector.nulObserver())
                 .stream()
                 .map(n -> n.name().value())
                 .collect(Collectors.toList());

--- a/src/test/java/walkingkooka/xml/DomDocumentTest.java
+++ b/src/test/java/walkingkooka/xml/DomDocumentTest.java
@@ -782,7 +782,7 @@ public final class DomDocumentTest extends DomParentNodeTestCase<DomDocument> {
                 .descendant()
                 .named(DomName.element("img"))
                 .build();
-        final Set<DomNode> matches = selector.accept(document);
+        final Set<DomNode> matches = selector.accept(document, selector.nulObserver());
         assertEquals("should have matched img tags\n" + matches, 20, matches.size());
     }
 
@@ -795,7 +795,7 @@ public final class DomDocumentTest extends DomParentNodeTestCase<DomDocument> {
                 .named(DomName.element("a"))
                 .attributeValueContains(DomNode.attribute("href", DomNode.NO_PREFIX), "19")
                 .build();
-        final Set<DomNode> matches = selector.accept(document);
+        final Set<DomNode> matches = selector.accept(document, selector.nulObserver());
         assertEquals("should have matched 3 links with 19 in href\n" + matches, 3, matches.size());
     }
 


### PR DESCRIPTION
- The Consumer<N> is invoked prior to each Node test and continued
traversal. The Consumer may abort the walking process by throwing an exception.