### PR TITLE
Added relative json pointer support to NodePointer and its parse(Stri…

### DIFF
--- a/src/main/java/walkingkooka/tree/pointer/AllNodePointer.java
+++ b/src/main/java/walkingkooka/tree/pointer/AllNodePointer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.pointer;
+
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+/**
+ * Matches all the nodes, or the start node.
+ */
+final class AllNodePointer<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> extends NodePointer<N, NAME, ANAME, AVALUE>{
+
+    /**
+     * Creates a {@link AllNodePointer}
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> AllNodePointer<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(INSTANCE);
+    }
+
+    private final static NodePointer INSTANCE = new AllNodePointer();
+
+    /**
+     * Private ctor.
+     */
+    AllNodePointer() {
+        super(null);
+    }
+
+    @Override
+    NodePointer<N, NAME, ANAME, AVALUE> append(final NodePointer<N, NAME, ANAME, AVALUE> pointer) {
+        return pointer;
+    }
+
+    @Override
+    final N nextNodeOrNull(final N node) {
+        return node;
+    }
+
+    @Override
+    final void toString0(final StringBuilder b) {
+        // nop
+    }
+
+    @Override
+    final void lastToString(final StringBuilder b){
+    }
+}

--- a/src/main/java/walkingkooka/tree/pointer/NodeChildNamedNodePointer.java
+++ b/src/main/java/walkingkooka/tree/pointer/NodeChildNamedNodePointer.java
@@ -67,6 +67,11 @@ final class NodeChildNamedNodePointer<N extends Node<N, NAME, ANAME, AVALUE>, NA
 
     @Override
     final void toString0(final StringBuilder b) {
+        b.append(SEPARATOR.character());
         b.append(this.name.value()); // escape slash and tilde
+    }
+
+    @Override
+    final void lastToString(final StringBuilder b){
     }
 }

--- a/src/main/java/walkingkooka/tree/pointer/NodeInvalidChildElementNodePointer.java
+++ b/src/main/java/walkingkooka/tree/pointer/NodeInvalidChildElementNodePointer.java
@@ -24,32 +24,41 @@ import walkingkooka.tree.Node;
 import java.util.List;
 
 /**
- * Represents a component that matches a node by its element.
+ * Represents a reference to an invalid array element.
+ * <a href="https://tools.ietf.org/html/rfc6901#page-5"></a>
+ * <pre>
+ * Note that the use of the "-" character to index an array will always
+ * result in such an error condition because by definition it refers to
+ * a nonexistent array element.  Thus, applications of JSON Pointer need
+ * to specify how that character is to be handled, if it is to be
+ * useful.
+ * ...
+ * </pre>
  */
-final class NodeChildElementNodePointer<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> extends NodePointer<N, NAME, ANAME, AVALUE>{
+final class NodeInvalidChildElementNodePointer<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> extends NodePointer<N, NAME, ANAME, AVALUE>{
 
     /**
-     * Creates a {@link NodeChildElementNodePointer}
+     * Creates a {@link NodeInvalidChildElementNodePointer}
      */
-    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodeChildElementNodePointer<N, NAME, ANAME, AVALUE> with(final int index) {
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodeInvalidChildElementNodePointer<N, NAME, ANAME, AVALUE> with(final int index) {
         if(index < 0) {
             throw new IllegalArgumentException("Invalid index " + index + " values should be greater or equal to 0");
         }
 
-        return new NodeChildElementNodePointer(index, NO_NEXT);
+        return new NodeInvalidChildElementNodePointer(index, NO_NEXT);
     }
 
     /**
      * Private ctor.
      */
-    NodeChildElementNodePointer(final int index, final NodePointer<N, NAME, ANAME, AVALUE> pointer) {
+    NodeInvalidChildElementNodePointer(final int index, final NodePointer<N, NAME, ANAME, AVALUE> pointer) {
         super(pointer);
         this.index = index;
     }
 
     @Override
     NodePointer<N, NAME, ANAME, AVALUE> append(final NodePointer<N, NAME, ANAME, AVALUE> pointer) {
-        return new NodeChildElementNodePointer(this.index, this.appendToNext(pointer));
+        return new NodeInvalidChildElementNodePointer(this.index, this.appendToNext(pointer));
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/pointer/NodePointer.java
+++ b/src/main/java/walkingkooka/tree/pointer/NodePointer.java
@@ -30,8 +30,13 @@ import java.util.function.Function;
 /**
  * A node pointer may be thought of as a JsonPointer that operates on any type of {@link Node}.
  * THe only difference is an element index will always match any first child, for something like a json object this will be the first key/value.
+ * Because the return value is a {@link Node} any relative pointer terminating with a trailing will ignore the hash itself and return the result as if it was absent.
+ * <br>
+ * <a href="http://json-schema.org/latest/relative-json-pointer.html#RFC4627">spec</a>
  */
 public abstract class NodePointer<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> {
+
+    final static String NONE = "-";
 
     /**
      * Accepts and parses a {@link String} holding a pointer.
@@ -42,41 +47,56 @@ public abstract class NodePointer<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
         Objects.requireNonNull(nodeType, "nodeType");
 
         final String[] components = pointer.split(SEPARATOR.string());
-        NodePointer<N, NAME, ANAME, AVALUE> result = null;
+        NodePointer<N, NAME, ANAME, AVALUE> result = all(nodeType);
+        boolean relative = true;
+        boolean hash = false;
 
-        int i = 0;
         for(String component : components) {
-            if(0 == i){
-                if(!component.isEmpty()) {
-                    throw new IllegalArgumentException("Point missing initial '/'=" + CharSequences.quote(pointer));
+            if(relative){
+                if(component.isEmpty()) {
+                    relative = false; // found a slash...
+                    continue;
                 }
-                i++;
-                continue;
+                if(component.endsWith("#")) {
+                    component = component.substring(0, component.length() - 1);
+                    hash = true;
+                }
             }
             if(component.isEmpty()) {
                 throw new IllegalArgumentException("Empty component found within pointer=" + CharSequences.quote(pointer));
             }
 
-            i++;
-
             try{
-                final int index = Integer.parseInt(component);
-                if(null==result){
-                   result = index(index, nodeType);
-                } else {
-                   result = result.index(index);
-                }
+                final int number = Integer.parseInt(component);
+                result = result.append(relative ?
+                       RelativeNodePointer.with(number, hash):
+                       index(number, nodeType));
             } catch (final NumberFormatException mustBeName) {
-                final NAME name = nameFactory.apply(component);
-                if(null==result){
-                    result = named(name, nodeType);
+                if(relative) {
+                    throw new IllegalArgumentException("Relative pointer expected number but got=" + CharSequences.quote(pointer));
+                }
+                if(NONE.equals(component)) {
+                    result = result.none();
                 } else {
+                    final NAME name = nameFactory.apply(component);
+                    if (relative) {
+                        throw new IllegalArgumentException("Expected number with relative pointer=" + CharSequences.quote(pointer));
+                    }
                     result = result.named(name);
                 }
             }
+            relative = false;
         }
 
         return result;
+    }
+
+    /**
+     * Creates a match all.
+     */
+    public static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodePointer<N, NAME, ANAME, AVALUE> all(final Class<N> nodeType) {
+        Objects.requireNonNull(nodeType, "nodeType");
+        return AllNodePointer.get();
     }
 
     /**
@@ -96,6 +116,30 @@ public abstract class NodePointer<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
     }
 
     /**
+     * Creates pointer that never matches anything.
+     */
+    public static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodePointer<N, NAME, ANAME, AVALUE> none(final Class<N> nodeType) {
+        Objects.requireNonNull(nodeType, "nodeType");
+        return NoneNodePointer.with(NONE);
+    }
+
+    /**
+     * Creates an relative.
+     */
+    public static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodePointer<N, NAME, ANAME, AVALUE> relative(final int ancestor, final Class<N> nodeType) {
+        Objects.requireNonNull(nodeType, "nodeType");
+        return RelativeNodePointer.with(ancestor, false);
+    }
+
+    /**
+     * Creates an relative.
+     */
+    public static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NodePointer<N, NAME, ANAME, AVALUE> relativeHash(final int ancestor, final Class<N> nodeType) {
+        Objects.requireNonNull(nodeType, "nodeType");
+        return RelativeNodePointer.with(ancestor, true);
+    }
+
+    /**
      * Named constant marking a terminal in a pointer.
      */
     final static NodePointer NO_NEXT = null;
@@ -112,6 +156,13 @@ public abstract class NodePointer<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
      */
     public final NodePointer<N, NAME, ANAME, AVALUE> named(final NAME name) {
         return this.append(NodeChildNamedNodePointer.with(name));
+    }
+
+    /**
+     * Appends a none pointer, equivalent to the "-" token within a string pointer.
+     */
+    public final NodePointer<N, NAME, ANAME, AVALUE> none() {
+        return this.append(NoneNodePointer.with("/" + NONE));
     }
 
     /**
@@ -175,17 +226,22 @@ public abstract class NodePointer<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
         final StringBuilder b = new StringBuilder();
 
         NodePointer<N, NAME, ANAME, AVALUE> pointer = this;
-        do {
-            b.append(SEPARATOR.character());
+        for(;;) {
             pointer.toString0(b);
 
+            if(null==pointer.next) {
+                pointer.lastToString(b);
+                break;
+            }
             pointer = pointer.next;
-        } while(null != pointer);
+        }
 
         return b.toString();
     }
 
-    private final static CharacterConstant SEPARATOR = CharacterConstant.with('/');
+    final static CharacterConstant SEPARATOR = CharacterConstant.with('/');
 
     abstract void toString0(final StringBuilder b);
+
+    abstract void lastToString(final StringBuilder b);
 }

--- a/src/main/java/walkingkooka/tree/pointer/NoneNodePointer.java
+++ b/src/main/java/walkingkooka/tree/pointer/NoneNodePointer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.pointer;
+
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+/**
+ * Represents a reference to an invalid array element.
+ * <a href="https://tools.ietf.org/html/rfc6901#page-5"></a>
+ * <pre>
+ * Note that the use of the "-" character to index an array will always
+ * result in such an error condition because by definition it refers to
+ * a nonexistent array element.  Thus, applications of JSON Pointer need
+ * to specify how that character is to be handled, if it is to be
+ * useful.
+ * ...
+ * </pre>
+ */
+final class NoneNodePointer<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> extends NodePointer<N, NAME, ANAME, AVALUE>{
+
+    /**
+     * Creates a {@link NoneNodePointer}
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> NoneNodePointer<N, NAME, ANAME, AVALUE> with(final String toString) {
+        return new NoneNodePointer(toString);
+    }
+
+    /**
+     * Private ctor.
+     */
+    NoneNodePointer(final String toString) {
+        super(null);
+        this.toString = toString;
+    }
+
+    @Override
+    NodePointer<N, NAME, ANAME, AVALUE> append(final NodePointer<N, NAME, ANAME, AVALUE> pointer) {
+        final StringBuilder b = new StringBuilder();
+        b.append(this.toString);
+        pointer.toString0(b);
+        pointer.lastToString(b);
+
+        return new NoneNodePointer(b.toString());
+    }
+
+    @Override
+    final N nextNodeOrNull(final N node) {
+        return null;
+    }
+
+    @Override
+    final void toString0(final StringBuilder b) {
+        b.append(this.toString);
+    }
+
+    private final String toString;
+
+    @Override
+    final void lastToString(final StringBuilder b){
+    }
+}

--- a/src/main/java/walkingkooka/tree/pointer/RelativeNodePointer.java
+++ b/src/main/java/walkingkooka/tree/pointer/RelativeNodePointer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.pointer;
+
+import walkingkooka.naming.Name;
+import walkingkooka.tree.Node;
+
+import java.util.Optional;
+
+/**
+ * Represents the opening relative pointer..
+ */
+final class RelativeNodePointer<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> extends NodePointer<N, NAME, ANAME, AVALUE>{
+
+    /**
+     * Creates a {@link RelativeNodePointer}
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> RelativeNodePointer<N, NAME, ANAME, AVALUE> with(final int ancestorCount, final boolean hash) {
+        if(ancestorCount < 0) {
+            throw new IllegalArgumentException("Invalid ancestorCount " + ancestorCount + " values should be greater or equal to 0");
+        }
+
+        return new RelativeNodePointer(ancestorCount, hash, NO_NEXT);
+    }
+
+    /**
+     * Private ctor.
+     */
+    RelativeNodePointer(final int ancestorCount, final boolean hash, final NodePointer<N, NAME, ANAME, AVALUE> pointer) {
+        super(pointer);
+        this.ancestorCount = ancestorCount;
+        this.hash = hash;
+    }
+
+    @Override
+    NodePointer<N, NAME, ANAME, AVALUE> append(final NodePointer<N, NAME, ANAME, AVALUE> pointer) {
+        return new RelativeNodePointer(this.ancestorCount, this.hash, this.appendToNext(pointer));
+    }
+
+    @Override
+    final N nextNodeOrNull(final N node) {
+        N next = node;
+
+        for(int i = 0; i < this.ancestorCount; i++){
+            final Optional<N> parent = next.parent();
+            if(!parent.isPresent()) {
+                next = null;
+                break;
+            }
+            next = parent.get();
+        }
+
+        return next;
+    }
+
+    final int ancestorCount;
+    final boolean hash;
+
+    @Override
+    final void toString0(final StringBuilder b) {
+        b.append(this.ancestorCount);
+    }
+
+    @Override
+    final void lastToString(final StringBuilder b){
+        if(this.hash) {
+            b.append('#');
+        }
+    }
+}

--- a/src/test/java/walkingkooka/tree/pointer/AllNodePointerTest.java
+++ b/src/test/java/walkingkooka/tree/pointer/AllNodePointerTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.pointer;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class AllNodePointerTest extends PackagePrivateClassTestCase<AllNodePointer<?, ?, ?, ?>> {
+
+    @Test
+    public void testToString() {
+        assertEquals("", AllNodePointer.get().toString());
+    }
+
+    @Override
+    protected Class<AllNodePointer<?, ?, ?, ?>> type() {
+        return Cast.to(AllNodePointer.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/pointer/NoneNodePointerTest.java
+++ b/src/test/java/walkingkooka/tree/pointer/NoneNodePointerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.pointer;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.test.PackagePrivateClassTestCase;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.tree.json.JsonNodeName;
+
+public final class NoneNodePointerTest extends PackagePrivateClassTestCase<NoneNodePointer<?, ?, ?, ?>> {
+
+    @Test
+    public void testElementAppendToString() {
+        final NodePointer<?, ?, ?, ?> element = NodePointer.named(JsonNodeName.with("abc"), JsonNode.class);
+        final NodePointer<?, ?, ?, ?> none = element.none();
+        assertEquals("/abc/-", none.toString());
+    }
+
+    @Test
+    public void testArrayAppendToString() {
+        final NodePointer<?, ?, ?, ?> array = NodePointer.index(123, JsonNode.class);
+        final NodePointer<?, ?, ?, ?> none = array.none();
+        assertEquals("/123/-", none.toString());
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("-", NoneNodePointer.with("-").toString());
+    }
+
+    @Override
+    protected Class<NoneNodePointer<?, ?, ?, ?>> type() {
+        return Cast.to(NoneNodePointer.class);
+    }
+}

--- a/src/test/java/walkingkooka/tree/pointer/RelativeNodePointerTest.java
+++ b/src/test/java/walkingkooka/tree/pointer/RelativeNodePointerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.pointer;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class RelativeNodePointerTest extends PackagePrivateClassTestCase<RelativeNodePointer<?, ?, ?, ?>> {
+
+    private final static boolean NO_HASH = false;
+    private final static boolean HASH = !NO_HASH;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWithNegativeFails() {
+        RelativeNodePointer.with(-1, NO_HASH);
+    }
+
+    @Test
+    public void testWithZero() {
+        this.createAndCheck(0);
+    }
+
+    @Test
+    public void testWith() {
+        this.createAndCheck(1);
+    }
+
+    @Test
+    public void testWith2() {
+        this.createAndCheck(10);
+    }
+
+    private void createAndCheck(final int ancestorCount) {
+        final RelativeNodePointer<?, ?, ?, ?> pointer = RelativeNodePointer.with(ancestorCount, NO_HASH);
+        assertEquals("ancestorCount", ancestorCount, pointer.ancestorCount);
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("1", RelativeNodePointer.with(1, NO_HASH).toString());
+    }
+
+    @Test
+    public void testToStringHash() {
+        assertEquals("1#", RelativeNodePointer.with(1, HASH).toString());
+    }
+
+    @Override
+    protected Class<RelativeNodePointer<?, ?, ?, ?>> type() {
+        return Cast.to(RelativeNodePointer.class);
+    }
+}


### PR DESCRIPTION
…ng).

- note the trailing hash of a relative pointer is ignored, primarily because the return type is Node,
and there is no way to return something like an Integer without changing the method signature.