### PR TITLE
Replaced TestCase.assertSame with org.junit.Assert.assertSame.

### DIFF
--- a/src/main/java/walkingkooka/build/chain/ChainBuilderTestCase.java
+++ b/src/main/java/walkingkooka/build/chain/ChainBuilderTestCase.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import walkingkooka.build.BuilderTestCase;
 import walkingkooka.collect.list.Lists;
 
+import static org.junit.Assert.assertSame;
+
 /**
  * Base class for any {@link ChainBuilder} that includes mostly parameter check tests
  */

--- a/src/main/java/walkingkooka/predicate/character/CharPredicateTestCase.java
+++ b/src/main/java/walkingkooka/predicate/character/CharPredicateTestCase.java
@@ -22,6 +22,9 @@ import org.junit.Test;
 import walkingkooka.test.PackagePrivateClassTestCase;
 import walkingkooka.text.CharSequences;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
 /**
  * Base class for any tests involving a {@link CharPredicate} including helpers to invoke andassert
  * {@link CharPredicate#test(char)} results.
@@ -47,7 +50,7 @@ abstract public class CharPredicateTestCase<P extends CharPredicate>
     @Test
     public void testNotNot() {
         final P predicate = this.createCharacterPredicate();
-        assertSame(predicate, predicate.negate().negate());
+        assertEquals(predicate, predicate.negate().negate());
     }
 
     @Test

--- a/src/main/java/walkingkooka/predicate/character/ToStringCharPredicate.java
+++ b/src/main/java/walkingkooka/predicate/character/ToStringCharPredicate.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.predicate.character;
 
+import walkingkooka.Cast;
 import walkingkooka.test.HashCodeEqualsDefined;
 import walkingkooka.text.Whitespace;
 
@@ -32,20 +33,26 @@ final class ToStringCharPredicate implements CharPredicate, HashCodeEqualsDefine
     /**
      * Creates a new {@link ToStringCharPredicate}
      */
-    static ToStringCharPredicate wrap(final CharPredicate predicate, final String toString) {
+    static CharPredicate wrap(final CharPredicate predicate, final String toString) {
         Objects.requireNonNull(predicate, "predicate");
         Whitespace.failIfNullOrWhitespace(toString, "toString");
 
-        return new ToStringCharPredicate(predicate instanceof ToStringCharPredicate ?
-                ToStringCharPredicate.unwrap(predicate) :
-                predicate, toString);
+        return predicate.toString().equals(toString) ?
+               predicate :
+               new ToStringCharPredicate(unwrapIfNecessary(predicate), toString);
     }
 
     /**
      * Returns the wrapped {@link CharPredicate}.
      */
-    private static CharPredicate unwrap(final CharPredicate predicate) {
-        return ((ToStringCharPredicate) predicate).predicate;
+    private static CharPredicate unwrapIfNecessary(final CharPredicate predicate) {
+        return predicate instanceof ToStringCharPredicate ?
+               unwrap(Cast.to(predicate)) :
+               predicate;
+    }
+
+    private static CharPredicate unwrap(final ToStringCharPredicate predicate) {
+        return predicate.predicate;
     }
 
     /**

--- a/src/main/java/walkingkooka/test/PublicThrowableTestCase.java
+++ b/src/main/java/walkingkooka/test/PublicThrowableTestCase.java
@@ -25,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * Base class for testing a {@link Throwable} with mostly parameter checking tests.

--- a/src/main/java/walkingkooka/test/SerializationTestCase.java
+++ b/src/main/java/walkingkooka/test/SerializationTestCase.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 abstract public class SerializationTestCase<S extends Serializable> extends TestCase {
 

--- a/src/main/java/walkingkooka/test/TestCase.java
+++ b/src/main/java/walkingkooka/test/TestCase.java
@@ -157,16 +157,6 @@ abstract public class TestCase {
         return new String(this.resourceAsBytes(source, resource));
     }
 
-    public static void assertSame(final Object expected, final Object actual) {
-        assertSame(null, expected, actual);
-    }
-
-    public static void assertSame(final String message, final Object expected, final Object actual) {
-        if (expected != actual) {
-            failNotSame(message, expected, actual);
-        }
-    }
-
     public static void failNotSame(final Object expected, final Object actual) {
         failNotSame(null, expected, actual);
     }

--- a/src/main/java/walkingkooka/text/CharSequenceTestCase.java
+++ b/src/main/java/walkingkooka/text/CharSequenceTestCase.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.test.TestCase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * Base class for testing any {@link CharSequence} with most tests testing parameter validation.

--- a/src/main/java/walkingkooka/text/cursor/TextCursorTestCase.java
+++ b/src/main/java/walkingkooka/text/cursor/TextCursorTestCase.java
@@ -18,10 +18,10 @@
 package walkingkooka.text.cursor;
 
 import org.junit.Test;
-import walkingkooka.test.TestCase;
 import walkingkooka.text.CharSequences;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 abstract public class TextCursorTestCase<C extends TextCursor> extends TextCursorPackageTestCase<C> {
 
@@ -65,7 +65,7 @@ abstract public class TextCursorTestCase<C extends TextCursor> extends TextCurso
     @Test
     public void testNext() {
         final C cursor = this.createTextCursor("123");
-        TestCase.assertSame("cursor didnt return this", cursor, cursor.next());
+        assertSame("cursor didnt return this", cursor, cursor.next());
     }
 
     @Test
@@ -137,7 +137,7 @@ abstract public class TextCursorTestCase<C extends TextCursor> extends TextCurso
     @Test
     public void testEnd() {
         final TextCursor cursor = this.createTextCursor("1234567890");
-        TestCase.assertSame("cursor didnt return this", cursor, cursor.end());
+        assertSame("cursor didnt return this", cursor, cursor.end());
         this.checkEmpty(cursor);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/MissingParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/MissingParserToken.java
@@ -48,7 +48,7 @@ public final class MissingParserToken extends ParserTemplateToken<ParserTokenNod
 
     @Override
     public ParserTokenNodeName name() {
-        return NAME;
+        return this.value();
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokenTestCase.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokenTestCase.java
@@ -28,6 +28,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public abstract class ParserTokenTestCase<T extends ParserToken> extends PublicClassTestCase<T> {
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserToken.java
@@ -44,7 +44,9 @@ abstract class EbnfParentParserToken extends EbnfParserToken implements Value<Li
                 .filter(t -> !t.isNoise())
                 .collect(Collectors.toList());
 
-        return Optional.of(this.replaceTokens(without));
+        return Optional.of(value.size()==without.size() ?
+                this :
+                this.replaceTokens(without));
     }
 
     final void checkOnlyOneToken() {

--- a/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeObjectParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeObjectParserToken.java
@@ -42,12 +42,16 @@ public final class JsonNodeObjectParserToken extends JsonNodeParentParserToken {
 
     private JsonNodeObjectParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout){
         super(value, text, valueWithout);
+        this.checkKeys(text);
+    }
 
-        if(null!=valueWithout){
+    private void checkKeys(final String text) {
+        final List<ParserToken> without = this.valueIfWithoutSymbolsOrWhitespaceOrNull();
+        if(null!=without) {
             int i = 0;
             JsonNodeParserToken j = null;
 
-            for(ParserToken t : this.value()) {
+            for(ParserToken t : without) {
                 j = JsonNodeParserToken.class.cast(t);
                 if((i&1) == 0) {
                     if(!j.isString()) {

--- a/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeParentParserToken.java
@@ -45,7 +45,9 @@ abstract class JsonNodeParentParserToken extends JsonNodeParserToken implements 
              .filter(t -> !t.isNoise())
              .collect(Collectors.toList());
 
-        return Optional.of(this.replaceTokens(without));
+        return Optional.of(value.size() == without.size() ?
+                this:
+                this.replaceTokens(without));
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserToken.java
@@ -55,7 +55,9 @@ abstract class SpreadsheetParentParserToken extends SpreadsheetParserToken imple
                 });
         Lists.array();
 
-        return Optional.of(this.replaceTokens(without));
+        return Optional.of(value.size() == without.size() ?
+                this :
+                this.replaceTokens(without));
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/NodeTestCase.java
+++ b/src/main/java/walkingkooka/tree/NodeTestCase.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 abstract public class NodeTestCase<N extends Node<N, NAME, ANAME, AVALUE>,
         NAME extends Name,

--- a/src/main/java/walkingkooka/tree/NodeTestCase2.java
+++ b/src/main/java/walkingkooka/tree/NodeTestCase2.java
@@ -26,6 +26,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 abstract public class NodeTestCase2<N extends Node<N, NAME, ANAME, AVALUE>,
         NAME extends Name,

--- a/src/main/java/walkingkooka/tree/expression/ExpressionLeafNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionLeafNode.java
@@ -35,8 +35,7 @@ abstract class ExpressionLeafNode extends ExpressionNode {
 
     @Override
     final ExpressionNode wrap(final int index) {
-        return this.wrap0(index)
-                .replaceChild(this.parent());
+        return this.wrap0(index);
     }
 
     abstract ExpressionLeafValueNode wrap0(final int index);

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNode.java
@@ -269,19 +269,6 @@ public abstract class ExpressionNode implements Node<ExpressionNode, ExpressionN
 
     int index;
 
-    /**
-     * Would be setter that returns an instance with the index, creating a new instance if necessary.
-     */
-    final ExpressionNode setIndex(final int index) {
-        return this.index == index ?
-                this :
-                this.replaceIndex(index);
-    }
-
-    private ExpressionNode replaceIndex(final int index) {
-        return this.wrap(index);
-    }
-
     abstract ExpressionNode wrap(final int index);
 
     // attributes.......................................................................................................

--- a/src/main/java/walkingkooka/tree/expression/ExpressionParentNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionParentNode.java
@@ -94,8 +94,7 @@ abstract class ExpressionParentNode extends ExpressionNode {
 
     @Override
     final ExpressionNode wrap(final int index) {
-        return this.wrap0(index, this.children())
-                .replaceChild(this.parent());
+        return this.wrap0(index, this.children());
     }
 
     abstract ExpressionParentNode wrap0(final int index, final List<ExpressionNode> children);

--- a/src/main/java/walkingkooka/tree/json/JsonLeafNodeTestCase.java
+++ b/src/main/java/walkingkooka/tree/json/JsonLeafNodeTestCase.java
@@ -25,6 +25,7 @@ import walkingkooka.collect.list.Lists;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public abstract class JsonLeafNodeTestCase<N extends JsonLeafNode<V>, V> extends JsonNodeTestCase<N> {
 

--- a/src/main/java/walkingkooka/tree/json/JsonNodeTestCase.java
+++ b/src/main/java/walkingkooka/tree/json/JsonNodeTestCase.java
@@ -33,6 +33,7 @@ import walkingkooka.type.MethodAttributes;
 import java.lang.reflect.Method;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public abstract class JsonNodeTestCase<N extends JsonNode> extends NodeTestCase2<JsonNode, JsonNodeName, Name, Object> {
 

--- a/src/main/java/walkingkooka/tree/pojo/PojoNode.java
+++ b/src/main/java/walkingkooka/tree/pojo/PojoNode.java
@@ -284,7 +284,7 @@ public abstract class PojoNode implements Node<PojoNode, PojoName, PojoNodeAttri
      * Would setter that returns a {@link PojoNode} with the new value creating a new node if necessary.
      */
     public final PojoNode setValue(final Object value) {
-        return Objects.equals(this.value(), value) ?
+        return Objects.deepEquals(this.value(), value) ?
                 this :
                 PojoNode.wrap0(this.name(),
                         value,

--- a/src/main/java/walkingkooka/util/variable/VariableTestCase.java
+++ b/src/main/java/walkingkooka/util/variable/VariableTestCase.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import walkingkooka.Cast;
 import walkingkooka.test.PackagePrivateClassTestCase;
 
+import static org.junit.Assert.assertSame;
+
 /**
  * Base class for testing a {@link Variable}.
  */

--- a/src/main/java/walkingkooka/xml/DomChildList.java
+++ b/src/main/java/walkingkooka/xml/DomChildList.java
@@ -78,6 +78,8 @@ final class DomChildList extends AbstractList<DomNode> {
                 DomNode node = this.children[i];
                 if(null==node){
                     node = DomNode.wrap(possible);
+                    node.parent = Optional.of(this.parent);
+                    node.index = i;
                     this.children[i]=node;
                 }
                 result = Optional.of(node);

--- a/src/test/java/walkingkooka/build/chain/ChainFactoryChainBuilderTest.java
+++ b/src/test/java/walkingkooka/build/chain/ChainFactoryChainBuilderTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class ChainFactoryChainBuilderTest
         extends ChainBuilderTestCase<ChainFactoryChainBuilder<Fake>, Fake> {

--- a/src/test/java/walkingkooka/build/chain/ChainTypeTest.java
+++ b/src/test/java/walkingkooka/build/chain/ChainTypeTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.test.HashCodeEqualsDefinedTestCase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class ChainTypeTest extends HashCodeEqualsDefinedTestCase<ChainType> {
     // constants

--- a/src/test/java/walkingkooka/build/tostring/ToStringBuilderTest.java
+++ b/src/test/java/walkingkooka/build/tostring/ToStringBuilderTest.java
@@ -31,6 +31,7 @@ import java.util.Enumeration;
 import java.util.Iterator;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class ToStringBuilderTest extends BuilderTestCase<ToStringBuilder, String> {
     // constants

--- a/src/test/java/walkingkooka/collect/enumeration/EnumerationChainTest.java
+++ b/src/test/java/walkingkooka/collect/enumeration/EnumerationChainTest.java
@@ -27,6 +27,7 @@ import java.util.NoSuchElementException;
 import java.util.Vector;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class EnumerationChainTest
         extends EnumerationTestCase<EnumerationChain<String>, String> {

--- a/src/test/java/walkingkooka/collect/enumeration/IteratorEnumerationTest.java
+++ b/src/test/java/walkingkooka/collect/enumeration/IteratorEnumerationTest.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class IteratorEnumerationTest
         extends EnumerationTestCase<IteratorEnumeration<Object>, Object> {

--- a/src/test/java/walkingkooka/collect/iterable/IteratorIterableTest.java
+++ b/src/test/java/walkingkooka/collect/iterable/IteratorIterableTest.java
@@ -25,6 +25,7 @@ import walkingkooka.collect.iterator.Iterators;
 import java.util.Iterator;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class IteratorIterableTest extends IterableTestCase<IteratorIterable<Object>, Object> {
 

--- a/src/test/java/walkingkooka/collect/iterable/ReverseIterableTest.java
+++ b/src/test/java/walkingkooka/collect/iterable/ReverseIterableTest.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class ReverseIterableTest extends IterableTestCase<ReverseIterable<String>, String> {
 

--- a/src/test/java/walkingkooka/collect/iterator/IteratorChainTest.java
+++ b/src/test/java/walkingkooka/collect/iterator/IteratorChainTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class IteratorChainTest extends IteratorTestCase<IteratorChain<String>, String> {
 

--- a/src/test/java/walkingkooka/collect/iterator/LimitedIteratorTest.java
+++ b/src/test/java/walkingkooka/collect/iterator/LimitedIteratorTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class LimitedIteratorTest extends IteratorTestCase<LimitedIterator<String>, String> {
 

--- a/src/test/java/walkingkooka/collect/iterator/ReadOnlyIteratorTest.java
+++ b/src/test/java/walkingkooka/collect/iterator/ReadOnlyIteratorTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class ReadOnlyIteratorTest extends IteratorTestCase<ReadOnlyIterator<Object>, Object> {
 

--- a/src/test/java/walkingkooka/collect/stack/ArrayListStackTest.java
+++ b/src/test/java/walkingkooka/collect/stack/ArrayListStackTest.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class ArrayListStackTest extends StackTestCase<ArrayListStack<Object>, Object> {
 

--- a/src/test/java/walkingkooka/collect/stack/ArrayStackTest.java
+++ b/src/test/java/walkingkooka/collect/stack/ArrayStackTest.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class ArrayStackTest extends StackTestCase<Stack<String>, String> {
 

--- a/src/test/java/walkingkooka/collect/stack/EmptyArrayStackTest.java
+++ b/src/test/java/walkingkooka/collect/stack/EmptyArrayStackTest.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class EmptyArrayStackTest extends StackTestCase<EmptyArrayStack<Object>, Object> {
 

--- a/src/test/java/walkingkooka/collect/stack/JdkStackStackTest.java
+++ b/src/test/java/walkingkooka/collect/stack/JdkStackStackTest.java
@@ -27,6 +27,7 @@ import java.util.EmptyStackException;
 import java.util.Iterator;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class JdkStackStackTest extends StackTestCase<JdkStackStack<Object>, Object> {
 

--- a/src/test/java/walkingkooka/collect/stack/ReadOnlyStackTest.java
+++ b/src/test/java/walkingkooka/collect/stack/ReadOnlyStackTest.java
@@ -25,6 +25,7 @@ import walkingkooka.collect.iterator.Iterators;
 import java.util.Iterator;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class ReadOnlyStackTest extends StackTestCase<ReadOnlyStack<Object>, Object> {
 

--- a/src/test/java/walkingkooka/collect/stack/UnreadableStackTest.java
+++ b/src/test/java/walkingkooka/collect/stack/UnreadableStackTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.Cast;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class UnreadableStackTest extends StackTestCase<UnreadableStack<Object>, Object> {
 

--- a/src/test/java/walkingkooka/compare/NotComparatorTest.java
+++ b/src/test/java/walkingkooka/compare/NotComparatorTest.java
@@ -25,6 +25,7 @@ import walkingkooka.predicate.Notable;
 import java.util.Comparator;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class NotComparatorTest extends ComparatorTestCase<NotComparator<Object>, Object> {
 

--- a/src/test/java/walkingkooka/io/printer/LineEndingPrinterTest.java
+++ b/src/test/java/walkingkooka/io/printer/LineEndingPrinterTest.java
@@ -21,6 +21,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import walkingkooka.text.LineEnding;
 
+import static org.junit.Assert.assertSame;
+
 final public class LineEndingPrinterTest extends PrinterTestCase2<LineEndingPrinter> {
 
     // constants

--- a/src/test/java/walkingkooka/io/printer/NullSkippingPrinterTest.java
+++ b/src/test/java/walkingkooka/io/printer/NullSkippingPrinterTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import walkingkooka.Cast;
 import walkingkooka.text.LineEnding;
 
+import static org.junit.Assert.assertSame;
+
 final public class NullSkippingPrinterTest extends PrinterTestCase<NullSkippingPrinter> {
 
     // constants

--- a/src/test/java/walkingkooka/io/printer/PlainTextWithoutTagsPrinterTest.java
+++ b/src/test/java/walkingkooka/io/printer/PlainTextWithoutTagsPrinterTest.java
@@ -21,6 +21,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import walkingkooka.text.LineEnding;
 
+import static org.junit.Assert.assertSame;
+
 final public class PlainTextWithoutTagsPrinterTest
         extends PrinterTestCase2<PlainTextWithoutTagsPrinter> {
 

--- a/src/test/java/walkingkooka/io/printer/PrintStreamPrinterTest.java
+++ b/src/test/java/walkingkooka/io/printer/PrintStreamPrinterTest.java
@@ -27,6 +27,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 
+import static org.junit.Assert.assertSame;
+
 final public class PrintStreamPrinterTest extends PrinterTestCase<PrintStreamPrinter> {
 
     // constants

--- a/src/test/java/walkingkooka/io/printer/SeparatorAddingPrinterTest.java
+++ b/src/test/java/walkingkooka/io/printer/SeparatorAddingPrinterTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import walkingkooka.Cast;
 import walkingkooka.text.LineEnding;
 
+import static org.junit.Assert.assertSame;
+
 final public class SeparatorAddingPrinterTest extends PrinterTestCase2<SeparatorAddingPrinter> {
 
     // constants

--- a/src/test/java/walkingkooka/io/printer/TeePrinterTest.java
+++ b/src/test/java/walkingkooka/io/printer/TeePrinterTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import walkingkooka.Cast;
 import walkingkooka.text.LineEnding;
 
+import static org.junit.Assert.assertSame;
+
 final public class TeePrinterTest extends PrinterTestCase<TeePrinter> {
 
     // constants

--- a/src/test/java/walkingkooka/io/printer/UnclosablePrinterTest.java
+++ b/src/test/java/walkingkooka/io/printer/UnclosablePrinterTest.java
@@ -21,6 +21,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import walkingkooka.text.LineEnding;
 
+import static org.junit.Assert.assertSame;
+
 final public class UnclosablePrinterTest extends PrinterTestCase2<UnclosablePrinter> {
 
     // constants

--- a/src/test/java/walkingkooka/io/printer/WhitespaceCleaningPrinterTest.java
+++ b/src/test/java/walkingkooka/io/printer/WhitespaceCleaningPrinterTest.java
@@ -21,6 +21,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import walkingkooka.text.LineEnding;
 
+import static org.junit.Assert.assertSame;
+
 final public class WhitespaceCleaningPrinterTest extends PrinterTestCase2<WhitespaceCleaningPrinter> {
 
     // constants

--- a/src/test/java/walkingkooka/io/printer/WriterPrinterTest.java
+++ b/src/test/java/walkingkooka/io/printer/WriterPrinterTest.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import static org.junit.Assert.assertSame;
+
 final public class WriterPrinterTest extends PrinterTestCase<WriterPrinter> {
 
     // constants

--- a/src/test/java/walkingkooka/io/printstream/PrinterPrintStreamTest.java
+++ b/src/test/java/walkingkooka/io/printstream/PrinterPrintStreamTest.java
@@ -30,6 +30,7 @@ import java.nio.charset.Charset;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class PrinterPrintStreamTest extends PrintStreamTestCase<PrinterPrintStream> {
 

--- a/src/test/java/walkingkooka/io/printstream/TeePrintStreamTest.java
+++ b/src/test/java/walkingkooka/io/printstream/TeePrintStreamTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.Charset;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class TeePrintStreamTest extends PrintStreamTestCase<TeePrintStream> {
     // constants

--- a/src/test/java/walkingkooka/naming/PathSeparatorTest.java
+++ b/src/test/java/walkingkooka/naming/PathSeparatorTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.test.HashCodeEqualsDefinedTestCase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class PathSeparatorTest extends HashCodeEqualsDefinedTestCase<PathSeparator> {
 

--- a/src/test/java/walkingkooka/naming/PropertiesPathSerializationTest.java
+++ b/src/test/java/walkingkooka/naming/PropertiesPathSerializationTest.java
@@ -22,6 +22,7 @@ import walkingkooka.test.SerializationTestCase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 final public class PropertiesPathSerializationTest extends SerializationTestCase<PropertiesPath> {
@@ -34,7 +35,7 @@ final public class PropertiesPathSerializationTest extends SerializationTestCase
         assertEquals("one.two", parent.value());
 
         assertFalse(parent.isRoot());
-        assertSame(parent, path.parent());
+        assertSame(parent, path.parent().get());
         assertEquals(PropertiesName.with("two"), parent.name());
 
         final PropertiesPath grandParent = parent.parent().get();

--- a/src/test/java/walkingkooka/naming/StringPathSerializationTest.java
+++ b/src/test/java/walkingkooka/naming/StringPathSerializationTest.java
@@ -22,6 +22,7 @@ import walkingkooka.test.SerializationTestCase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 
 final public class StringPathSerializationTest extends SerializationTestCase<StringPath> {
 
@@ -38,7 +39,7 @@ final public class StringPathSerializationTest extends SerializationTestCase<Str
         assertEquals("/one/two", parent.value());
 
         assertFalse(parent.isRoot());
-        assertSame(parent, path.parent());
+        assertSame(parent, path.parent().get());
         assertEquals(StringName.with("two"), parent.name());
 
         final StringPath grandParent = parent.parent().get();
@@ -46,7 +47,7 @@ final public class StringPathSerializationTest extends SerializationTestCase<Str
         assertFalse(grandParent.isRoot());
         assertEquals(StringName.with("one"), grandParent.name());
 
-        assertSame(StringPath.ROOT, grandParent.parent());
+        assertSame(StringPath.ROOT, grandParent.parent().get());
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/AbsoluteUrlTest.java
+++ b/src/test/java/walkingkooka/net/AbsoluteUrlTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public final class AbsoluteUrlTest extends UrlTestCase<AbsoluteUrl> {

--- a/src/test/java/walkingkooka/net/Ip4AddressTest.java
+++ b/src/test/java/walkingkooka/net/Ip4AddressTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
 public final class Ip4AddressTest extends IpAddressTestCase<Ip4Address> {

--- a/src/test/java/walkingkooka/net/RelativeUrlTest.java
+++ b/src/test/java/walkingkooka/net/RelativeUrlTest.java
@@ -21,6 +21,7 @@ package walkingkooka.net;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public final class RelativeUrlTest extends UrlTestCase<RelativeUrl> {

--- a/src/test/java/walkingkooka/net/UrlPathNameTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathNameTest.java
@@ -25,6 +25,7 @@ import walkingkooka.text.CharSequences;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class UrlPathNameTest extends NameTestCase<UrlPathName> {
 

--- a/src/test/java/walkingkooka/net/UrlPathTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathTest.java
@@ -24,6 +24,7 @@ import walkingkooka.naming.PathSeparator;
 import walkingkooka.naming.PathTestCase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class UrlPathTest extends PathTestCase<UrlPath, UrlPathName> {
 

--- a/src/test/java/walkingkooka/net/UrlQueryStringTest.java
+++ b/src/test/java/walkingkooka/net/UrlQueryStringTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class UrlQueryStringTest extends HashCodeEqualsDefinedTestCase<UrlQueryString> {
 

--- a/src/test/java/walkingkooka/net/UrlSchemeTest.java
+++ b/src/test/java/walkingkooka/net/UrlSchemeTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import walkingkooka.naming.NameTestCase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class UrlSchemeTest extends NameTestCase<UrlScheme> {
 

--- a/src/test/java/walkingkooka/net/UrlTestCase.java
+++ b/src/test/java/walkingkooka/net/UrlTestCase.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.test.PublicClassTestCase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 /**
  * Base class for testing a {@link Url} with mostly parameter checking tests.

--- a/src/test/java/walkingkooka/predicate/AlwaysPredicateTest.java
+++ b/src/test/java/walkingkooka/predicate/AlwaysPredicateTest.java
@@ -23,6 +23,7 @@ import walkingkooka.Cast;
 import java.util.function.Predicate;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class AlwaysPredicateTest extends PredicateTestCase<AlwaysPredicate<Object>, Object> {
     @Test

--- a/src/test/java/walkingkooka/predicate/CharPredicateCharSequencePredicateSerializationTest.java
+++ b/src/test/java/walkingkooka/predicate/CharPredicateCharSequencePredicateSerializationTest.java
@@ -36,6 +36,6 @@ final public class CharPredicateCharSequencePredicateSerializationTest
 
     @Override
     protected boolean isSingleton() {
-        return true;
+        return false;
     }
 }

--- a/src/test/java/walkingkooka/predicate/CustomToStringPredicateTest.java
+++ b/src/test/java/walkingkooka/predicate/CustomToStringPredicateTest.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class CustomToStringPredicateTest extends PredicateTestCase<CustomToStringPredicate<String>, String>{
 

--- a/src/test/java/walkingkooka/predicate/NeverPredicateTest.java
+++ b/src/test/java/walkingkooka/predicate/NeverPredicateTest.java
@@ -23,6 +23,7 @@ import walkingkooka.Cast;
 import java.util.function.Predicate;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class NeverPredicateTest extends PredicateTestCase<NeverPredicate<Object>, Object> {
     @Test

--- a/src/test/java/walkingkooka/predicate/NotPredicateTest.java
+++ b/src/test/java/walkingkooka/predicate/NotPredicateTest.java
@@ -24,6 +24,7 @@ import walkingkooka.Cast;
 import java.util.function.Predicate;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class NotPredicateTest extends PredicateTestCase<NotPredicate<String>, String> {
 

--- a/src/test/java/walkingkooka/predicate/character/AlwaysCharPredicateTest.java
+++ b/src/test/java/walkingkooka/predicate/character/AlwaysCharPredicateTest.java
@@ -20,6 +20,7 @@ package walkingkooka.predicate.character;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class AlwaysCharPredicateTest extends CharPredicateTestCase<AlwaysCharPredicate> {
 

--- a/src/test/java/walkingkooka/predicate/character/AndCharPredicateTest.java
+++ b/src/test/java/walkingkooka/predicate/character/AndCharPredicateTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import walkingkooka.Cast;
 
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 final public class AndCharPredicateTest extends LogicalCharPredicateTestCase<AndCharPredicate> {
 

--- a/src/test/java/walkingkooka/predicate/character/AndNotCharPredicateTest.java
+++ b/src/test/java/walkingkooka/predicate/character/AndNotCharPredicateTest.java
@@ -20,30 +20,13 @@ import org.junit.Test;
 import walkingkooka.Cast;
 
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 final public class AndNotCharPredicateTest extends LogicalCharPredicateTestCase<AndNotCharPredicate> {
 
     private final static CharPredicate PREDICATE = CharPredicates.is('a');
 
     // tests
-
-    @Test
-    public void testWrapWithLeftAlways() {
-        final CharPredicate always = CharPredicates.always();
-        assertSame(PREDICATE, AndNotCharPredicate.wrap(always, PREDICATE));
-    }
-
-    @Test
-    public void testWrapWithRightAlways() {
-        final CharPredicate always = CharPredicates.always();
-        assertSame(PREDICATE, AndNotCharPredicate.wrap(PREDICATE, always));
-    }
-
-    @Test
-    public void testWrapWithLeftNever() {
-        final CharPredicate never = CharPredicates.never();
-        assertSame(never, AndNotCharPredicate.wrap(never, PREDICATE));
-    }
 
     @Test
     public void testWrapWithSame() {

--- a/src/test/java/walkingkooka/predicate/character/CharPredicateBuilderTest.java
+++ b/src/test/java/walkingkooka/predicate/character/CharPredicateBuilderTest.java
@@ -24,6 +24,7 @@ import walkingkooka.build.BuilderTestCase;
 import walkingkooka.text.CharSequences;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class CharPredicateBuilderTest
         extends BuilderTestCase<CharPredicateBuilder, CharPredicate> {

--- a/src/test/java/walkingkooka/predicate/character/LowerCasingCharPredicateTest.java
+++ b/src/test/java/walkingkooka/predicate/character/LowerCasingCharPredicateTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.Cast;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class LowerCasingCharPredicateTest
         extends CharPredicateTestCase<LowerCasingCharPredicate> {

--- a/src/test/java/walkingkooka/predicate/character/NeverCharPredicateTest.java
+++ b/src/test/java/walkingkooka/predicate/character/NeverCharPredicateTest.java
@@ -20,6 +20,7 @@ package walkingkooka.predicate.character;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class NeverCharPredicateTest extends CharPredicateTestCase<NeverCharPredicate> {
 

--- a/src/test/java/walkingkooka/predicate/character/NotCharPredicateTest.java
+++ b/src/test/java/walkingkooka/predicate/character/NotCharPredicateTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.Cast;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class NotCharPredicateTest extends CharPredicateTestCase<NotCharPredicate> {
 

--- a/src/test/java/walkingkooka/predicate/character/OrCharPredicateTest.java
+++ b/src/test/java/walkingkooka/predicate/character/OrCharPredicateTest.java
@@ -20,6 +20,8 @@ package walkingkooka.predicate.character;
 import org.junit.Test;
 import walkingkooka.Cast;
 
+import static org.junit.Assert.assertSame;
+
 final public class OrCharPredicateTest extends LogicalCharPredicateTestCase<OrCharPredicate> {
 
     private final static CharPredicate PREDICATE = CharPredicates.is('s');

--- a/src/test/java/walkingkooka/predicate/character/ToStringCharPredicateEqualityTest.java
+++ b/src/test/java/walkingkooka/predicate/character/ToStringCharPredicateEqualityTest.java
@@ -18,6 +18,7 @@
 package walkingkooka.predicate.character;
 
 import org.junit.Test;
+import walkingkooka.Cast;
 import walkingkooka.test.HashCodeEqualsDefinedEqualityTestCase;
 
 final public class ToStringCharPredicateEqualityTest
@@ -45,7 +46,7 @@ final public class ToStringCharPredicateEqualityTest
 
     @Override
     protected ToStringCharPredicate createObject() {
-        return ToStringCharPredicate.wrap(ToStringCharPredicateEqualityTest.PREDICATE,
-                ToStringCharPredicateEqualityTest.TOSTRING);
+        return Cast.to(ToStringCharPredicate.wrap(ToStringCharPredicateEqualityTest.PREDICATE,
+                ToStringCharPredicateEqualityTest.TOSTRING));
     }
 }

--- a/src/test/java/walkingkooka/predicate/character/ToStringCharPredicateSerializationTest.java
+++ b/src/test/java/walkingkooka/predicate/character/ToStringCharPredicateSerializationTest.java
@@ -25,7 +25,7 @@ final public class ToStringCharPredicateSerializationTest
 
     @Override
     protected ToStringCharPredicate create() {
-        return ToStringCharPredicate.wrap(CharPredicates.is('a'), "fancy toString");
+        return Cast.to(ToStringCharPredicate.wrap(CharPredicates.is('a'), "fancy toString"));
     }
 
     @Override

--- a/src/test/java/walkingkooka/predicate/character/ToStringCharPredicateTest.java
+++ b/src/test/java/walkingkooka/predicate/character/ToStringCharPredicateTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.Cast;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class ToStringCharPredicateTest extends CharPredicateTestCase<ToStringCharPredicate> {
 
@@ -69,8 +70,8 @@ final public class ToStringCharPredicateTest extends CharPredicateTestCase<ToStr
     @Test
     public void testWrapPredicate() {
         final ToStringCharPredicate predicate
-                = ToStringCharPredicate.wrap(ToStringCharPredicateTest.PREDICATE,
-                ToStringCharPredicateTest.TOSTRING);
+                = Cast.to(ToStringCharPredicate.wrap(ToStringCharPredicateTest.PREDICATE,
+                ToStringCharPredicateTest.TOSTRING));
         assertSame("predicate", ToStringCharPredicateTest.PREDICATE, predicate.predicate);
         assertSame("toString", ToStringCharPredicateTest.TOSTRING, predicate.toString);
     }
@@ -78,8 +79,8 @@ final public class ToStringCharPredicateTest extends CharPredicateTestCase<ToStr
     @Test
     public void testWrapAnotherToStringCharacterPredicate() {
         final ToStringCharPredicate predicate
-                = ToStringCharPredicate.wrap(ToStringCharPredicate.wrap(ToStringCharPredicateTest.PREDICATE,
-                "different"), ToStringCharPredicateTest.TOSTRING);
+                = Cast.to(ToStringCharPredicate.wrap(ToStringCharPredicate.wrap(ToStringCharPredicateTest.PREDICATE,
+                "different"), ToStringCharPredicateTest.TOSTRING));
         assertSame("predicate", ToStringCharPredicateTest.PREDICATE, predicate.predicate);
         assertSame("toString", ToStringCharPredicateTest.TOSTRING, predicate.toString);
     }
@@ -108,8 +109,8 @@ final public class ToStringCharPredicateTest extends CharPredicateTestCase<ToStr
 
     @Override
     protected ToStringCharPredicate createCharacterPredicate() {
-        return ToStringCharPredicate.wrap(ToStringCharPredicateTest.PREDICATE,
-                ToStringCharPredicateTest.TOSTRING);
+        return Cast.to(ToStringCharPredicate.wrap(ToStringCharPredicateTest.PREDICATE,
+                ToStringCharPredicateTest.TOSTRING));
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/CharSequencesCapitalizeTest.java
+++ b/src/test/java/walkingkooka/text/CharSequencesCapitalizeTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.test.StaticMethodTestCase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class CharSequencesCapitalizeTest extends StaticMethodTestCase {
 

--- a/src/test/java/walkingkooka/text/CharacterConstantTest.java
+++ b/src/test/java/walkingkooka/text/CharacterConstantTest.java
@@ -20,6 +20,7 @@ package walkingkooka.text;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class CharacterConstantTest extends CharSequenceTestCase<CharacterConstant> {
 

--- a/src/test/java/walkingkooka/text/IndentationTest.java
+++ b/src/test/java/walkingkooka/text/IndentationTest.java
@@ -24,6 +24,7 @@ import walkingkooka.test.HashCodeEqualsDefinedTestCase;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class IndentationTest extends HashCodeEqualsDefinedTestCase<Indentation> {
 

--- a/src/test/java/walkingkooka/text/LeftPaddedCharSequenceTest.java
+++ b/src/test/java/walkingkooka/text/LeftPaddedCharSequenceTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 final public class LeftPaddedCharSequenceTest extends CharSequenceTestCase<LeftPaddedCharSequence> {
 

--- a/src/test/java/walkingkooka/text/LineEndingTest.java
+++ b/src/test/java/walkingkooka/text/LineEndingTest.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class LineEndingTest extends CharSequenceTestCase<LineEnding> {
 

--- a/src/test/java/walkingkooka/text/ReaderConsumingCharSequenceTest.java
+++ b/src/test/java/walkingkooka/text/ReaderConsumingCharSequenceTest.java
@@ -81,6 +81,12 @@ public class ReaderConsumingCharSequenceTest extends CharSequenceTestCase<Reader
 
     @Test
     @Ignore
+    public void testSubSequenceWithSameFromAndToReturnsThis() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Ignore
     public void testEmptySubSequence2() {
         //nop
     }
@@ -106,6 +112,12 @@ public class ReaderConsumingCharSequenceTest extends CharSequenceTestCase<Reader
         final ReaderConsumingCharSequence chars = this.createCharSequence(text);
         chars.charAt(3);
         assertEquals("abcde", chars.toString());
+    }
+
+    @Test
+    @Ignore
+    public void testToStringCached() {
+        throw new UnsupportedOperationException();
     }
 
     @Override protected ReaderConsumingCharSequence createCharSequence() {

--- a/src/test/java/walkingkooka/text/RepeatingCharSequenceTest.java
+++ b/src/test/java/walkingkooka/text/RepeatingCharSequenceTest.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class RepeatingCharSequenceTest extends CharSequenceTestCase<RepeatingCharSequence> {
 

--- a/src/test/java/walkingkooka/text/RightPaddedCharSequenceTest.java
+++ b/src/test/java/walkingkooka/text/RightPaddedCharSequenceTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 final public class RightPaddedCharSequenceTest extends CharSequenceTestCase<RightPaddedCharSequence> {
 

--- a/src/test/java/walkingkooka/text/WhitespaceCharSequenceTest.java
+++ b/src/test/java/walkingkooka/text/WhitespaceCharSequenceTest.java
@@ -20,6 +20,7 @@ package walkingkooka.text;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class WhitespaceCharSequenceTest extends CharSequenceTestCase<Whitespace> {
 

--- a/src/test/java/walkingkooka/text/WhitespaceTest.java
+++ b/src/test/java/walkingkooka/text/WhitespaceTest.java
@@ -21,6 +21,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import walkingkooka.test.HashCodeEqualsDefinedTestCase;
 
+import static org.junit.Assert.assertSame;
+
 final public class WhitespaceTest extends HashCodeEqualsDefinedTestCase<Whitespace> {
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/CharSequenceTextCursorLineInfoTest.java
+++ b/src/test/java/walkingkooka/text/cursor/CharSequenceTextCursorLineInfoTest.java
@@ -18,11 +18,11 @@
 package walkingkooka.text.cursor;
 
 import org.junit.Test;
-import walkingkooka.test.TestCase;
 import walkingkooka.text.CharSequences;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 final public class CharSequenceTextCursorLineInfoTest extends TextCursorLineInfoTestCase<CharSequenceTextCursorLineInfo> {
 
@@ -41,7 +41,7 @@ final public class CharSequenceTextCursorLineInfoTest extends TextCursorLineInfo
     public void testWith() {
         final CharSequenceTextCursorLineInfo info = CharSequenceTextCursorLineInfo
                 .with(CharSequenceTextCursorLineInfoTest.TEXT, CharSequenceTextCursorLineInfoTest.POS);
-        TestCase.assertSame("text", CharSequenceTextCursorLineInfoTest.TEXT, info.text);
+        assertSame("text", CharSequenceTextCursorLineInfoTest.TEXT, info.text);
         assertEquals("pos", CharSequenceTextCursorLineInfoTest.POS, info.pos);
         assertNull("lineAndColumn", info.lineAndColumn);
     }

--- a/src/test/java/walkingkooka/text/cursor/parser/AlternativesParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/AlternativesParserTest.java
@@ -21,6 +21,7 @@ import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class AlternativesParserTest extends ParserTemplateTestCase<AlternativesParser<FakeParserContext>,
         ParserToken> {

--- a/src/test/java/walkingkooka/text/cursor/parser/CharacterParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/CharacterParserTokenTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class CharacterParserTokenTest extends ParserTokenTestCase<CharacterParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/CustomToStringParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/CustomToStringParserTest.java
@@ -21,6 +21,7 @@ import walkingkooka.Cast;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class CustomToStringParserTest extends ParserTestCase2<CustomToStringParser<StringParserToken, FakeParserContext>, StringParserToken>{
 
@@ -76,7 +77,7 @@ public final class CustomToStringParserTest extends ParserTestCase2<CustomToStri
 
     @Test
     public void testDefaultMethodSetToStringCustomToString() {
-        assertSame(CUSTOM_TO_STRING,  this.createParser().setToString(CUSTOM_TO_STRING));
+        assertSame(CUSTOM_TO_STRING,  this.createParser().setToString(CUSTOM_TO_STRING).toString());
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/DecimalParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/DecimalParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.math.BigDecimal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class DecimalParserTokenTest extends ParserTokenTestCase<DecimalParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/DoubleParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/DoubleParserTokenTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class DoubleParserTokenTest extends ParserTokenTestCase<DoubleParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/DoubleQuotedParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/DoubleQuotedParserTokenTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class DoubleQuotedParserTokenTest extends ParserTokenTestCase<DoubleQuotedParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/LongParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/LongParserTokenTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class LongParserTokenTest extends ParserTokenTestCase<LongParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/MissingParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/MissingParserTokenTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class MissingParserTokenTest extends ParserTokenTestCase<MissingParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/NumberParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/NumberParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.math.BigInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class NumberParserTokenTest extends ParserTokenTestCase<NumberParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/OptionalParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/OptionalParserTest.java
@@ -23,6 +23,7 @@ import walkingkooka.predicate.character.CharPredicates;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public class OptionalParserTest extends ParserTestCase2<OptionalParser<FakeParserContext>, ParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/RepeatedParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/RepeatedParserTest.java
@@ -22,6 +22,7 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.TextCursors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class RepeatedParserTest extends ParserTemplateTestCase<RepeatedParser<FakeParserContext>,
         RepeatedParserToken> {

--- a/src/test/java/walkingkooka/text/cursor/parser/RepeatedParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/RepeatedParserTokenTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class RepeatedParserTokenTest extends ParserTokenTestCase<RepeatedParserToken> {
 
@@ -112,7 +113,6 @@ public final class RepeatedParserTokenTest extends ParserTokenTestCase<RepeatedP
 
             @Override
             protected void endVisit(final ParserToken t) {
-                assertSame(token, t);
                 b.append("2");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenNodeTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenNodeTest.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public class SequenceParserTokenNodeTest extends ParserTokenNodeTestCase<SequenceParserTokenNode> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class SequenceParserTokenTest extends ParserTokenTestCase<SequenceParserToken> {
 
@@ -151,7 +152,7 @@ public final class SequenceParserTokenTest extends ParserTokenTestCase<SequenceP
 
     @Test
     public void testRemovingMissingNone() {
-        final SequenceParserToken token = this.createToken();
+        final SequenceParserToken token = sequence(STRING1, STRING2);
         assertSame(token, token.removeMissing());
     }
 
@@ -168,7 +169,7 @@ public final class SequenceParserTokenTest extends ParserTokenTestCase<SequenceP
 
     @Test
     public void testRemovingNoiseNone() {
-        final SequenceParserToken token = this.createToken();
+        final SequenceParserToken token = sequence(STRING1, STRING2);
         assertSame(token, token.removeNoise());
     }
 
@@ -229,7 +230,6 @@ public final class SequenceParserTokenTest extends ParserTokenTestCase<SequenceP
 
             @Override
             protected void endVisit(final ParserToken t) {
-                assertSame(token, t);
                 b.append("2");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/SignParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SignParserTokenTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SignParserTokenTest extends ParserTokenTestCase<SignParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/SingleQuotedParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SingleQuotedParserTokenTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SingleQuotedParserTokenTest extends ParserTokenTestCase<SingleQuotedParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/StringParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/StringParserTokenTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class StringParserTokenTest extends ParserTokenTestCase<StringParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfAlternativeParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class EbnfAlternativeParserTokenTest extends EbnfAlternativeConcatenationParentParserTokenTestCase<EbnfAlternativeParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfCommentParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfCommentParserTokenTest.java
@@ -21,6 +21,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class EbnfCommentParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfCommentParserToken, String> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfConcatenationParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class EbnfConcatenationParserTokenTest extends EbnfAlternativeConcatenationParentParserTokenTestCase<EbnfConcatenationParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserTokenTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public class EbnfExceptionParserTokenTest extends EbnfParentParserTokenTestCase2<EbnfExceptionParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTokenTest.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class EbnfGrammarParserTokenTest extends EbnfParentParserTokenTestCase<EbnfGrammarParserToken> {
 
@@ -86,7 +87,7 @@ public final class EbnfGrammarParserTokenTest extends EbnfParentParserTokenTestC
 
             @Override
             protected void visit(final EbnfIdentifierParserToken t) {
-                assertSame(range, t);
+                assertSame(identifier, t);
                 b.append("5");
                 visited.add(t);
             }
@@ -108,7 +109,6 @@ public final class EbnfGrammarParserTokenTest extends EbnfParentParserTokenTestC
 
             @Override
             protected void visit(final EbnfSymbolParserToken t) {
-                assertSame(range, t);
                 b.append("8");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGroupParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class EbnfGroupParserTokenTest extends EbnfGroupOptionalRepeatParentParserTokenTestCase<EbnfGroupParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierParserTokenTest.java
@@ -21,6 +21,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class EbnfIdentifierParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfIdentifierParserToken, EbnfIdentifierName> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfOptionalParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class EbnfOptionalParserTokenTest extends EbnfGroupOptionalRepeatParentParserTokenTestCase<EbnfOptionalParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParentParserTokenTestCase.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 public abstract class EbnfParentParserTokenTestCase<T extends EbnfParentParserToken> extends EbnfParserTokenTestCase<T> {
 
@@ -53,7 +54,7 @@ public abstract class EbnfParentParserTokenTestCase<T extends EbnfParentParserTo
         final T token = this.createToken(text, tokens);
         this.checkText(token, text);
         this.checkValue(token, tokens);
-        assertSame("tokens not copied", tokens, token.value());
+        assertEquals("tokens not copied", tokens, token.value());
     }
 
     @Test
@@ -66,7 +67,7 @@ public abstract class EbnfParentParserTokenTestCase<T extends EbnfParentParserTo
     @Test
     public void testWithoutCommentsSymbolsOrWhitespaceDoubleSame() {
         final T token = this.createToken();
-        assertSame(token, token.withoutCommentsSymbolsOrWhitespace().get());
+        assertSame(token.withoutCommentsSymbolsOrWhitespace(), token.withoutCommentsSymbolsOrWhitespace());
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserTokenTest.java
@@ -24,6 +24,8 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class EbnfRangeParserTokenTest extends EbnfParentParserTokenTestCase<EbnfRangeParserToken> {
 
@@ -116,7 +118,7 @@ public final class EbnfRangeParserTokenTest extends EbnfParentParserTokenTestCas
     @Test
     public void testWithoutCommentsSymbolsOrWhitespace() {
         final EbnfRangeParserToken token = this.createToken();
-        assertSame(token, token.withoutCommentsSymbolsOrWhitespace().get());
+        assertNotSame(token, token.withoutCommentsSymbolsOrWhitespace().get());
     }
 
     @Test
@@ -173,7 +175,6 @@ public final class EbnfRangeParserTokenTest extends EbnfParentParserTokenTestCas
 
             @Override
             protected void visit(final EbnfSymbolParserToken t) {
-                assertSame(range, t);
                 b.append("7");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRepeatParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class EbnfRepeatParserTokenTest extends EbnfGroupOptionalRepeatParentParserTokenTestCase<EbnfRepeatedParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTokenTest.java
@@ -24,6 +24,8 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfRuleParserToken> {
 
@@ -45,7 +47,7 @@ public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfR
     @Test
     public void testWithoutCommentsSymbolsOrWhitespace() {
         final EbnfRuleParserToken token = this.createToken();
-        assertSame(token, token.withoutCommentsSymbolsOrWhitespace().get());
+        assertNotSame(token, token.withoutCommentsSymbolsOrWhitespace().get());
     }
 
     @Test
@@ -54,7 +56,7 @@ public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfR
         final List<ParserToken> visited = Lists.array();
 
 
-        final EbnfRuleParserToken range = this.createToken();
+        final EbnfRuleParserToken rule = this.createToken();
         final EbnfIdentifierParserToken identifier = this.identifier1();
         final EbnfSymbolParserToken assignment = this.assignment();
         final EbnfTerminalParserToken terminal = this.terminal1();
@@ -89,14 +91,14 @@ public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfR
 
             @Override
             protected void visit(final EbnfIdentifierParserToken t) {
-                assertSame(range, t);
+                assertEquals(identifier, t);
                 b.append("5");
                 visited.add(t);
             }
 
             @Override
             protected Visiting startVisit(final EbnfRuleParserToken t) {
-                assertSame(range, t);
+                assertSame(rule, t);
                 b.append("6");
                 visited.add(t);
                 return Visiting.CONTINUE;
@@ -104,14 +106,13 @@ public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfR
 
             @Override
             protected void endVisit(final EbnfRuleParserToken t) {
-                assertSame(range, t);
+                assertSame(rule, t);
                 b.append("7");
                 visited.add(t);
             }
 
             @Override
             protected void visit(final EbnfSymbolParserToken t) {
-                assertSame(range, t);
                 b.append("8");
                 visited.add(t);
             }
@@ -121,15 +122,15 @@ public class EbnfRuleParserTokenTest extends EbnfParentParserTokenTestCase<EbnfR
                 b.append("9");
                 visited.add(t);
             }
-        }.accept(range);
+        }.accept(rule);
         assertEquals("13613542138421394213842742", b.toString());
         assertEquals("visited",
-                Lists.of(range, range, range,
+                Lists.of(rule, rule, rule,
                         identifier, identifier, identifier, identifier, identifier,
                         assignment, assignment, assignment, assignment, assignment,
                         terminal, terminal, terminal, terminal, terminal,
                         terminator, terminator, terminator, terminator, terminator,
-                        range, range, range),
+                        rule, rule, rule),
                 visited);
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfSymbolParserTokenTest.java
@@ -21,6 +21,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class EbnfSymbolParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfSymbolParserToken, String> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfTerminalParserTokenTest.java
@@ -21,6 +21,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class EbnfTerminalParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfTerminalParserToken, String> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfWhitespaceParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfWhitespaceParserTokenTest.java
@@ -21,6 +21,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class EbnfWhitespaceParserTokenTest extends EbnfLeafParserTokenTestCase<EbnfWhitespaceParserToken, String> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeArrayBeginSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeArrayBeginSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonNodeArrayBeginSymbolParserTokenTest extends JsonNodeSymbolParserTokenTestCase<JsonNodeArrayBeginSymbolParserToken, String> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeArrayEndSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeArrayEndSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonNodeArrayEndSymbolParserTokenTest extends JsonNodeSymbolParserTokenTestCase<JsonNodeArrayBeginSymbolParserToken, String> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeBooleanParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeBooleanParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonNodeBooleanParserTokenTest extends JsonNodeLeafParserTokenTestCase2<JsonNodeBooleanParserToken, Boolean, JsonBooleanNode> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeNullParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeNullParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.json.JsonNullNode;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonNodeNullParserTokenTest extends JsonNodeLeafParserTokenTestCase2<JsonNodeNullParserToken, Void, JsonNullNode> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeNumberParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeNumberParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.json.JsonNumberNode;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonNodeNumberParserTokenTest extends JsonNodeLeafParserTokenTestCase2<JsonNodeNumberParserToken, Double, JsonNumberNode> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeObjectBeginSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeObjectBeginSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonNodeObjectBeginSymbolParserTokenTest extends JsonNodeSymbolParserTokenTestCase<JsonNodeArrayBeginSymbolParserToken, String> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeObjectEndSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeObjectEndSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonNodeObjectEndSymbolParserTokenTest extends JsonNodeSymbolParserTokenTestCase<JsonNodeArrayBeginSymbolParserToken, String> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeParentParserTokenTestCase.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 public abstract class JsonNodeParentParserTokenTestCase<T extends JsonNodeParentParserToken> extends JsonNodeParserTokenTestCase<T> {
 
@@ -49,7 +50,7 @@ public abstract class JsonNodeParentParserTokenTestCase<T extends JsonNodeParent
         final T token = this.createToken(text, tokens);
         this.checkText(token, text);
         assertEquals("tokens", tokens, token.value());
-        assertSame("tokens not copied", tokens, token.value());
+        assertEquals("tokens not copied", tokens, token.value());
     }
 
     @Test
@@ -62,7 +63,7 @@ public abstract class JsonNodeParentParserTokenTestCase<T extends JsonNodeParent
     @Test
     public final void testWithoutSymbolsOrWhitespaceDoubleSame() {
         final T token = this.createToken();
-        assertSame(token, token.withoutSymbolsOrWhitespace().get());
+        assertSame(token.withoutSymbolsOrWhitespace(), token.withoutSymbolsOrWhitespace());
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeStringParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeStringParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.json.JsonStringNode;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonNodeStringParserTokenTest extends JsonNodeLeafParserTokenTestCase2<JsonNodeStringParserToken, String, JsonStringNode> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeWhitespaceParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeWhitespaceParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonNodeWhitespaceParserTokenTest extends JsonNodeLeafParserTokenTestCase<JsonNodeWhitespaceParserToken, String> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetAdditionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetAdditionParserTokenTest.java
@@ -27,6 +27,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetAdditionParserTokenTest extends SpreadsheetBinaryParserTokenTestCase2<SpreadsheetAdditionParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBetweenSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBetweenSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetBetweenSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetBetweenSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserTokenTestCase.java
@@ -26,6 +26,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public abstract class SpreadsheetBinaryParserTokenTestCase<T extends SpreadsheetBinaryParserToken> extends SpreadsheetParentParserTokenTestCase<T> {
 
@@ -63,9 +64,9 @@ public abstract class SpreadsheetBinaryParserTokenTestCase<T extends Spreadsheet
         final SpreadsheetParserToken right = this.rightToken();
 
         final String text = left.text() + operator.text() + right.text();
-        final T token = this.createToken(text, left, operator, right);
+        final T token = this.createToken(text, left, right);
         this.checkText(token, text);
-        this.checkValue(token, left, operator, right);
+        this.checkValue(token, left, right);
 
         assertSame(token, token.withoutSymbolsOrWhitespace().get());
     }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellParserTokenTest.java
@@ -26,6 +26,7 @@ import walkingkooka.tree.expression.ExpressionNode;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetCellParserTokenTest extends SpreadsheetParentParserTokenTestCase<SpreadsheetCellParserToken> {
 
@@ -59,7 +60,7 @@ public final class SpreadsheetCellParserTokenTest extends SpreadsheetParentParse
         this.checkValue(cell, row, column);
         assertEquals("cell", SpreadsheetCell.with(column.value(), row.value()), cell.cell());
 
-        assertSame(cell, cell.withoutSymbolsOrWhitespace());
+        assertSame(cell, cell.withoutSymbolsOrWhitespace().get());
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.test.HashCodeEqualsDefinedTestCase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetCellTest extends HashCodeEqualsDefinedTestCase<SpreadsheetCell> {
     
@@ -40,8 +41,8 @@ public final class SpreadsheetCellTest extends HashCodeEqualsDefinedTestCase<Spr
         final SpreadsheetColumn column = this.column();
         final SpreadsheetRow row = this.row();
         final SpreadsheetCell cell = SpreadsheetCell.with(column, row);
-        assertSame("column", column(), cell.column());
-        assertSame("row", row(), cell.row());
+        assertSame("column", column, cell.column());
+        assertSame("row", row, cell.row());
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCloseParenthesisSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCloseParenthesisSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetCloseParenthesisSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetCloseParenthesisSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetColumnParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetColumnParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetColumnParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetColumnParserToken, SpreadsheetColumn> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDecimalParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDecimalParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.math.BigDecimal;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetDecimalParserTokenTest extends SpreadsheetNumericParserTokenTestCase<SpreadsheetDecimalParserToken, BigDecimal> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDivideSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDivideSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetDivideSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetDivideSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDivisionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDivisionParserTokenTest.java
@@ -27,6 +27,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetDivisionParserTokenTest extends SpreadsheetBinaryParserTokenTestCase2<SpreadsheetDivisionParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDoubleParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDoubleParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetDoubleParserTokenTest extends SpreadsheetNumericParserTokenTestCase<SpreadsheetDoubleParserToken, Double> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetEqualsParserTokenTest.java
@@ -27,6 +27,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetEqualsParserTokenTest extends SpreadsheetBinaryParserTokenTestCase2<SpreadsheetEqualsParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetEqualsSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetEqualsSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetEqualsSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetEqualsSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionNameParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionNameParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetFunctionNameParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetFunctionNameParserToken, SpreadsheetFunctionName> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParameterSeparatorSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParameterSeparatorSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetFunctionParameterSeparatorSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetFunctionParameterSeparatorSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParserTokenTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetFunctionParserTokenTest extends SpreadsheetParentParserTokenTestCase<SpreadsheetFunctionParserToken> {
 
@@ -46,7 +47,7 @@ public final class SpreadsheetFunctionParserTokenTest extends SpreadsheetParentP
         final SpreadsheetFunctionNameParserToken name = this.function();
         final SpreadsheetFunctionParserToken token = this.createToken(text, name, this.number1());
         this.checkText(token, text);
-        assertSame(token, token.withoutSymbolsOrWhitespace());
+        assertSame(token, token.withoutSymbolsOrWhitespace().get());
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanEqualsParserTokenTest.java
@@ -27,6 +27,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetGreaterThanEqualsParserTokenTest extends SpreadsheetBinaryParserTokenTestCase2<SpreadsheetGreaterThanEqualsParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanEqualsSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanEqualsSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetGreaterThanEqualsSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetGreaterThanEqualsSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanParserTokenTest.java
@@ -27,6 +27,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetGreaterThanParserTokenTest extends SpreadsheetBinaryParserTokenTestCase2<SpreadsheetGreaterThanParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetGreaterThanSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetGreaterThanSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGroupParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGroupParserTokenTest.java
@@ -28,6 +28,7 @@ import java.math.BigInteger;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetGroupParserTokenTest extends SpreadsheetParentParserTokenTestCase<SpreadsheetGroupParserToken> {
 
@@ -46,7 +47,7 @@ public final class SpreadsheetGroupParserTokenTest extends SpreadsheetParentPars
         final String text = "(" + NUMBER1 + ")";
         final SpreadsheetGroupParserToken token = this.createToken(text, this.number1());
         this.checkText(token, text);
-        assertSame(token, token.withoutSymbolsOrWhitespace());
+        assertSame(token, token.withoutSymbolsOrWhitespace().get());
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLabelNameParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLabelNameParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetLabelNameParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetLabelNameParserToken, SpreadsheetLabelName> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanEqualsParserTokenTest.java
@@ -27,6 +27,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetLessThanEqualsParserTokenTest extends SpreadsheetBinaryParserTokenTestCase2<SpreadsheetLessThanEqualsParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanEqualsSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanEqualsSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetLessThanEqualsSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetLessThanEqualsSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanParserTokenTest.java
@@ -27,6 +27,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetLessThanParserTokenTest extends SpreadsheetBinaryParserTokenTestCase2<SpreadsheetLessThanParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetLessThanSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetLessThanSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLongParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLongParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetLongParserTokenTest extends SpreadsheetNumericParserTokenTestCase<SpreadsheetLongParserToken, Long> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetMinusSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetMinusSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetMinusSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetMinusSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetMultiplySymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetMultiplySymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetMultiplySymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetMultiplySymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNegativeParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNegativeParserTokenTest.java
@@ -28,6 +28,7 @@ import java.math.BigInteger;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetNegativeParserTokenTest extends SpreadsheetUnaryParserTokenTestCase<SpreadsheetNegativeParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNotEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNotEqualsParserTokenTest.java
@@ -27,6 +27,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetNotEqualsParserTokenTest extends SpreadsheetBinaryParserTokenTestCase2<SpreadsheetNotEqualsParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNotEqualsSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNotEqualsSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetNotEqualsSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetNotEqualsSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNumberParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNumberParserTokenTest.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.math.BigInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetNumberParserTokenTest extends SpreadsheetNumericParserTokenTestCase<SpreadsheetNumberParserToken, BigInteger> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetOpenParenthesisSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetOpenParenthesisSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetOpenParenthesisSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetOpenParenthesisSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserTokenTestCase.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public abstract class SpreadsheetParentParserTokenTestCase<T extends SpreadsheetParentParserToken> extends SpreadsheetParserTokenTestCase<T> {
 
@@ -54,7 +55,7 @@ public abstract class SpreadsheetParentParserTokenTestCase<T extends Spreadsheet
         final T token = this.createToken(text, tokens);
         this.checkText(token, text);
         assertEquals("tokens", tokens, token.value());
-        assertSame("tokens not copied", tokens, token.value());
+        assertEquals("tokens not copied", tokens, token.value());
     }
 
     @Test
@@ -67,7 +68,7 @@ public abstract class SpreadsheetParentParserTokenTestCase<T extends Spreadsheet
     @Test
     public void testWithoutSymbolsOrWhitespaceDoubleSame() {
         final T token = this.createToken();
-        assertSame(token, token.withoutSymbolsOrWhitespace().get());
+        assertSame(token.withoutSymbolsOrWhitespace().get(), token.withoutSymbolsOrWhitespace().get());
     }
 
     abstract T createToken(final String text, final List<ParserToken> tokens);

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPercentSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPercentSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetPercentSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetPercentSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPercentageParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPercentageParserTokenTest.java
@@ -28,6 +28,7 @@ import java.math.BigInteger;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetPercentageParserTokenTest extends SpreadsheetUnaryParserTokenTestCase<SpreadsheetPercentageParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPlusSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPlusSymbolParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetPlusSymbolParserTokenTest extends SpreadsheetSymbolParserTokenTestCase<SpreadsheetPlusSymbolParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPowerParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPowerParserTokenTest.java
@@ -27,6 +27,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetPowerParserTokenTest extends SpreadsheetBinaryParserTokenTestCase2<SpreadsheetPowerParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetRangeParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetRangeParserTokenTest.java
@@ -26,6 +26,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetRangeParserTokenTest extends SpreadsheetBinaryParserTokenTestCase<SpreadsheetRangeParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetRowParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetRowParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetRowParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetRowParserToken, SpreadsheetRow> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSubtractionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSubtractionParserTokenTest.java
@@ -27,6 +27,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetSubtractionParserTokenTest extends SpreadsheetBinaryParserTokenTestCase2<SpreadsheetSubtractionParserToken> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetTextParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetTextParserTokenTest.java
@@ -23,6 +23,7 @@ import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetTextParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetTextParserToken, String> {
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetWhitespaceParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetWhitespaceParserTokenTest.java
@@ -22,6 +22,7 @@ import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class SpreadsheetWhitespaceParserTokenTest extends SpreadsheetLeafParserTokenTestCase<SpreadsheetWhitespaceParserToken, String> {
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionAdditionNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionAdditionNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionAdditionNodeTest extends ExpressionBinaryNodeTestCase<ExpressionAdditionNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionAndNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionAndNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionAndNodeTest extends ExpressionBinaryNodeTestCase<ExpressionAndNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionBinaryNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionBinaryNodeTestCase.java
@@ -27,6 +27,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public abstract class ExpressionBinaryNodeTestCase<N extends ExpressionBinaryNode> extends ExpressionParentFixedNodeTestCase<N> {
 
@@ -74,7 +75,7 @@ public abstract class ExpressionBinaryNodeTestCase<N extends ExpressionBinaryNod
         this.checkChildren(expression, children);
 
         assertSame("original children", children, expression.children());
-        assertSame("updated children", differentChildren, different.children());
+        assertNotSame("updated children", differentChildren, different.children());
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/expression/ExpressionBooleanNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionBooleanNodeTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionBooleanNodeTest extends ExpressionLeafValueNodeTestCase<ExpressionBooleanNode, Boolean>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionDivisionNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionDivisionNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionDivisionNodeTest extends ExpressionBinaryNodeTestCase<ExpressionDivisionNode>{
     

--- a/src/test/java/walkingkooka/tree/expression/ExpressionEqualsNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionEqualsNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionEqualsNodeTest extends ExpressionBinaryNodeTestCase<ExpressionEqualsNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionFunctionNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionFunctionNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionFunctionNodeTest extends ExpressionVariableNodeTestCase<ExpressionFunctionNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionGreaterThanEqualsNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionGreaterThanEqualsNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionGreaterThanEqualsNodeTest extends ExpressionBinaryNodeTestCase<ExpressionGreaterThanEqualsNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionGreaterThanNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionGreaterThanNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionGreaterThanNodeTest extends ExpressionBinaryNodeTestCase<ExpressionGreaterThanNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionGroupNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionGroupNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionGroupNodeTest extends ExpressionUnaryNodeTestCase<ExpressionGroupNode> {
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionLeafValueNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionLeafValueNodeTestCase.java
@@ -24,6 +24,7 @@ import walkingkooka.collect.list.Lists;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public abstract class ExpressionLeafValueNodeTestCase<N extends ExpressionLeafValueNode<V>, V> extends ExpressionLeafNodeTestCase<N> {
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionLessThanEqualsNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionLessThanEqualsNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionLessThanEqualsNodeTest extends ExpressionBinaryNodeTestCase<ExpressionLessThanEqualsNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionLessThanNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionLessThanNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionLessThanNodeTest extends ExpressionBinaryNodeTestCase<ExpressionLessThanNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionModuloNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionModuloNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionModuloNodeTest extends ExpressionBinaryNodeTestCase<ExpressionModuloNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionMultiplicationNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionMultiplicationNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionMultiplicationNodeTest extends ExpressionBinaryNodeTestCase<ExpressionMultiplicationNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNegativeNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNegativeNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionNegativeNodeTest extends ExpressionUnaryNodeTestCase<ExpressionNegativeNode> {
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNotEqualsNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNotEqualsNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionNotEqualsNodeTest extends ExpressionBinaryNodeTestCase<ExpressionNotEqualsNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNotNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNotNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionNotNodeTest extends ExpressionUnaryNodeTestCase<ExpressionNotNode> {
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNumberNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNumberNodeTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionNumberNodeTest extends ExpressionLeafValueNodeTestCase<ExpressionNumberNode, Number>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionOrNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionOrNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionOrNodeTest extends ExpressionBinaryNodeTestCase<ExpressionOrNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionParentNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionParentNodeTestCase.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public abstract class ExpressionParentNodeTestCase<N extends ExpressionParentNode> extends ExpressionNodeTestCase<N> {
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionPowerNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionPowerNodeTest.java
@@ -7,6 +7,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionPowerNodeTest extends ExpressionBinaryNodeTestCase<ExpressionPowerNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionReferenceNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionReferenceNodeTest.java
@@ -26,6 +26,7 @@ import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRow;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionReferenceNodeTest extends ExpressionLeafValueNodeTestCase<ExpressionReferenceNode, ExpressionReference>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionSubtractionNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionSubtractionNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionSubtractionNodeTest extends ExpressionBinaryNodeTestCase<ExpressionSubtractionNode>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionTextNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionTextNodeTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionTextNodeTest extends ExpressionLeafValueNodeTestCase<ExpressionTextNode, String>{
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionUnaryNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionUnaryNodeTestCase.java
@@ -27,6 +27,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public abstract class ExpressionUnaryNodeTestCase<N extends ExpressionUnaryNode> extends ExpressionParentFixedNodeTestCase<N> {
 
@@ -61,7 +62,7 @@ public abstract class ExpressionUnaryNodeTestCase<N extends ExpressionUnaryNode>
         this.checkChildren(expression, children);
 
         assertSame("original children", children, expression.children());
-        assertSame("updated children", differentChildren, different.children());
+        assertNotSame("updated children", differentChildren, different.children());
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/expression/ExpressionVariableNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionVariableNodeTestCase.java
@@ -26,6 +26,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public abstract class ExpressionVariableNodeTestCase<N extends ExpressionVariableNode> extends  ExpressionParentNodeTestCase<N> {
 
@@ -72,7 +73,7 @@ public abstract class ExpressionVariableNodeTestCase<N extends ExpressionVariabl
         this.checkChildren(expression, children);
 
         assertSame("original children", children, expression.children());
-        assertSame("updated children", differentChildren, different.children());
+        assertNotSame("updated children", differentChildren, different.children());
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/expression/ExpressionXorNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionXorNodeTest.java
@@ -25,6 +25,7 @@ import walkingkooka.tree.visit.Visiting;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class ExpressionXorNodeTest extends ExpressionBinaryNodeTestCase<ExpressionXorNode>{
 

--- a/src/test/java/walkingkooka/tree/file/FileNodeTest.java
+++ b/src/test/java/walkingkooka/tree/file/FileNodeTest.java
@@ -44,6 +44,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/src/test/java/walkingkooka/tree/json/JsonArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonArrayNodeTest.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
 public final class JsonArrayNodeTest extends JsonParentNodeTestCase<JsonArrayNode>{

--- a/src/test/java/walkingkooka/tree/json/JsonBooleanNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonBooleanNodeTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonBooleanNodeTest extends JsonLeafNodeTestCase<JsonBooleanNode, Boolean>{
 

--- a/src/test/java/walkingkooka/tree/json/JsonNullNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonNullNodeTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonNullNodeTest extends JsonLeafNodeTestCase<JsonNullNode, Void>{
 

--- a/src/test/java/walkingkooka/tree/json/JsonNumberNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonNumberNodeTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonNumberNodeTest extends JsonLeafNodeTestCase<JsonNumberNode, Double>{
 

--- a/src/test/java/walkingkooka/tree/json/JsonObjectNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonObjectNodeTest.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonObjectNodeTest extends JsonParentNodeTestCase<JsonObjectNode>{
 

--- a/src/test/java/walkingkooka/tree/json/JsonStringNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonStringNodeTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import walkingkooka.tree.visit.Visiting;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public final class JsonStringNodeTest extends JsonLeafNodeTestCase<JsonStringNode, String>{
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoBooleanArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoBooleanArrayNodeTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoBooleanArrayNodeTest extends PojoArrayNodeTestCase<PojoBooleanArrayNode, boolean[]> {
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoByteArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoByteArrayNodeTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoByteArrayNodeTest extends PojoArrayNodeTestCase<PojoByteArrayNode, byte[]> {
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoCharArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoCharArrayNodeTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoCharArrayNodeTest extends PojoArrayNodeTestCase<PojoCharArrayNode, char[]> {
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoDoubleArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoDoubleArrayNodeTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoDoubleArrayNodeTest extends PojoArrayNodeTestCase<PojoDoubleArrayNode, double[]> {
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoFloatArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoFloatArrayNodeTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoFloatArrayNodeTest extends PojoArrayNodeTestCase<PojoFloatArrayNode, float[]> {
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoIntArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoIntArrayNodeTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoIntArrayNodeTest extends PojoArrayNodeTestCase<PojoIntArrayNode, int[]> {
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoListNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoListNodeTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoListNodeTest extends PojoCollectionNodeTestCase<PojoListNode, List<Object>> {
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoLongArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoLongArrayNodeTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoLongArrayNodeTest extends PojoArrayNodeTestCase<PojoLongArrayNode, long[]> {
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoMapNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoMapNodeTest.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoMapNodeTest extends PojoCollectionNodeTestCase<PojoMapNode, Map<Object, Object>> {
 
@@ -142,7 +143,7 @@ public final class PojoMapNodeTest extends PojoCollectionNodeTestCase<PojoMapNod
         this.childrenValuesCheck(childNode2, children2);
 
         final PojoNode parentNode2 = childNode2.parent().get();
-        assertSame(parentNode, parentNode2);
+        assertNotSame(parentNode, parentNode2);
 
         this.childrenValuesCheck(parentNode2, Lists.of(
                 entry(KEY0, new TestMutableLeaf(STRING2)),
@@ -212,7 +213,7 @@ public final class PojoMapNodeTest extends PojoCollectionNodeTestCase<PojoMapNod
         this.childrenValuesCheck(childNode2, children2);
 
         final PojoNode parentNode2 = childNode2.parent().get();
-        assertSame(parentNode, parentNode2);
+        assertNotSame(parentNode, parentNode2);
 
         this.childrenValuesCheck(parentNode2, Lists.of(
                 entry(KEY0, new TestMutableLeaf(STRING2)),

--- a/src/test/java/walkingkooka/tree/pojo/PojoNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoNodeTestCase.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public abstract class PojoNodeTestCase<N extends PojoNode, V> extends NodeTestCase<PojoNode, PojoName, PojoNodeAttributeName, Object> {
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoNodeTestCase2.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoNodeTestCase2.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public abstract class PojoNodeTestCase2<N extends PojoNode2, V> extends PojoNodeTestCase<N, V>{
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoObjectArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoObjectArrayNodeTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoObjectArrayNodeTest extends PojoArrayNodeTestCase<PojoObjectArrayNode, Object[]> {
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoObjectNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoObjectNodeTest.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoObjectNodeTest extends PojoNodeTestCase2<PojoObjectNode, Object> {
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoSetNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoSetNodeTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoSetNodeTest extends PojoCollectionNodeTestCase<PojoSetNode, Set<Object>> {
 

--- a/src/test/java/walkingkooka/tree/pojo/PojoShortArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoShortArrayNodeTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class PojoShortArrayNodeTest extends PojoArrayNodeTestCase<PojoShortArrayNode, short[]> {
 

--- a/src/test/java/walkingkooka/tree/pojo/ReflectionImmutableWritablePojoPropertyTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/ReflectionImmutableWritablePojoPropertyTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class ReflectionImmutableWritablePojoPropertyTest extends PojoPropertyTestCase<ReflectionImmutableWritablePojoProperty> {
 

--- a/src/test/java/walkingkooka/tree/select/AbsoluteNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/AbsoluteNodeSelectorTest.java
@@ -25,6 +25,7 @@ import walkingkooka.predicate.Predicates;
 import java.util.function.Predicate;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class AbsoluteNodeSelectorTest extends
         UnaryNodeSelectorTestCase<AbsoluteNodeSelector<TestFakeNode, StringName, StringName, Object>> {

--- a/src/test/java/walkingkooka/tree/select/LogicalNodeSelectorTestCase.java
+++ b/src/test/java/walkingkooka/tree/select/LogicalNodeSelectorTestCase.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 import walkingkooka.Cast;
 import walkingkooka.naming.StringName;
 
+import static org.junit.Assert.assertSame;
+
 public abstract class LogicalNodeSelectorTestCase<S extends LogicalNodeSelector<TestFakeNode, StringName, StringName, Object>>
 extends NodeSelectorTestCase<S>{
 

--- a/src/test/java/walkingkooka/util/PairTest.java
+++ b/src/test/java/walkingkooka/util/PairTest.java
@@ -23,6 +23,7 @@ import walkingkooka.Cast;
 import walkingkooka.test.HashCodeEqualsDefinedTestCase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class PairTest extends HashCodeEqualsDefinedTestCase<Pair<?, ?>> {
 

--- a/src/test/java/walkingkooka/util/systemproperty/SystemPropertyConstantsTest.java
+++ b/src/test/java/walkingkooka/util/systemproperty/SystemPropertyConstantsTest.java
@@ -26,6 +26,8 @@ import walkingkooka.type.MemberVisibility;
 import java.lang.reflect.Field;
 import java.util.Set;
 
+import static org.junit.Assert.assertSame;
+
 final public class SystemPropertyConstantsTest extends ConstantsTestCase<SystemProperty> {
 
     @Test
@@ -40,7 +42,11 @@ final public class SystemPropertyConstantsTest extends ConstantsTestCase<SystemP
             if (false == SystemProperty.class.equals(field.getType())) {
                 continue;
             }
-            final String name = field.getName().toLowerCase().replace("_", ".");
+            final String fieldName = field.getName();
+            if(fieldName.equals("FILE_SYSTEM_CASE_SENSITIVITY")){
+                continue;
+            }
+            final String name = fieldName.toLowerCase().replace("_", ".");
             final SystemProperty property = SystemProperty.class.cast(field.get(null));
             assertSame(property, SystemProperty.get(name));
         }

--- a/src/test/java/walkingkooka/util/systemproperty/SystemPropertyTest.java
+++ b/src/test/java/walkingkooka/util/systemproperty/SystemPropertyTest.java
@@ -23,6 +23,7 @@ import walkingkooka.test.PublicClassTestCase;
 import walkingkooka.text.CharSequences;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class SystemPropertyTest extends PublicClassTestCase<SystemProperty> {
 

--- a/src/test/java/walkingkooka/util/variable/AtomicReferenceVariableTest.java
+++ b/src/test/java/walkingkooka/util/variable/AtomicReferenceVariableTest.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class AtomicReferenceVariableTest extends VariableTestCase<AtomicReferenceVariable<Object>, Object> {
 

--- a/src/test/java/walkingkooka/util/variable/LabelledVariableTest.java
+++ b/src/test/java/walkingkooka/util/variable/LabelledVariableTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class LabelledVariableTest extends VariableTestCase<LabelledVariable<Object>, Object> {
 

--- a/src/test/java/walkingkooka/util/variable/NonNullVariableTest.java
+++ b/src/test/java/walkingkooka/util/variable/NonNullVariableTest.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class NonNullVariableTest extends VariableTestCase<NonNullVariable<Object>, Object> {
 

--- a/src/test/java/walkingkooka/util/variable/ReadOnlyVariableTest.java
+++ b/src/test/java/walkingkooka/util/variable/ReadOnlyVariableTest.java
@@ -21,6 +21,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class ReadOnlyVariableTest extends VariableTestCase<ReadOnlyVariable<Object>, Object> {
 

--- a/src/test/java/walkingkooka/util/variable/SetOnceVariableTest.java
+++ b/src/test/java/walkingkooka/util/variable/SetOnceVariableTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 final public class SetOnceVariableTest extends VariableTestCase<SetOnceVariable<Object>, Object> {
 

--- a/src/test/java/walkingkooka/xml/DomDocumentTest.java
+++ b/src/test/java/walkingkooka/xml/DomDocumentTest.java
@@ -38,6 +38,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public final class DomDocumentTest extends DomParentNodeTestCase<DomDocument> {
 
@@ -712,7 +713,7 @@ public final class DomDocumentTest extends DomParentNodeTestCase<DomDocument> {
         final DomDocument document2 = document.appendChild(
                 document.createElement(DomName.element("root"))
                 .appendChild( document.createText(TEXT)));
-        assertSame(document, document.setElement(document2.element()));
+        assertSame(document2, document2.setElement(document2.element()));
     }
 
     @Test

--- a/src/test/java/walkingkooka/xml/DomElementTest.java
+++ b/src/test/java/walkingkooka/xml/DomElementTest.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public final class DomElementTest extends DomParentNodeTestCase<DomElement> {

--- a/src/test/java/walkingkooka/xml/DomNodeTestCase.java
+++ b/src/test/java/walkingkooka/xml/DomNodeTestCase.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public abstract class DomNodeTestCase<N extends DomNode> extends NodeTestCase<DomNode, DomName, DomAttributeName, String> {
 

--- a/src/test/java/walkingkooka/xml/DomParentNodeTestCase.java
+++ b/src/test/java/walkingkooka/xml/DomParentNodeTestCase.java
@@ -18,9 +18,9 @@
 package walkingkooka.xml;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public abstract class DomParentNodeTestCase<N extends DomParentNode> extends DomNodeTestCase<N> {
 
@@ -35,7 +35,7 @@ public abstract class DomParentNodeTestCase<N extends DomParentNode> extends Dom
         final List<DomNode> children= parent.children();
         for(int i = 0; i <count; i++) {
             final DomNode child = children.get(i);
-            assertSame("child of "+ label+ " has wrong parent", Optional.of(parent), child.parent());
+            assertSame("child of "+ label+ " has wrong parent", parent, child.parent().get());
             if(null!=parentNode) {
                 assertSame("parent node of child is wrong", parentNode, child.node.getParentNode());
             }

--- a/src/test/java/walkingkooka/xml/DomTextNodeTestCase.java
+++ b/src/test/java/walkingkooka/xml/DomTextNodeTestCase.java
@@ -22,6 +22,7 @@ import org.w3c.dom.Document;
 import walkingkooka.Cast;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 public abstract class DomTextNodeTestCase<N extends DomTextNode> extends DomLeafNodeTestCase<N> {
 


### PR DESCRIPTION
- Fixed ExpressionNode.setChildren adoption of incoming children.
- Fixed ToStringCharPredicate.wrap/avoiding unnecessary wrap
- Fixed Pojo.setValue to equality check objects and arrays.
- Fixed a few tests that were using broken TestCase.assertSame.
- Fixed case where DomParentNodes werent setting of parent and index for children.
- Optimised computeWithout for EbnfParserToken, JsonParserToken, SpreadsheetParserToken
- Fixed MissingParserToken.name() to return value.