### PR TITLE
A read only FileNode abstraction.

### DIFF
--- a/src/main/java/walkingkooka/tree/file/DirectoryFileNode.java
+++ b/src/main/java/walkingkooka/tree/file/DirectoryFileNode.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.set.Sets;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Represents directory {@link FileNode}.
+ */
+final class DirectoryFileNode extends FileNode{
+
+    /**
+     * Factory that creates a new {@link DirectoryFileNode}. This should only be called by a {@link FileNodeContext#directory(Path)}
+     */
+    static DirectoryFileNode with(final Path path, final FileNodeContext context) {
+        check(path, context);
+
+        return new DirectoryFileNode(path, context);
+    }
+
+    /**
+     * Private ctor use factory.
+     */
+    private DirectoryFileNode(final Path path, final FileNodeContext context) {
+        super(path, context);
+        this.children = null;
+    }
+
+    /**
+     * Directories return {@link FileNode} for each and every entry in their directory.
+     */
+    @Override
+    public List<FileNode> children() {
+        if(null != this.children && this.mustLoad(FileNodeCacheAtom.CHILDREN)){
+            this.children = null;
+        }
+        if(null == this.children) {
+            this.children = this.makeFileNodesFromDirectoryListing();
+        }
+        return this.children;
+    }
+
+    private List<FileNode> children;
+
+    /**
+     * Lists the immediate directory fetching nodes for each of the entries.
+     */
+    private List<FileNode> makeFileNodesFromDirectoryListing() {
+        final List<FileNode> children = Lists.array();
+        final File[] files = this.path.toFile().listFiles();
+
+        if(null != files) {
+            for (File file : files) {
+                final Path path = file.toPath();
+                if(file.isDirectory()) {
+                    children.add(this.context.directory(path));
+                }
+                if(file.isFile()) {
+                    children.add(this.context.file(path));
+                }
+            }
+        }
+
+        return Lists.readOnly(children);
+    }
+
+    @Override
+    public final boolean isDirectory() {
+        return true;
+    }
+
+    @Override
+    public final boolean isFile() {
+        return false;
+    }
+
+    @Override
+    Set<FileNodeAttributeName> attributeNames() {
+        return ATTRIBUTE_NAMES;
+    }
+
+    // VisibleForTesting
+    final static Set<FileNodeAttributeName> ATTRIBUTE_NAMES = Sets.of(FileNodeAttributeName.CREATED,
+            FileNodeAttributeName.HIDDEN,
+            FileNodeAttributeName.LAST_ACCESSED,
+            FileNodeAttributeName.LAST_MODIFIED,
+            FileNodeAttributeName.OWNER,
+            FileNodeAttributeName.TYPE);
+
+    @Override
+    String size() {
+        return "";
+    }
+
+    @Override
+    String text() {
+        return "";
+    }
+
+    @Override
+    String type() {
+        return DIRECTORY_TYPE;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/DirectoryFileNodeTest.java
+++ b/src/main/java/walkingkooka/tree/file/DirectoryFileNodeTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class DirectoryFileNodeTest extends PackagePrivateClassTestCase<DirectoryFileNode> {
+    @Override
+    protected Class<DirectoryFileNode> type() {
+        return DirectoryFileNode.class;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileFileNode.java
+++ b/src/main/java/walkingkooka/tree/file/FileFileNode.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.collect.list.Lists;
+
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Represents file {@link FileNode}
+ */
+final class FileFileNode extends FileNode{
+
+    /**
+     * Factory that creates a new {@link FileFileNode}. This should only be called by a {@link FileNodeContext#file(Path)}
+     */
+    static FileFileNode with(final Path path, final FileNodeContext context) {
+        check(path, context);
+
+        return new FileFileNode(path, context);
+    }
+
+    /**
+     * Private ctor use factory.
+     */
+    private FileFileNode(final Path path, final FileNodeContext context) {
+        super(path, context);
+    }
+
+    /**
+     * Files return an empty list, while directories return {@link FileNode} for each and every entry in their directory.
+     */
+    @Override
+    public List<FileNode> children() {
+        return Lists.empty();
+    }
+
+    @Override
+    public final boolean isDirectory() {
+        return false;
+    }
+
+    @Override
+    public final boolean isFile() {
+        return true;
+    }
+
+    // Attributes......................................................................................................
+
+    @Override
+    Set<FileNodeAttributeName> attributeNames() {
+        return ATTRIBUTE_NAMES;
+    }
+
+    // VisibleForTesting
+    final static Set<FileNodeAttributeName> ATTRIBUTE_NAMES = EnumSet.allOf(FileNodeAttributeName.class);
+
+    @Override
+    String size() {
+        if(null != this.size && this.mustLoad(FileNodeCacheAtom.SIZE)){
+            this.size = null;
+        }
+
+        if(null==this.size){
+            this.size = String.valueOf(this.path.toFile().length());
+        }
+        return this.size;
+    }
+
+    private String size;
+
+    @Override
+    String text() {
+        if(null != this.text && this.mustLoad(FileNodeCacheAtom.TEXT)){
+            this.text = null;
+        }
+
+        if(null==this.text){
+            try {
+                this.text = this.context.text(this.path);
+            } catch ( final Exception cause) {
+                throw this.exception("Failed to get text for " + pathToString(), cause);
+            }
+        }
+        return this.text;
+    }
+
+    private String text;
+
+    @Override
+    String type() {
+        return FILE_TYPE;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileFileNodeTest.java
+++ b/src/main/java/walkingkooka/tree/file/FileFileNodeTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class FileFileNodeTest extends PackagePrivateClassTestCase<FileFileNode> {
+    @Override
+    protected Class<FileFileNode> type() {
+        return FileFileNode.class;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNode.java
+++ b/src/main/java/walkingkooka/tree/file/FileNode.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.Cast;
+import walkingkooka.Value;
+import walkingkooka.naming.PathSeparator;
+import walkingkooka.text.CharSequences;
+import walkingkooka.tree.Node;
+import walkingkooka.tree.select.NodeSelectorBuilder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileOwnerAttributeView;
+import java.nio.file.attribute.FileTime;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * A {@link FileNode} represents a file or directory under a path.
+ */
+public abstract class FileNode implements Node<FileNode, FileNodeName, FileNodeAttributeName, String>, Value<Path> {
+
+    public final static String DIRECTORY_TYPE = "DIRECTORY";
+    public final static String FILE_TYPE = "FILE";
+
+    /**
+     * Creates a {@link FileNode} for a directory.
+     */
+    public static FileNode directory(final Path path, final FileNodeContext context) {
+        return DirectoryFileNode.with(path, context);
+    }
+
+    /**
+     * Creates a {@link FileNode} for a file.
+     */
+    public static FileNode file(final Path path, final FileNodeContext context) {
+        return FileFileNode.with(path, context);
+    }
+
+    /**
+     * Parameter checks
+     */
+    static void check(final Path path, final FileNodeContext context) {
+        Objects.requireNonNull(path, "path");
+        Objects.requireNonNull(context, "context");
+    }
+
+    /**
+     * Absolute {@see NodeSelectorBuilder}
+     */
+    public static NodeSelectorBuilder<FileNode, FileNodeName, FileNodeAttributeName, String> absoluteNodeSelectorBuilder() {
+        return NodeSelectorBuilder.absolute(PathSeparator.requiredAtStart('/'));
+    }
+
+    /**
+     * Absolute {@see NodeSelectorBuilder}
+     */
+    public static NodeSelectorBuilder<FileNode, FileNodeName, FileNodeAttributeName, String> relativeNodeSelectorBuilder() {
+        return NodeSelectorBuilder.relative(PathSeparator.requiredAtStart('/'));
+    }
+    
+    /**
+     * Package private to limit sub classing.
+     */
+    FileNode(final Path path, final FileNodeContext context) {
+        this.path = path;
+        this.context = context;
+        this.attributes = new FileNodeAttributeMap<>(this);
+    }
+
+    @Override
+    public final FileNodeName name() {
+        if(null==this.name){
+            // only want the filename and not a path including parent directories etc.
+            this.name = FileNodeName.with(this.path.getFileName().toString());
+        }
+        return this.name;
+    }
+
+    private FileNodeName name;
+
+    /**
+     * Returns the parent of empty if this node is the root as determined by {@link FileNodeContext#rootPath()}
+     */
+    @Override
+    public final Optional<FileNode> parent() {
+        if(null==this.parent) {
+            final Path path = this.path;
+            final Path root = this.context.rootPath();
+            this.parent = root.equals(path) ?
+                    Optional.empty() :
+                    Optional.of(this.context.directory(path.getParent()));
+        }
+        return this.parent;
+    }
+
+    private Optional<FileNode> parent;
+
+    /**
+     * Updating children is not supported.
+     */
+    @Override
+    public final FileNode setChildren(final List<FileNode> children) {
+        Objects.requireNonNull(children, "children");
+        throw new UnsupportedOperationException();
+    }
+
+    public abstract boolean isDirectory();
+
+    public abstract boolean isFile();
+
+    // attributes...........................................................................................
+
+    public final Map<FileNodeAttributeName, String> attributes() {
+        return this.attributes;
+    }
+
+    private final Map<FileNodeAttributeName, String> attributes;
+
+    /**
+     * The fixed set of available attribute names.
+     */
+    abstract Set<FileNodeAttributeName> attributeNames();
+
+    /**
+     * Update attributes is not supported.
+     */
+    @Override
+    public final FileNode setAttributes(final Map<FileNodeAttributeName, String> attributes) {
+        Objects.requireNonNull(attributes, "attributes");
+        throw new UnsupportedOperationException();
+    }
+
+    final String created() {
+        if(null == this.created && this.mustLoad(FileNodeCacheAtom.CREATED)) {
+            this.created = null;
+        }
+
+        if(null==this.created) {
+            this.basicFileAttributes();
+            this.created = this.timeToString(this.basicFileAttributes.creationTime());
+        }
+        return this.created;
+    }
+
+    private String created;
+
+    final String hidden() {
+        if(null == this.hidden && this.mustLoad(FileNodeCacheAtom.HIDDEN)) {
+            this.hidden = null;
+        }
+
+        if(null==this.hidden) {
+            try {
+                this.hidden = String.valueOf(Files.isHidden(this.path));
+                return this.hidden;
+            } catch (final IOException cause) {
+                throw exception("Failed to test whether " + this.pathToString() + " is hidden", cause);
+            }
+        }
+        return this.hidden;
+    }
+
+    private String hidden;
+
+    final String lastAccessed() {
+        if(null == this.lastAccessed && this.mustLoad(FileNodeCacheAtom.LAST_ACCESSED)) {
+            this.lastAccessed = null;
+        }
+
+        if(null==this.lastAccessed) {
+            this.basicFileAttributes();
+            this.lastAccessed = this.timeToString(this.basicFileAttributes.lastAccessTime());
+        }
+        return this.lastAccessed;
+    }
+
+    private String lastAccessed;
+
+    final String lastModified() {
+        if(null == this.lastModified && this.mustLoad(FileNodeCacheAtom.LAST_MODIFIED)) {
+            this.lastModified = null;
+        }
+
+        if(null==this.lastModified) {
+            this.basicFileAttributes();
+            this.lastModified = this.timeToString(this.basicFileAttributes.lastAccessTime());
+        }
+        return this.lastModified;
+    }
+
+    private String lastModified;
+
+    final String owner() {
+        if(null == this.owner && this.mustLoad(FileNodeCacheAtom.OWNER)) {
+            this.owner = null;
+        }
+
+        if(null==this.owner) {
+            try {
+                this.owner = this.fileAttributesView(FileOwnerAttributeView.class).getOwner().getName();
+            } catch (final IOException cause) {
+                throw exception("Failed to get owner attribute for " + pathToString(), cause);
+            }
+        }
+        return this.owner;
+    }
+
+    private String owner;
+
+    abstract String size();
+
+    abstract String text();
+
+    abstract String type();
+
+    private void basicFileAttributes() {
+        try {
+            this.basicFileAttributes = fileAttributesView(BasicFileAttributeView.class).readAttributes();
+        } catch (final IOException cause) {
+            throw exception("Failed to get created, lastAccessed, lastModified attributes for " + pathToString(), cause);
+        }
+    }
+
+    private BasicFileAttributes basicFileAttributes;
+
+    private <V extends FileAttributeView> V fileAttributesView(final Class<V> view) {
+        return Files.getFileAttributeView(this.path, view);
+    }
+
+    static FileNodeException exception(final String message, final Exception cause) {
+        return new FileNodeException(message + ", message: " + cause.getMessage(), cause);
+    }
+
+    /**
+     * Queries the context to determine if a atom belonging to the {@link FileNode} must be loaded.
+     */
+    final boolean mustLoad(final FileNodeCacheAtom atom) {
+        return this.context.mustLoad(this, atom);
+    }
+
+    final CharSequence pathToString() {
+        return CharSequences.quote(this.path.toString());
+    }
+
+    private final String timeToString(final FileTime fileTime) {
+        return ISO_FORMATTER.format(LocalDateTime.ofInstant(fileTime.toInstant(), ZoneId.systemDefault()));
+    }
+
+    private final static DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+
+    final Path path;
+    final FileNodeContext context;
+
+    // Value..........................................................................................................
+
+    /**
+     * Returns the {@link Path} for this {@link FileNode}.
+     */
+    @Override
+    public final Path value() {
+        return this.path;
+    }
+
+    // Object..........................................................................................................
+
+    @Override
+    public final int hashCode() {
+        return this.path.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+               other instanceof FileNode &&
+               this.equals0(Cast.to(other));
+    }
+
+    private boolean equals0(final FileNode other) {
+        return this.path.equals(other.path);
+    }
+
+    /**
+     * Returns the full path for this file as a {@link String}
+     */
+    @Override
+    public String toString() {
+        return this.path.toString();
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeAttributeMap.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeAttributeMap.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.Cast;
+
+import java.util.AbstractMap;
+import java.util.Set;
+
+/**
+ * A {@link java.util.Map} that holds the attributes for both files and directories.
+ */
+final class FileNodeAttributeMap<N extends FileNode> extends AbstractMap<FileNodeAttributeName, String> {
+
+    /**
+     * Ctor only called by the {@link FileNode} ctor.
+     */
+    FileNodeAttributeMap(final FileNode fileNode) {
+        this.fileNode = fileNode;
+    }
+
+    @Override
+    public boolean containsKey(final Object key) {
+        return this.keySet().contains(key);
+    }
+
+    @Override
+    public Set<Entry<FileNodeAttributeName, String>> entrySet() {
+        return new FileNodeAttributeMapEntrySet(this.fileNode);
+    }
+
+    @Override
+    public String get(final Object key) {
+        return key instanceof FileNodeAttributeName ?
+               this.get0(Cast.to(key)) :
+               null;
+    }
+
+    private String get0(final FileNodeAttributeName key) {
+        return key.read(this.fileNode);
+    }
+
+    /**
+     * An attribute map always has some names, thus is never empty.
+     */
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public final Set<FileNodeAttributeName> keySet() {
+        return this.fileNode.attributeNames();
+    }
+
+    /**
+     * Simply count the attribute names for this file node.
+     */
+    @Override
+    public int size() {
+        return this.fileNode.attributeNames().size();
+    }
+
+    @Override
+    public final int hashCode() {
+        return this.fileNode.hashCode();
+    }
+
+    private final FileNode fileNode;
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapEntrySet.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapEntrySet.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Set;
+
+/**
+ * A readonly {@link Set} view of entries belonging to the attribute Map view for a {@link FileNode}.
+ */
+final class FileNodeAttributeMapEntrySet extends AbstractSet<Entry<FileNodeAttributeName, String>> {
+
+    FileNodeAttributeMapEntrySet(final FileNode fileNode){
+        this.fileNode = fileNode;
+    }
+
+    @Override
+    public Iterator<Entry<FileNodeAttributeName, String>> iterator() {
+        return new FileNodeAttributeMapEntrySetIterator(this.fileNode);
+    }
+
+    @Override
+    public int size() {
+        return this.fileNode.attributeNames().size();
+    }
+
+    private final FileNode fileNode;
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapEntrySetIterator.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapEntrySetIterator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+/**
+ * The {@link Iterator} returned by {@link FileNodeAttributeMapEntrySet#iterator()}
+ */
+final class FileNodeAttributeMapEntrySetIterator implements Iterator<Entry<FileNodeAttributeName, String>> {
+
+    FileNodeAttributeMapEntrySetIterator(final FileNode node){
+        this.node = node;
+        this.names = node.attributeNames().iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return this.names.hasNext();
+    }
+
+    @Override
+    public Entry<FileNodeAttributeName, String> next() {
+        final FileNodeAttributeName name = this.names.next();
+        return new FileNodeAttributeMapEntrySetIteratorEntry(name, name.read(this.node));
+    }
+
+    private final Iterator<FileNodeAttributeName> names;
+    private final FileNode node;
+
+    public String toString() {
+        return this.node.toString();
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapEntrySetIteratorEntry.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapEntrySetIteratorEntry.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.Cast;
+
+import java.util.Map.Entry;
+import java.util.Objects;
+
+/**
+ * The {@link Entry} for {@link FileNodeAttributeMapEntrySetIterator}
+ */
+final class FileNodeAttributeMapEntrySetIteratorEntry implements Entry<FileNodeAttributeName, String> {
+
+    FileNodeAttributeMapEntrySetIteratorEntry(final FileNodeAttributeName key, final String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public FileNodeAttributeName getKey() {
+        return this.key;
+    }
+
+    private final FileNodeAttributeName key;
+
+    @Override
+    public String getValue() {
+        return this.value;
+    }
+
+    private final String value;
+
+    /**
+     * Attributes are immutable, therefore setValue will throw {@link UnsupportedOperationException}.
+     */
+    @Override
+    public String setValue(final String value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.key, this.value);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this ==other ||
+               other instanceof Entry &&
+               this.equals0(Cast.to(other));
+    }
+
+    private boolean equals0(final Entry<?, ?> other){
+        return this.key.equals(other.getKey()) &&
+               this.value.equals(other.getValue());
+    }
+
+    @Override
+    public String toString() {
+        return this.key + "=" + this.value;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapEntrySetIteratorEntryTest.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapEntrySetIteratorEntryTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class FileNodeAttributeMapEntrySetIteratorEntryTest extends PackagePrivateClassTestCase<FileNodeAttributeMapEntrySetIteratorEntry> {
+    @Override
+    protected Class<FileNodeAttributeMapEntrySetIteratorEntry> type() {
+        return FileNodeAttributeMapEntrySetIteratorEntry.class;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapEntrySetIteratorTest.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapEntrySetIteratorTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class FileNodeAttributeMapEntrySetIteratorTest extends PackagePrivateClassTestCase<FileNodeAttributeMapEntrySetIterator> {
+    @Override
+    protected Class<FileNodeAttributeMapEntrySetIterator> type() {
+        return FileNodeAttributeMapEntrySetIterator.class;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapEntrySetTest.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapEntrySetTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class FileNodeAttributeMapEntrySetTest extends PackagePrivateClassTestCase<FileNodeAttributeMapEntrySet> {
+    @Override
+    protected Class<FileNodeAttributeMapEntrySet> type() {
+        return FileNodeAttributeMapEntrySet.class;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapTest.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeAttributeMapTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class FileNodeAttributeMapTest extends PackagePrivateClassTestCase<FileNodeAttributeMap> {
+    @Override
+    protected Class<FileNodeAttributeMap> type() {
+        return FileNodeAttributeMap.class;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeAttributeName.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeAttributeName.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.naming.Name;
+import walkingkooka.test.HashCodeEqualsDefined;
+
+/**
+ * A file or directory name. Note case-sensitivity matches the same rules of the underlying filesystem.
+ * A directory has the following attributes: CREATED, GROUP, HIDDEN, LAST_ACCESSED, LAST_MODIFIED, OWNER, TYPE
+ * A file has the following attributes: CREATED, GROUP, HIDDEN, LAST_ACCESSED, LAST_MODIFIED, OWNER, SIZE, TEXT, TYPE
+ */
+public enum FileNodeAttributeName implements Name, Comparable<FileNodeAttributeName>, HashCodeEqualsDefined {
+
+    /**
+     * An ISO_FORMATTED timestamp of the creation, taken from {@link java.nio.file.attribute.BasicFileAttributes}
+     * {@see java.time.format.DateTimeFormatter}
+     */
+    CREATED{
+        @Override
+        String read(final FileNode node){
+            return node.created();
+        }
+    },
+
+    /**
+     * A String holding either the boolean value of true of false using {@link java.nio.file.Files#isHidden}.
+     */
+    HIDDEN{
+        @Override
+        String read(final FileNode node){
+            return node.hidden();
+        }
+    },
+
+    /**
+     * An ISO_FORMATTED timestamp of the last access, taken from {@link java.nio.file.attribute.BasicFileAttributes}
+     * {@see java.time.format.DateTimeFormatter}
+     */
+    LAST_ACCESSED{
+        @Override
+        String read(final FileNode node){
+            return node.lastAccessed();
+        }
+    },
+
+    /**
+     * An ISO_FORMATTED timestamp of the last modification, taken from {@link java.nio.file.attribute.BasicFileAttributes}
+     * {@see java.time.format.DateTimeFormatter}
+     */
+    LAST_MODIFIED{
+        @Override
+        String read(final FileNode node){
+            return node.lastModified();
+        }
+    },
+
+    /**
+     * The owner, taken from {@link java.nio.file.attribute.PosixFileAttributes}
+     */
+    OWNER{
+        @Override
+        String read(final FileNode node){
+            return node.owner();
+        }
+    },
+
+    /**
+     * The size of the file in bytes
+     * (File only attribute)
+     */
+    SIZE{
+        @Override
+        String read(final FileNode node){
+            return node.size();
+        }
+    },
+
+    /**
+     * The text attribute holds the text for a given file.
+     * (File only attribute)
+     */
+    TEXT{
+        @Override
+        String read(final FileNode node){
+            return node.text();
+        }
+    },
+
+    /**
+     * A String value that currently holds either: FILE or DIRECTORY.
+     */
+    TYPE{
+        @Override
+        String read(final FileNode node){
+            return node.type();
+        }
+    };
+
+    abstract String read(final FileNode node);
+
+    @Override
+    public final String value() {
+        return this.toString();
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeAttributeNameTest.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeAttributeNameTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.test.PublicClassTestCase;
+
+public final class FileNodeAttributeNameTest extends PublicClassTestCase<FileNodeAttributeName> {
+
+    @Override
+    protected Class<FileNodeAttributeName> type() {
+        return FileNodeAttributeName.class;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeCacheAtom.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeCacheAtom.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+/**
+ * Individual representatives of each cachable atom belonging to a {@link FileNode}.
+ */
+public enum FileNodeCacheAtom {
+    CHILDREN,
+    CREATED,
+    HIDDEN,
+    LAST_ACCESSED,
+    LAST_MODIFIED,
+    OWNER,
+    SIZE,
+    TEXT,
+    TYPE;
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeCacheAtomTest.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeCacheAtomTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import org.junit.Test;
+import walkingkooka.test.PublicClassTestCase;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+public final class FileNodeCacheAtomTest extends PublicClassTestCase<FileNodeCacheAtom> {
+
+    @Test
+    public void testAtoms() {
+        final Set<String> atoms = names(FileNodeCacheAtom.class);
+        final Set<String> names = names(FileNodeAttributeName.class);
+        names.add(FileNodeCacheAtom.CHILDREN.name());
+
+        assertEquals(atoms, names);
+    }
+
+    private Set<String> names(final Class<? extends Enum> constants) {
+        final Set<? extends Enum> all = EnumSet.allOf(constants);
+        return all.stream()
+                .map( e -> ((Enum) e).name())
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    @Override
+    protected Class<FileNodeCacheAtom> type() {
+        return FileNodeCacheAtom.class;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeContext.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeContext.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.Context;
+
+import java.nio.file.Path;
+
+/**
+ * A context that accompanies the process of reading the filesystem and creating and updating the {@link FileNode} instances
+ * created to match. Because some attributes of a file, such as the text can be costly its not ideal to constantly
+ * process the file again to get the "text" attribute so the context is responsible for controlling / clearing
+ * cached values which will then be reloaded.
+ */
+public interface FileNodeContext extends Context {
+
+    /**
+     * The root path of the file system being represented as a {@link FileNode} graph.
+     */
+    Path rootPath();
+
+    /**
+     * Factory that creates a {@link FileNode}. Implementations should use a cache of some sort matching paths to filenodes.
+     */
+    FileNode directory(final Path path);
+
+    /**
+     * Factory that creates a {@link FileNode}. Implementations should use a cache of some sort matching paths to filenodes.
+     */
+    FileNode file(final Path path);
+
+    /**
+     * This is called prior to any attribute or children being returned.
+     */
+    boolean mustLoad(final FileNode node, final FileNodeCacheAtom atom);
+
+    /**
+     * Returns the text form for the given path. This might be as simple as reading a text file, returning nothing if
+     * too many binary type characters/bytes are found, or doing something a little extra such as identifying the file to be
+     * a PDF and extracting text from that.
+     */
+    String text(final Path path) throws Exception;
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeContextTest.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeContextTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.ContextTestCase;
+
+public final class FileNodeContextTest extends ContextTestCase<FileNodeContext> {
+    @Override
+    protected FileNodeContext createContext() {
+        return null;
+    }
+
+    @Override
+    protected Class<FileNodeContext> type() {
+        return FileNodeContext.class;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeException.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.tree.NodeException;
+
+/**
+ * Used to report or wrap any exceptions thrown while performing file operations.
+ */
+public class FileNodeException extends NodeException {
+
+    protected FileNodeException() {
+        super();
+    }
+
+    public FileNodeException(final String message) {
+        super(message);
+    }
+
+    public FileNodeException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeExceptionTest.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeExceptionTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.test.PublicThrowableTestCase;
+
+public final class FileNodeExceptionTest extends PublicThrowableTestCase<FileNodeException> {
+    @Override
+    protected Class<FileNodeException> type() {
+        return FileNodeException.class;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeName.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeName.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.test.HashCodeEqualsDefined;
+import walkingkooka.text.CaseSensitivity;
+import walkingkooka.text.CharSequences;
+
+import java.io.File;
+
+/**
+ * A file or directory name. Note case-sensitivity matches the same rules of the underlying filesystem.
+ */
+public final class FileNodeName implements Name, Comparable<FileNodeName>, HashCodeEqualsDefined {
+
+    static CaseSensitivity fileSystemCaseSensitivity(){
+        final String name = "lowercase";
+        File lowercase = new File(name);
+        File uppercase = new File(name.toUpperCase());
+        return lowercase.equals(uppercase) ?
+                CaseSensitivity.INSENSITIVE :
+                CaseSensitivity.SENSITIVE;
+    }
+
+    /**
+     * Matches the file system case sensitivity. The equals and compare methods use this to do their tests.
+     */
+    private final static CaseSensitivity CASE_SENSITIVITY = fileSystemCaseSensitivity();
+
+    /**
+     * Factory that creates a new {@link FileNodeName}
+     */
+    public static FileNodeName with(final String name) {
+        CharSequences.failIfNullOrEmpty(name, "name");
+
+        return new FileNodeName(name);
+    }
+
+    private FileNodeName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String value() {
+        return this.name;
+    }
+
+    private final String name;
+
+    // Object..................................................................................................
+
+    public final int hashCode() {
+        return this.name.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+               other instanceof FileNodeName &&
+               this.equals0(Cast.to(other));
+    }
+
+    private boolean equals0(final FileNodeName other) {
+        return CASE_SENSITIVITY.equals(this.name, other.name);
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
+
+    // Comparable ...................................................................................................
+
+    @Override
+    public int compareTo(final FileNodeName other) {
+        return CASE_SENSITIVITY.comparator().compare(this.name, other.name);
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeNameTest.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeNameTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import org.junit.Test;
+import walkingkooka.naming.NameTestCase;
+
+public final class FileNodeNameTest extends NameTestCase<FileNodeName> {
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullFails() {
+        this.createName(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWithEmptyFails() {
+        this.createName("");
+    }
+
+    @Test
+    public void testWith() {
+        final String value = "abc";
+        final FileNodeName name = FileNodeName.with(value);
+        assertEquals("value", value, name.value());
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("abc", this.createName("abc").toString());
+    }
+
+    @Override
+    protected FileNodeName createName(final String name) {
+        return FileNodeName.with(name);
+    }
+
+    @Override protected Class<FileNodeName> type() {
+        return FileNodeName.class;
+    }
+}

--- a/src/main/java/walkingkooka/tree/file/FileNodeTest.java
+++ b/src/main/java/walkingkooka/tree/file/FileNodeTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.file;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.text.CharSequences;
+import walkingkooka.tree.NodeTestCase;
+import walkingkooka.tree.select.NodeSelector;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public final class FileNodeTest extends NodeTestCase<FileNode, FileNodeName, FileNodeAttributeName, String> {
+
+    private final static String SUB = "sub";
+    private final static String SUB_SUB = "subSub";
+    private final static String SUB_FILE = "subFile";
+    private final static String SUB_FILE2 = "subFile2";
+
+    private final static String CONTENT1 = "content-1";
+    private final static String CONTENT2 = "content-2";
+    private final static String DIFFERENT_CONTENT_TEXT = "DIFFERENT_CONTENT_TEXT-content-text";
+
+    @Before
+    public void createDirectoryStructure() throws IOException{
+        home = Files.createTempDirectory(FileNodeTest.class.getName() + "-");
+
+        sub = Files.createDirectory(home.resolve(SUB)); // /sub
+        subSub = Files.createDirectory(sub.resolve(SUB_SUB)); // /sub/subSub
+
+        subFile = writeFile(sub.resolve(SUB_FILE), CONTENT1);
+        subFile2 = writeFile(sub.resolve(SUB_FILE2), CONTENT2);
+
+        fileNodeToCache.clear();
+    }
+
+    private static Path writeFile(final Path file, final String text) throws IOException {
+        Files.write(file, text.getBytes(Charset.defaultCharset()));
+        return file;
+    }
+
+    @After
+    public void deleteDirectoryStructure() throws IOException{
+        Files.delete(subFile);
+        Files.delete(subFile2);
+        Files.delete(subSub);
+        Files.delete(sub);
+        Files.delete(home);
+    }
+
+    private static Path home;
+    private static Path sub;
+    private static Path subFile;
+    private static Path subFile2;
+    private static Path subSub;
+
+    /**
+     * Static so tests can clear the cache by manipulating the map when they wish.
+     */
+    static Map<Path, Map<FileNodeCacheAtom, String>> fileNodeToCache = Maps.ordered();
+
+    // Tests ...........................................................................................................
+
+    @Test
+    public void testParentOfRoot() {
+        this.checkWithoutParent(this.createNode());
+    }
+
+    @Test
+    public void testDirectoryAttributesKeySet() {
+        assertEquals(DirectoryFileNode.ATTRIBUTE_NAMES, this.createNode().attributes().keySet());
+    }
+
+    @Test
+    public void testDirectoryAttributesValues() {
+        this.checkAttributes(this.createNode(), DirectoryFileNode.ATTRIBUTE_NAMES);
+    }
+
+    @Test
+    public void testChildrenOfRoot() {
+        final FileNode root = this.createNode();
+        final List<FileNode> children = root.children();
+        assertEquals("child count=" + children, 1, children.size());
+
+        assertSame("children cached", children, root.children());
+
+        final FileNode child = root.children().get(0);
+        assertEquals("child", FileNodeName.with("sub"), child.name());
+    }
+
+    @Test
+    public void testCreatedLastAccessedModifiedAttributes() {
+        final FileNode root = this.createNode();
+
+        final String today = DateTimeFormatter.ISO_DATE.format(LocalDateTime.now());
+        checkAttributeContains(root, FileNodeAttributeName.CREATED, today);
+        checkAttributeContains(root, FileNodeAttributeName.LAST_ACCESSED, today);
+        checkAttributeContains(root, FileNodeAttributeName.LAST_MODIFIED, today);
+    }
+
+    @Test
+    public void testHidden() {
+        final FileNode root = this.createNode();
+
+        checkAttributeEquals(root, FileNodeAttributeName.HIDDEN, Boolean.FALSE.toString());
+    }
+
+    @Test
+    public void testChildrenOfGraphAndAttributes() {
+        final FileNode root = this.createNode();
+        final List<FileNode> children = root.children();
+        assertEquals("child count=" + children, 1, children.size());
+
+        assertSame("children cached", children, root.children());
+
+        final FileNode child = root.children().get(0);
+        assertEquals("child", sub(), child.name());
+
+        FileNode subSub = null;
+        FileNode subFile = null;
+        FileNode subFile2 = null;
+
+        for(FileNode subChild : child.children()) {
+            final FileNodeName name = subChild.name();
+            if(name.equals(subSub())){
+                subSub = subChild;
+                continue;
+            }
+            if(name.equals(subFile())){
+                subFile = subChild;
+                continue;
+            }
+            if(name.equals(subFile2())){
+                subFile2 = subChild;
+                continue;
+            }
+        }
+
+        assertNotNull(subSub);
+        assertNotNull(subFile);
+        assertNotNull(subFile2);
+
+        checkIsDirectoryAndIsFile(subSub, true);
+        checkIsDirectoryAndIsFile(subFile, false);
+        checkIsDirectoryAndIsFile(subFile2, false);
+
+        checkAttributeEquals(subSub, FileNodeAttributeName.TYPE, FileNode.DIRECTORY_TYPE);
+        checkAttributeEquals(subSub, FileNodeAttributeName.HIDDEN, Boolean.FALSE.toString());
+
+        checkAttributeEquals(subFile, FileNodeAttributeName.TYPE, FileNode.FILE_TYPE);
+        checkAttributeEquals(subFile2, FileNodeAttributeName.TYPE, FileNode.FILE_TYPE);
+    }
+
+    private void checkIsDirectoryAndIsFile(final FileNode node, final boolean isDirectory) {
+        assertEquals(node + " isDirectory()", node.isDirectory(), isDirectory);
+        assertEquals(node + " isFile()", node.isFile(), !isDirectory);
+    }
+
+    @Test
+    public void testFile() {
+        final FileNode subFile = this.subFileFileNode();
+        this.checkAttributeEquals(subFile, FileNodeAttributeName.SIZE, "" + CONTENT1.length());
+        this.checkAttributeEquals(subFile, FileNodeAttributeName.TEXT, CONTENT1);
+        this.checkAttributeEquals(subFile, FileNodeAttributeName.TEXT, CONTENT1);
+        this.checkAttributeEquals(subFile, FileNodeAttributeName.TEXT, CONTENT1);
+    }
+
+    @Test
+    public void testFileTextRepeatedAfterClearingCache() {
+        final FileNode subFile = this.subFileFileNode();
+        final String text = this.checkAttributeEquals(subFile, FileNodeAttributeName.TEXT, CONTENT1);
+        final String textAgain = this.checkAttributeEquals(subFile, FileNodeAttributeName.TEXT, CONTENT1);
+        assertSame("text was not cached", text, textAgain);
+    }
+
+    @Test
+    public void testFileCreatedDoesntChangeAfterWrite() throws Exception {
+        final FileNode subFile = this.subFileFileNode();
+        this.checkAttributeEquals(subFile, FileNodeAttributeName.TEXT, CONTENT1);
+
+        final String created = attribute(subFile, FileNodeAttributeName.CREATED);
+        writeFile(subFile.value(), DIFFERENT_CONTENT_TEXT);
+
+        this.checkAttributeEquals(subFile, FileNodeAttributeName.CREATED, created);
+    }
+
+    @Test
+    public void testFileAttributesKeySet() {
+        assertEquals(FileFileNode.ATTRIBUTE_NAMES, this.subFileFileNode().attributes().keySet());
+    }
+
+    @Test
+    public void testFileAttributesValues() {
+        this.checkAttributes(this.subFileFileNode(),  FileFileNode.ATTRIBUTE_NAMES);
+    }
+
+    private void checkAttributes(final FileNode node, final Set<FileNodeAttributeName> names) {
+        final Map<FileNodeAttributeName, String> read = node.attributes();
+        assertEquals("read attributes size", names.size(), read.size());
+
+        final Map<FileNodeAttributeName, String> attributes = Maps.ordered();
+        for(Entry<FileNodeAttributeName, String> nameAndValue : read.entrySet()) {
+            final FileNodeAttributeName name = nameAndValue.getKey();
+            assertNotNull("name key must not be null", name);
+            final String value = nameAndValue.getValue();
+            assertNotNull("value must not be null", value);
+
+            attributes.put(name, value);
+        }
+        attributes.putAll(read);
+
+        assertEquals("attribute values collection", toList(attributes.values()), toList(read.values()));
+    }
+
+    private static List<String> toList(final Collection<String> values) {
+        final List<String> list = Lists.array();
+        list.addAll(values);
+        return list;
+    }
+
+    @Test
+    public void testSelectorUsage() throws Exception {
+        final FileNode document = this.createNode();
+        final NodeSelector<FileNode, FileNodeName, FileNodeAttributeName, String> selector = FileNode.absoluteNodeSelectorBuilder()
+                .descendant()
+                .named(FileNodeName.with(SUB_FILE))
+                .build();
+        final Set<FileNode> matches = selector.accept(document, selector.nulObserver());
+        assertEquals("should have matched a single file\n" + matches, 1, matches.size());
+    }
+
+    private FileNode subFileFileNode() {
+        final FileNode root = this.createNode();
+        final FileNode sub = root.children().get(0);
+        for(FileNode subChild : sub.children()) {
+            final FileNodeName name = subChild.name();
+            if(name.equals(subFile())){
+                return subChild;
+            }
+        }
+        fail("didnt find " + SUB_FILE);
+        return null;
+    }
+
+    private FileNodeName sub() {
+        return FileNodeName.with(SUB);
+    }
+
+    private FileNodeName subSub() {
+        return FileNodeName.with(SUB_SUB);
+    }
+
+    private FileNodeName subFile() {
+        return FileNodeName.with(SUB_FILE);
+    }
+
+    private FileNodeName subFile2() {
+        return FileNodeName.with(SUB_FILE2);
+    }
+
+    private String attribute(final FileNode node, final FileNodeAttributeName attribute) {
+        return node.attributes().get(attribute);
+    }
+
+    private String checkAttributeEquals(final FileNode node, final FileNodeAttributeName attribute, final String value) {
+        final String actual = node.attributes().get(attribute);
+        assertEquals(node.value().getFileName() + "." + attribute, value, actual);
+        return actual;
+    }
+
+    private String checkAttributeContains(final FileNode node, final FileNodeAttributeName attribute, final String value) {
+        final String actual = node.attributes().get(attribute);
+        assertTrue(node.value().getFileName() + "." + attribute + "=" + CharSequences.quote(actual) + " doesnt contain " + CharSequences.quote(value), actual.contains(value));
+        return actual;
+    }
+
+    // Helpers ...........................................................................................................
+
+    @Override
+    protected FileNode createNode() {
+        return FileNode.directory(home, new FileNodeContext() {
+
+            private Map<Path, FileNode> pathToFileNode = Maps.ordered();
+
+            @Override
+            public Path rootPath() {
+                return home;
+            }
+
+            @Override
+            public FileNode directory(final Path path) {
+                FileNode node = pathToFileNode.get(path);
+                if(null == node) {
+                    node = FileNode.directory(path, this);
+                    pathToFileNode.put(path, node);
+                }
+                return node;
+            }
+
+            @Override
+            public FileNode file(final Path path) {
+                FileNode node = pathToFileNode.get(path);
+                if(null == node) {
+                    node = FileNode.file(path, this);
+                    pathToFileNode.put(path, node);
+                }
+                return node;
+            }
+
+            @Override
+            public boolean mustLoad(final FileNode node, final FileNodeCacheAtom atom) {
+                final Path path = node.value();
+                Map<FileNodeCacheAtom, String> fileNodeCache = fileNodeToCache.get(path);
+                if(null == fileNodeCache) {
+                    fileNodeCache = Maps.hash();
+                    fileNodeToCache.put(path, fileNodeCache);
+                }
+
+                return fileNodeCache.containsKey(atom);
+            }
+
+            // just read the text for the path.
+            @Override
+            public String text(final Path path) throws IOException{
+                final char[] buffer = new char[4096];
+                final StringBuilder text = new StringBuilder();
+                try(final Reader reader = new InputStreamReader(new FileInputStream(path.toFile()))){
+                    for(;;) {
+                        final int read = reader.read(buffer);
+                        if (-1 == read) {
+                            break;
+                        }
+                        text.append(buffer, 0, read);
+                    }
+                }
+                return text.toString();
+            }
+        });
+    }
+
+    @Override
+    protected Class<FileNode> type() {
+        return FileNode.class;
+    }
+}


### PR DESCRIPTION
- Implementing FileNodeContext supports factory methods to
-- create/reuse a file node
-- create/reuse a directory node
-- control caching of file/dir attributes and children.