### PR TITLE
SpreadsheetParserToken.toExtensionNode()

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCell.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCell.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.spreadsheet;
+
+import walkingkooka.Cast;
+import walkingkooka.test.HashCodeEqualsDefined;
+import walkingkooka.tree.expression.ExpressionReference;
+
+import java.util.Objects;
+
+/**
+ * A reference that includes a defined name or column and row.
+ */
+public final class SpreadsheetCell implements HashCodeEqualsDefined, ExpressionReference {
+
+    public static SpreadsheetCell with(final SpreadsheetColumn column, final SpreadsheetRow row){
+        Objects.requireNonNull(column, "column");
+        Objects.requireNonNull(row, "row");
+
+        return new SpreadsheetCell(column, row);
+    }
+
+    private SpreadsheetCell(final SpreadsheetColumn column, final SpreadsheetRow row){
+        super();
+        this.column = column;
+        this.row = row;
+    }
+
+    public SpreadsheetRow row() {
+        return this.row;
+    }
+
+    private final SpreadsheetRow row;
+
+    public SpreadsheetColumn column() {
+        return this.column;
+    }
+
+    private final SpreadsheetColumn column;
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.column, this.row);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+               other instanceof SpreadsheetCell &&
+               this.equals0(Cast.to(other));
+    }
+
+    private boolean equals0(final SpreadsheetCell other) {
+        return this.column.equals(other.column) &&
+               this.row.equals(other.row);
+    }
+
+    public String toString() {
+        return "" + this.column + this.row;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellParserToken.java
@@ -49,28 +49,20 @@ public final class SpreadsheetCellParserToken extends SpreadsheetParentParserTok
 
         return new SpreadsheetCellParserToken(copy,
                 checkText(text),
-                row.value(),
-                column.value(),
+                SpreadsheetCell.with(column.value(), row.value()),
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetCellParserToken(final List<ParserToken> value, final String text, final SpreadsheetRow row, final SpreadsheetColumn column, final boolean computeWithout){
+    private SpreadsheetCellParserToken(final List<ParserToken> value, final String text, final SpreadsheetCell cell, final boolean computeWithout){
         super(value, text, computeWithout);
-        this.row = row;
-        this.column = column;
+        this.cell = cell;
     }
 
-    public SpreadsheetRow row() {
-        return this.row;
+    public SpreadsheetCell cell() {
+        return this.cell;
     }
 
-    private final SpreadsheetRow row;
-
-    public SpreadsheetColumn column() {
-        return this.column;
-    }
-
-    private final SpreadsheetColumn column;
+    private final SpreadsheetCell cell;
 
     @Override
     public SpreadsheetCellParserToken setText(final String text) {
@@ -79,12 +71,12 @@ public final class SpreadsheetCellParserToken extends SpreadsheetParentParserTok
 
     @Override
     SpreadsheetCellParserToken replaceText(final String text) {
-        return new SpreadsheetCellParserToken(this.value, text, this.row, this.column, WITHOUT_USE_THIS);
+        return new SpreadsheetCellParserToken(this.value, text, this.cell, WITHOUT_USE_THIS);
     }
 
     @Override
     SpreadsheetParentParserToken replaceTokens(final List<ParserToken> tokens) {
-        return new SpreadsheetCellParserToken(tokens, this.text(), this.row, this.column, WITHOUT_USE_THIS);
+        return new SpreadsheetCellParserToken(tokens, this.text(), this.cell, WITHOUT_USE_THIS);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLabelName.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLabelName.java
@@ -24,6 +24,7 @@ import walkingkooka.predicate.character.CharPredicate;
 import walkingkooka.predicate.character.CharPredicates;
 import walkingkooka.test.HashCodeEqualsDefined;
 import walkingkooka.text.CharSequences;
+import walkingkooka.tree.expression.ExpressionReference;
 
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -36,7 +37,7 @@ import java.util.function.Predicate;
  * For example, the name AB11 is invalid because AB11 is a valid cell reference. Names are not case sensitive.
  * </pre>
  */
-final public class SpreadsheetLabelName implements Name, HashCodeEqualsDefined, Comparable<SpreadsheetLabelName> {
+final public class SpreadsheetLabelName implements Name, HashCodeEqualsDefined, Comparable<SpreadsheetLabelName>, ExpressionReference {
 
     private final static CharPredicate LETTER = CharPredicates.range('A', 'Z').or(CharPredicates.range('a', 'z'));
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserToken.java
@@ -23,6 +23,8 @@ import walkingkooka.text.Whitespace;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 import walkingkooka.text.cursor.parser.ParserTokenVisitor;
+import walkingkooka.tree.expression.ExpressionNode;
+import walkingkooka.tree.expression.HasExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 import java.math.BigDecimal;
@@ -34,7 +36,7 @@ import java.util.Optional;
 /**
  * Represents a token within the grammar.
  */
-public abstract class SpreadsheetParserToken implements ParserToken {
+public abstract class SpreadsheetParserToken implements ParserToken, HasExpressionNode {
 
     /**
      * Factory used by all sub classes to create their {@link ParserTokenNodeName} constants.
@@ -640,6 +642,15 @@ public abstract class SpreadsheetParserToken implements ParserToken {
     }
 
     abstract public void accept(final SpreadsheetParserTokenVisitor visitor);
+
+    // Has
+
+    /**
+     * Converts this token to its {@link ExpressionNode} equivalent.
+     */
+    public final Optional<ExpressionNode> expressionNode() {
+        return SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor.accept(this);
+    }
 
     // Object ...........................................................................................................
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.spreadsheet;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.stack.Stack;
+import walkingkooka.collect.stack.Stacks;
+import walkingkooka.tree.expression.ExpressionNode;
+import walkingkooka.tree.expression.ExpressionNodeName;
+import walkingkooka.tree.expression.ExpressionReference;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * A {@link SpreadsheetParserTokenVisitor} that a {@link SpreadsheetParserToken} into its {@link ExpressionNode}.
+ */
+final class SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVisitor {
+
+    static Optional<ExpressionNode> accept(final SpreadsheetParserToken token) {
+        final SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor visitor = new SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor();
+        token.accept(visitor);
+
+        final List<ExpressionNode> nodes = visitor.children;
+        final int count = nodes.size();
+        return count == 1 ?
+                Optional.of(nodes.get(0)) :
+                count == 0 ?
+                Optional.empty() :
+                fail(count, nodes);
+    }
+
+    private static Optional<ExpressionNode> fail(final int count, final List<ExpressionNode> nodes){
+        throw new SpreadsheetParserException("Expected either 0 or 1 ExpressionNodes but got " + count + "=" + nodes);
+    }
+
+    // @VisibleForTesting
+    SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor(){
+        super();
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetAdditionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetAdditionParserToken token) {
+        this.exitBinary(ExpressionNode::addition, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetCellParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetCellParserToken token) {
+        this.exitReference(token.cell(), token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetDivisionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetDivisionParserToken token) {
+        this.exitBinary(ExpressionNode::division, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetEqualsParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetEqualsParserToken token) {
+        this.exitBinary(ExpressionNode::equalsNode, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetFunctionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetFunctionParserToken token) {
+        final ExpressionNode function = ExpressionNode.function(
+                ExpressionNodeName.with(token.functionName().value()),
+                this.children);
+        this.exit();
+        this.add(function, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetGreaterThanParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetGreaterThanParserToken token) {
+        this.exitBinary(ExpressionNode::greaterThan, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetGreaterThanEqualsParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetGreaterThanEqualsParserToken token) {
+        this.exitBinary(ExpressionNode::greaterThanEquals, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetGroupParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetGroupParserToken token) {
+        this.exitUnary(ExpressionNode::group, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetLessThanParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetLessThanParserToken token) {
+        this.exitBinary(ExpressionNode::lessThan, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetLessThanEqualsParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetLessThanEqualsParserToken token) {
+        this.exitBinary(ExpressionNode::lessThanEquals, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetMultiplicationParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetMultiplicationParserToken token) {
+        this.exitBinary(ExpressionNode::multiplication, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetNegativeParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetNegativeParserToken token) {
+        this.exitUnary(ExpressionNode::negative, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetNotEqualsParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetNotEqualsParserToken token) {
+        this.exitBinary(ExpressionNode::notEquals, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetPercentageParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    /**
+     * Replace the percentage and value with a multiply value by 100.
+     */
+    @Override
+    protected void endVisit(final SpreadsheetPercentageParserToken token) {
+        final ExpressionNode parameter = this.children.get(0);
+        this.exit();
+        this.add(ExpressionNode.multiplication(parameter, ExpressionNode.number(100L)), token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetPowerParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetPowerParserToken token) {
+        this.exitBinary(ExpressionNode::power, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetRangeParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetRangeParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Visiting startVisit(final SpreadsheetSubtractionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetSubtractionParserToken token) {
+        this.exitBinary(ExpressionNode::subtraction, token);
+    }
+
+    // visit....................................................................................................
+    // ignore all SymbolParserTokens, dont bother to collect them.
+
+    @Override
+    protected void visit(final SpreadsheetDecimalParserToken token) {
+        this.add(ExpressionNode.number(token.value()), token);
+    }
+
+    @Override
+    protected void visit(final SpreadsheetDoubleParserToken token) {
+        this.add(ExpressionNode.number(token.value()), token);
+    }
+
+    @Override
+    protected void visit(final SpreadsheetLabelNameParserToken token) {
+        this.exitReference(token.value(), token);
+    }
+
+    @Override
+    protected void visit(final SpreadsheetLongParserToken token) {
+        this.add(ExpressionNode.number(token.value()), token);
+    }
+
+    @Override
+    protected void visit(final SpreadsheetNumberParserToken token) {
+        this.add(ExpressionNode.number(token.value()), token);
+    }
+
+    @Override
+    protected void visit(final SpreadsheetTextParserToken token) {
+        this.add(ExpressionNode.text(token.value()), token);
+    }
+
+    // GENERAL PURPOSE .................................................................................................
+
+    private void enter() {
+        this.previousChildren = this.previousChildren.push(this.children);
+        this.children = Lists.array();
+    }
+
+    private void exitBinary(final BiFunction<ExpressionNode, ExpressionNode, ExpressionNode> factory, final SpreadsheetParserToken token) {
+        final ExpressionNode left = this.children.get(0);
+        final ExpressionNode right = this.children.get(1);
+        this.exit();
+        this.add(factory.apply(left,right), token);
+    }
+
+    private void exitUnary(final Function<ExpressionNode, ExpressionNode> factory, final SpreadsheetParserToken token) {
+        final ExpressionNode parameter = this.children.get(0);
+        this.exit();
+        this.add(factory.apply(parameter), token);
+    }
+
+    private void exit() {
+        this.children = this.previousChildren.peek();
+        this.previousChildren = this.previousChildren.pop();
+    }
+
+    private void exitReference(final ExpressionReference reference, final SpreadsheetParserToken token) {
+        final ExpressionNode node = ExpressionNode.reference(reference);
+        this.exit();
+        this.add(node, token);
+    }
+
+    private void add(final ExpressionNode node, final SpreadsheetParserToken token) {
+        if (null == node) {
+            throw new NullPointerException("Null node returned for " + token);
+        }
+        this.children.add(node);
+    }
+
+    private Stack<List<ExpressionNode>> previousChildren = Stacks.arrayList();
+
+    private List<ExpressionNode> children = Lists.array();
+
+    public String toString() {
+        return this.children + "," + this.previousChildren;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenVisitorTestCase.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenVisitorTestCase.java
@@ -18,15 +18,7 @@
 
 package walkingkooka.text.cursor.parser.spreadsheet;
 
-public final class SpreadsheetParserTokenVisitorTest extends SpreadsheetParserTokenVisitorTestCase<FakeSpreadsheetParserTokenVisitor> {
+import walkingkooka.text.cursor.parser.ParserTokenVisitorTestCase;
 
-    @Override
-    protected FakeSpreadsheetParserTokenVisitor createParserTokenVisitor() {
-        return new FakeSpreadsheetParserTokenVisitor();
-    }
-
-    @Override
-    protected Class<FakeSpreadsheetParserTokenVisitor> parserTokenVisitorType() {
-        return FakeSpreadsheetParserTokenVisitor.class;
-    }
+public abstract class SpreadsheetParserTokenVisitorTestCase<V extends SpreadsheetParserTokenVisitor> extends ParserTokenVisitorTestCase<V, SpreadsheetParserToken> {
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNode.java
@@ -168,6 +168,13 @@ public abstract class ExpressionNode implements Node<ExpressionNode, ExpressionN
     }
 
     /**
+     * {@see ExpressionReferenceNode}
+     */
+    public static ExpressionReferenceNode reference(final ExpressionReference reference){
+        return ExpressionReferenceNode.with(reference);
+    }
+
+    /**
      * {@see ExpressionSubtractionNode}
      */
     public static ExpressionSubtractionNode subtraction(final ExpressionNode left, final ExpressionNode right){

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNodeName.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNodeName.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  */
 public final class ExpressionNodeName implements Name, Comparable<ExpressionNodeName>, HashCodeEqualsDefined {
 
-    static ExpressionNodeName with(final String name) {
+    public static ExpressionNodeName with(final String name) {
         Objects.requireNonNull(name, "name");
         return new ExpressionNodeName(name);
     }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionReferenceNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionReferenceNode.java
@@ -18,6 +18,8 @@
 
 package walkingkooka.tree.expression;
 
+import java.util.Objects;
+
 /**
  * A reference expression.
  */
@@ -25,7 +27,13 @@ public final class ExpressionReferenceNode extends ExpressionLeafValueNode<Expre
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionReferenceNode.class);
 
-    ExpressionReferenceNode(final int index, final ExpressionReference reference){
+    static ExpressionReferenceNode with(final ExpressionReference reference){
+        Objects.requireNonNull(reference, "reference");
+
+        return new ExpressionReferenceNode(NO_PARENT_INDEX, reference);
+    }
+
+    private ExpressionReferenceNode(final int index, final ExpressionReference reference){
         super(index, reference);
     }
 

--- a/src/main/java/walkingkooka/tree/expression/HasExpressionNode.java
+++ b/src/main/java/walkingkooka/tree/expression/HasExpressionNode.java
@@ -16,17 +16,18 @@
  *
  */
 
-package walkingkooka.text.cursor.parser.spreadsheet;
+package walkingkooka.tree.expression;
 
-public final class SpreadsheetParserTokenVisitorTest extends SpreadsheetParserTokenVisitorTestCase<FakeSpreadsheetParserTokenVisitor> {
+import java.util.Optional;
 
-    @Override
-    protected FakeSpreadsheetParserTokenVisitor createParserTokenVisitor() {
-        return new FakeSpreadsheetParserTokenVisitor();
-    }
+/**
+ * An interface that contains a method supporting converting an instance to a {@link ExpressionNode}.
+ */
+public interface HasExpressionNode {
 
-    @Override
-    protected Class<FakeSpreadsheetParserTokenVisitor> parserTokenVisitorType() {
-        return FakeSpreadsheetParserTokenVisitor.class;
-    }
+    /**
+     * Converts this instance to its {@link ExpressionNode} equivalent or returns empty. Empty is usually returned for
+     * worthless tokens such as whitespace.
+     */
+    Optional<ExpressionNode> expressionNode();
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetAdditionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetAdditionParserTokenTest.java
@@ -21,6 +21,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -109,6 +110,11 @@ public final class SpreadsheetAdditionParserTokenTest extends SpreadsheetBinaryP
     @Override
     SpreadsheetParserToken operatorSymbol() {
         return SpreadsheetParserToken.plusSymbol("+", "+");
+    }
+
+    @Override
+    ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right){
+        return ExpressionNode.addition(left, right);
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBetweenSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBetweenSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetBetweenSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetBetweenSymbolParserToken, String> {
+public final class SpreadsheetBetweenSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetBetweenSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserTokenTestCase2.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserTokenTestCase2.java
@@ -18,17 +18,37 @@
 
 package walkingkooka.text.cursor.parser.spreadsheet;
 
+import org.junit.Test;
+import walkingkooka.tree.expression.ExpressionNode;
+
 import java.math.BigInteger;
 
 public abstract class SpreadsheetBinaryParserTokenTestCase2<T extends SpreadsheetBinaryParserToken> extends SpreadsheetBinaryParserTokenTestCase<T> {
 
+    @Test
+    public final void testToExpressionNode() {
+        this.toExpressionNodeAndCheck(this.expressionNode(
+                ExpressionNode.number(leftBigInteger()),
+                ExpressionNode.number(rightBigInteger())));
+    }
+
+    abstract ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right);
+
     @Override
     final SpreadsheetParserToken leftToken() {
-        return SpreadsheetParserToken.number(BigInteger.valueOf(1), "1");
+        return SpreadsheetParserToken.number(leftBigInteger(), "1");
+    }
+
+    private BigInteger leftBigInteger() {
+        return BigInteger.valueOf(1);
     }
 
     @Override
     final SpreadsheetParserToken rightToken() {
-        return SpreadsheetParserToken.number(BigInteger.valueOf(22), "22");
+        return SpreadsheetParserToken.number(rightBigInteger(), "22");
+    }
+
+    private BigInteger rightBigInteger() {
+        return BigInteger.valueOf(22);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellEqualityTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellEqualityTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.spreadsheet;
+
+import org.junit.Test;
+import walkingkooka.test.HashCodeEqualsDefinedEqualityTestCase;
+
+public final class SpreadsheetCellEqualityTest extends HashCodeEqualsDefinedEqualityTestCase<SpreadsheetCell> {
+
+    private final static int COLUMN = 12;
+    private final static int ROW = 34;
+
+    @Test
+    public void testDifferentColumn() {
+        this.checkNotEquals(this.createSpreadsheetCell(COLUMN + 100, ROW));
+    }
+
+    @Test
+    public void testDifferentRow() {
+        this.checkNotEquals(this.createSpreadsheetCell(COLUMN, ROW + 100));
+    }
+
+    @Override
+    protected SpreadsheetCell createObject() {
+        return this.createSpreadsheetCell(COLUMN, ROW);
+    }
+
+    private  SpreadsheetCell createSpreadsheetCell(final int column, final int row) {
+        return SpreadsheetCell.with(
+                SpreadsheetColumn.with(column, SpreadsheetReferenceKind.RELATIVE),
+                SpreadsheetRow.with(row, SpreadsheetReferenceKind.RELATIVE));
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellParserTokenTest.java
@@ -21,6 +21,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 
 import java.util.List;
 
@@ -54,8 +55,14 @@ public final class SpreadsheetCellParserTokenTest extends SpreadsheetParentParse
         final SpreadsheetCellParserToken cell = this.createToken(text, row, column);
         this.checkText(cell, text);
         this.checkValue(cell, row, column);
+        assertEquals("cell", SpreadsheetCell.with(column.value(), row.value()), cell.cell());
 
         assertSame(cell, cell.withoutSymbolsOrWhitespace());
+    }
+
+    @Test
+    public void testToExpressionNode() {
+        this.toExpressionNodeAndCheck(ExpressionNode.reference(SpreadsheetCell.with(column().value(), row().value())));
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.spreadsheet;
+
+import org.junit.Test;
+import walkingkooka.test.HashCodeEqualsDefinedTestCase;
+
+public final class SpreadsheetCellTest extends HashCodeEqualsDefinedTestCase<SpreadsheetCell> {
+    
+    @Test(expected = NullPointerException.class)
+    public void testWithNullColumnFails() {
+        SpreadsheetCell.with(null, row());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullRowFails() {
+        SpreadsheetCell.with(column(), null);
+    }
+
+    @Test
+    public void testWith() {
+        final SpreadsheetColumn column = this.column();
+        final SpreadsheetRow row = this.row();
+        final SpreadsheetCell cell = SpreadsheetCell.with(column, row);
+        assertSame("column", column(), cell.column());
+        assertSame("row", row(), cell.row());
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("$M$35", this.create().toString());
+    }
+
+    private SpreadsheetCell create() {
+        return SpreadsheetCell.with(column(), row());
+    }
+    
+    private SpreadsheetColumn column() {
+        return SpreadsheetColumn.with(12, SpreadsheetReferenceKind.ABSOLUTE);
+    }
+
+    private SpreadsheetRow row() {
+        return SpreadsheetRow.with(34, SpreadsheetReferenceKind.ABSOLUTE);
+    }
+    
+    @Override
+    protected Class<SpreadsheetCell> type() {
+        return SpreadsheetCell.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCloseParenthesisSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCloseParenthesisSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetCloseParenthesisSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetCloseParenthesisSymbolParserToken, String> {
+public final class SpreadsheetCloseParenthesisSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetCloseParenthesisSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDivideSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDivideSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetDivideSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetDivideSymbolParserToken, String> {
+public final class SpreadsheetDivideSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetDivideSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDivisionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDivisionParserTokenTest.java
@@ -21,6 +21,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -109,6 +110,11 @@ public final class SpreadsheetDivisionParserTokenTest extends SpreadsheetBinaryP
     @Override
     SpreadsheetParserToken operatorSymbol() {
         return SpreadsheetParserToken.divideSymbol("/", "/");
+    }
+
+    @Override
+    ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right){
+        return ExpressionNode.division(left, right);
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetEqualsParserTokenTest.java
@@ -21,6 +21,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -109,6 +110,11 @@ public final class SpreadsheetEqualsParserTokenTest extends SpreadsheetBinaryPar
     @Override
     SpreadsheetParserToken operatorSymbol() {
         return SpreadsheetParserToken.equalsSymbol("==", "==");
+    }
+
+    @Override
+    ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right){
+        return ExpressionNode.equalsNode(left, right);
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetEqualsSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetEqualsSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetEqualsSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetEqualsSymbolParserToken, String> {
+public final class SpreadsheetEqualsSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetEqualsSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionNameParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionNameParserTokenTest.java
@@ -64,6 +64,11 @@ public final class SpreadsheetFunctionNameParserTokenTest extends SpreadsheetLea
         assertEquals("13542", b.toString());
     }
 
+    @Test
+    public void testToExpressionNode() {
+        this.toExpressionNodeAndFail();
+    }
+
     @Override
     String text() {
         return "sum";

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParameterSeparatorSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParameterSeparatorSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetFunctionParameterSeparatorSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetFunctionParameterSeparatorSymbolParserToken, String> {
+public final class SpreadsheetFunctionParameterSeparatorSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetFunctionParameterSeparatorSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParserTokenTest.java
@@ -22,7 +22,10 @@ import org.junit.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
+import walkingkooka.tree.expression.ExpressionNodeName;
 
+import java.math.BigInteger;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
@@ -91,6 +94,13 @@ public final class SpreadsheetFunctionParserTokenTest extends SpreadsheetParentP
         this.checkValue(token2, name, number);
         this.checkFunction(token, this.functionName());
         this.checkParameters(token, number);
+    }
+
+    @Test
+    public void testToExpressionNode() {
+        this.toExpressionNodeAndCheck(ExpressionNode.function(
+                ExpressionNodeName.with(FUNCTION),
+                Lists.of(ExpressionNode.number(new BigInteger(NUMBER1, 10)))));
     }
 
     private void checkFunction(final SpreadsheetFunctionParserToken function, final SpreadsheetFunctionName name) {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanEqualsParserTokenTest.java
@@ -21,6 +21,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -109,6 +110,11 @@ public final class SpreadsheetGreaterThanEqualsParserTokenTest extends Spreadshe
     @Override
     SpreadsheetParserToken operatorSymbol() {
         return SpreadsheetParserToken.greaterThanEqualsSymbol(">=", ">=");
+    }
+
+    @Override
+    ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right){
+        return ExpressionNode.greaterThanEquals(left, right);
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanEqualsSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanEqualsSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetGreaterThanEqualsSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetGreaterThanEqualsSymbolParserToken, String> {
+public final class SpreadsheetGreaterThanEqualsSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetGreaterThanEqualsSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanParserTokenTest.java
@@ -21,6 +21,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -109,6 +110,11 @@ public final class SpreadsheetGreaterThanParserTokenTest extends SpreadsheetBina
     @Override
     SpreadsheetParserToken operatorSymbol() {
         return SpreadsheetParserToken.greaterThanSymbol(">", ">");
+    }
+
+    @Override
+    ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right){
+        return ExpressionNode.greaterThan(left, right);
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetGreaterThanSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetGreaterThanSymbolParserToken, String> {
+public final class SpreadsheetGreaterThanSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetGreaterThanSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGroupParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGroupParserTokenTest.java
@@ -22,7 +22,9 @@ import org.junit.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 
+import java.math.BigInteger;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
@@ -83,6 +85,11 @@ public final class SpreadsheetGroupParserTokenTest extends SpreadsheetParentPars
         assertNotSame(token, token2);
         this.checkText(token2, text);
         this.checkValue(token2, number);
+    }
+
+    @Test
+    public void testToExpressionNode() {
+        this.toExpressionNodeAndCheck(ExpressionNode.group(ExpressionNode.number(new BigInteger(NUMBER1, 10))));
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanEqualsParserTokenTest.java
@@ -21,6 +21,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -109,6 +110,11 @@ public final class SpreadsheetLessThanEqualsParserTokenTest extends SpreadsheetB
     @Override
     SpreadsheetParserToken operatorSymbol() {
         return SpreadsheetParserToken.lessThanEqualsSymbol("<=", "<=");
+    }
+
+    @Override
+    ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right){
+        return ExpressionNode.lessThanEquals(left, right);
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanEqualsSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanEqualsSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetLessThanEqualsSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetLessThanEqualsSymbolParserToken, String> {
+public final class SpreadsheetLessThanEqualsSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetLessThanEqualsSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanParserTokenTest.java
@@ -21,6 +21,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -109,6 +110,11 @@ public final class SpreadsheetLessThanParserTokenTest extends SpreadsheetBinaryP
     @Override
     SpreadsheetParserToken operatorSymbol() {
         return SpreadsheetParserToken.lessThanSymbol("<", "<");
+    }
+
+    @Override
+    ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right){
+        return ExpressionNode.lessThan(left, right);
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetLessThanSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetLessThanSymbolParserToken, String> {
+public final class SpreadsheetLessThanSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetLessThanSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetMinusSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetMinusSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetMinusSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetMinusSymbolParserToken, String> {
+public final class SpreadsheetMinusSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetMinusSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetMultiplicationParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetMultiplicationParserTokenTest.java
@@ -19,6 +19,7 @@
 package walkingkooka.text.cursor.parser.spreadsheet;
 
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 
 import java.util.List;
 
@@ -32,6 +33,11 @@ public final class SpreadsheetMultiplicationParserTokenTest extends SpreadsheetB
     @Override
     SpreadsheetParserToken operatorSymbol() {
         return SpreadsheetParserToken.multiplySymbol("*", "*");
+    }
+
+    @Override
+    ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right){
+        return ExpressionNode.multiplication(left, right);
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetMultiplySymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetMultiplySymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetMultiplySymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetMultiplySymbolParserToken, String> {
+public final class SpreadsheetMultiplySymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetMultiplySymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNegativeParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNegativeParserTokenTest.java
@@ -21,8 +21,10 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
+import java.math.BigInteger;
 import java.util.List;
 
 public final class SpreadsheetNegativeParserTokenTest extends SpreadsheetUnaryParserTokenTestCase<SpreadsheetNegativeParserToken> {
@@ -97,6 +99,11 @@ public final class SpreadsheetNegativeParserTokenTest extends SpreadsheetUnaryPa
                         parameter, parameter, parameter, parameter, parameter,
                         unary, unary, unary),
                 visited);
+    }
+
+    @Test
+    public final void testToExpressionNode() {
+        this.toExpressionNodeAndCheck(ExpressionNode.negative(ExpressionNode.number(new BigInteger(NUMBER1, 10))));
     }
     
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNotEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNotEqualsParserTokenTest.java
@@ -21,6 +21,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -109,6 +110,11 @@ public final class SpreadsheetNotEqualsParserTokenTest extends SpreadsheetBinary
     @Override
     SpreadsheetParserToken operatorSymbol() {
         return SpreadsheetParserToken.notEqualsSymbol("!=", "!=");
+    }
+
+    @Override
+    ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right){
+        return ExpressionNode.notEquals(left, right);
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNotEqualsSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNotEqualsSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetNotEqualsSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetNotEqualsSymbolParserToken, String> {
+public final class SpreadsheetNotEqualsSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetNotEqualsSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNumericParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNumericParserTokenTestCase.java
@@ -18,5 +18,13 @@
 
 package walkingkooka.text.cursor.parser.spreadsheet;
 
-public abstract class SpreadsheetNumericParserTokenTestCase<T extends SpreadsheetNumericParserToken, V> extends SpreadsheetLeafParserTokenTestCase<T, V> {
+import org.junit.Test;
+import walkingkooka.tree.expression.ExpressionNode;
+
+public abstract class SpreadsheetNumericParserTokenTestCase<T extends SpreadsheetNumericParserToken, V extends Number> extends SpreadsheetLeafParserTokenTestCase<T, V> {
+
+    @Test
+    public final void testToExpressionNode() {
+        this.toExpressionNodeAndCheck(ExpressionNode.number(this.value()));
+    }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetOpenParenthesisSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetOpenParenthesisSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetOpenParenthesisSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetOpenParenthesisSymbolParserToken, String> {
+public final class SpreadsheetOpenParenthesisSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetOpenParenthesisSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenTestCase.java
@@ -21,9 +21,13 @@ import org.junit.Test;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenTestCase;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.type.MethodAttributes;
 
 import java.lang.reflect.Method;
+import java.util.Optional;
+
+import static org.junit.Assert.assertNotNull;
 
 public abstract class SpreadsheetParserTokenTestCase<T extends SpreadsheetParserToken> extends ParserTokenTestCase<T> {
 
@@ -93,4 +97,25 @@ public abstract class SpreadsheetParserTokenTestCase<T extends SpreadsheetParser
     abstract T createToken(final String text);
 
     abstract String text();
+
+    final void toExpressionNodeAndFail() {
+        this.toExpressionNodeAndFail(this.createToken());
+    }
+
+    final void toExpressionNodeAndFail(final T token) {
+        final Optional<ExpressionNode> node = token.expressionNode();
+        assertEquals("toExpressionNode", Optional.empty(), node);
+    }
+
+    final void toExpressionNodeAndCheck(final ExpressionNode expected) {
+        this.toExpressionNodeAndCheck(this.createToken(), expected);
+    }
+
+    final void toExpressionNodeAndCheck(final T token, final ExpressionNode expected) {
+        assertNotNull( "token", token);
+        assertNotNull( "expected", expected);
+
+        final Optional<ExpressionNode> node = this.createToken().expressionNode();
+        assertEquals("toExpressionNode", Optional.of(expected), node);
+    }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitorTest.java
@@ -18,15 +18,14 @@
 
 package walkingkooka.text.cursor.parser.spreadsheet;
 
-public final class SpreadsheetParserTokenVisitorTest extends SpreadsheetParserTokenVisitorTestCase<FakeSpreadsheetParserTokenVisitor> {
-
+public final class SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitorTest extends SpreadsheetParserTokenVisitorTestCase<SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor> {
     @Override
-    protected FakeSpreadsheetParserTokenVisitor createParserTokenVisitor() {
-        return new FakeSpreadsheetParserTokenVisitor();
+    protected SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor createParserTokenVisitor() {
+        return new SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor();
     }
 
     @Override
-    protected Class<FakeSpreadsheetParserTokenVisitor> parserTokenVisitorType() {
-        return FakeSpreadsheetParserTokenVisitor.class;
+    protected Class<SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor> parserTokenVisitorType() {
+        return SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor.class;
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPercentSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPercentSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetPercentSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetPercentSymbolParserToken, String> {
+public final class SpreadsheetPercentSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetPercentSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPercentageParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPercentageParserTokenTest.java
@@ -21,8 +21,10 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
+import java.math.BigInteger;
 import java.util.List;
 
 public final class SpreadsheetPercentageParserTokenTest extends SpreadsheetUnaryParserTokenTestCase<SpreadsheetPercentageParserToken> {
@@ -97,6 +99,12 @@ public final class SpreadsheetPercentageParserTokenTest extends SpreadsheetUnary
                         symbol, symbol, symbol, symbol, symbol,
                         unary, unary, unary),
                 visited);
+    }
+
+    @Test
+    public final void testToExpressionNode() {
+        this.toExpressionNodeAndCheck(ExpressionNode.multiplication(ExpressionNode.number(new BigInteger(NUMBER1)),
+                ExpressionNode.number(100L)));
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPlusSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPlusSymbolParserTokenTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
-public final class SpreadsheetPlusSymbolParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetPlusSymbolParserToken, String> {
+public final class SpreadsheetPlusSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetPlusSymbolParserToken> {
 
     @Test
     public void testAccept() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPowerParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPowerParserTokenTest.java
@@ -21,6 +21,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -109,6 +110,11 @@ public final class SpreadsheetPowerParserTokenTest extends SpreadsheetBinaryPars
     @Override
     SpreadsheetParserToken operatorSymbol() {
         return SpreadsheetParserToken.powerSymbol("^", "^");
+    }
+
+    @Override
+    ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right){
+        return ExpressionNode.power(left, right);
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSubtractionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSubtractionParserTokenTest.java
@@ -21,6 +21,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -109,6 +110,11 @@ public final class SpreadsheetSubtractionParserTokenTest extends SpreadsheetBina
     @Override
     SpreadsheetParserToken operatorSymbol() {
         return SpreadsheetParserToken.minusSymbol("-", "-");
+    }
+
+    @Override
+    ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right){
+        return ExpressionNode.subtraction(left, right);
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSymbolParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSymbolParserTokenTestCase.java
@@ -18,15 +18,12 @@
 
 package walkingkooka.text.cursor.parser.spreadsheet;
 
-public final class SpreadsheetParserTokenVisitorTest extends SpreadsheetParserTokenVisitorTestCase<FakeSpreadsheetParserTokenVisitor> {
+import org.junit.Test;
 
-    @Override
-    protected FakeSpreadsheetParserTokenVisitor createParserTokenVisitor() {
-        return new FakeSpreadsheetParserTokenVisitor();
-    }
+public abstract class SpreadsheetSymbolParserTokenTestCase<T extends SpreadsheetSymbolParserToken> extends SpreadsheetLeafParserTokenTestCase<T, String>{
 
-    @Override
-    protected Class<FakeSpreadsheetParserTokenVisitor> parserTokenVisitorType() {
-        return FakeSpreadsheetParserTokenVisitor.class;
+    @Test
+    public final void testToExpressionNode() {
+        this.toExpressionNodeAndFail();
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetTextParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetTextParserTokenTest.java
@@ -19,6 +19,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 
 import org.junit.Test;
 import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 public final class SpreadsheetTextParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetTextParserToken, String> {
@@ -62,6 +63,11 @@ public final class SpreadsheetTextParserTokenTest extends SpreadsheetLeafParserT
             }
         }.accept(token);
         assertEquals("13542", b.toString());
+    }
+
+    @Test
+    public void testToExpressionNode() {
+        this.toExpressionNodeAndCheck(ExpressionNode.text(this.text()));
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetWhitespaceParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetWhitespaceParserTokenTest.java
@@ -64,6 +64,11 @@ public final class SpreadsheetWhitespaceParserTokenTest extends SpreadsheetLeafP
         assertEquals("13542", b.toString());
     }
 
+    @Test
+    public void testToExpressionNode() {
+        this.toExpressionNodeAndFail();
+    }
+
     @Override
     String text() {
         return " ";

--- a/src/test/java/walkingkooka/tree/expression/ExpressionReferenceNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionReferenceNodeTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.expression;
+
+import org.junit.Test;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCell;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumn;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetReferenceKind;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRow;
+import walkingkooka.tree.visit.Visiting;
+
+public final class ExpressionReferenceNodeTest extends ExpressionLeafValueNodeTestCase<ExpressionReferenceNode, ExpressionReference>{
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final ExpressionReferenceNode node = this.createExpressionNode();
+
+        new FakeExpressionNodeVisitor() {
+            @Override
+            protected Visiting startVisit(final ExpressionNode n) {
+                assertSame(node, n);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ExpressionNode n) {
+                assertSame(node, n);
+                b.append("2");
+            }
+
+            @Override
+            protected void visit(final ExpressionReferenceNode n) {
+                assertSame(node, n);
+                b.append("3");
+            }
+        }.accept(node);
+        assertEquals("132", b.toString());
+    }
+    
+    @Test
+    public void testToString() {
+        assertEquals("$B$3", this.createExpressionNode().toString());
+    }
+
+    @Override
+    ExpressionReferenceNode createExpressionNode(final ExpressionReference value) {
+        return ExpressionReferenceNode.with(value);
+    }
+
+    @Override
+    ExpressionReference value() {
+        return cell(1, 2);
+    }
+
+    @Override
+    ExpressionReference differentValue() {
+        return cell(30, 40);
+    }
+
+    private SpreadsheetCell cell(final int column, final int row) {
+        return SpreadsheetCell.with(SpreadsheetColumn.with(column, SpreadsheetReferenceKind.ABSOLUTE), SpreadsheetRow.with(row, SpreadsheetReferenceKind.ABSOLUTE));
+    }
+
+    @Override
+    Class<ExpressionReferenceNode> expressionNodeType() {
+        return ExpressionReferenceNode.class;
+    }
+}


### PR DESCRIPTION
- defined HasExtensionNode
- Added public factory for ExpressionReferenceNode & ExpressionNodeName.
- Created SpreadsheetCell, so SpreadsheetCellParserToken.value returns SC.
- introduced SpreadsheetParserTokenVisitorTestCase.
- SpreadsheetRangeParserToken will fail conversion, need an ExpressionNode equiv.