### PR TITLE
For NodeTestCase & ParserTokenTestCases added tests that properties n…

### DIFF
--- a/src/main/java/walkingkooka/test/SkipPropertyNeverReturnsNullCheck.java
+++ b/src/main/java/walkingkooka/test/SkipPropertyNeverReturnsNullCheck.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface SkipPropertyNeverReturnsNullCheck {
+
+    /**
+     * When empty all derived methods are skipped, if some classes are contained the method only for those types are skipped.
+     * @return
+     */
+    Class<?>[] value();
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokenTestCase.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokenTestCase.java
@@ -111,6 +111,11 @@ public abstract class ParserTokenTestCase<T extends ParserToken> extends PublicC
     }
 
     @Test
+    public void testPropertiesNeverReturnNull() throws Exception {
+        propertiesNeverReturnNullCheck(this.createToken());
+    }
+
+    @Test
     public final void testEqualsNull() {
         assertNotEquals(this.createToken(), null);
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserToken.java
@@ -75,7 +75,8 @@ final public class EbnfRangeParserToken extends EbnfParentParserToken {
 
     @Override
     EbnfRangeParserToken replaceTokens(final List<ParserToken> tokens) {
-        return new EbnfRangeParserToken(tokens, this.text(), this.begin, this.end, tokens);
+        // this method is only called by the ctor which happens before the begin/end fields have been set.
+        return new EbnfRangeParserToken(tokens, this.text(), tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     public EbnfParserToken begin() {

--- a/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeLeafParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeLeafParserToken.java
@@ -18,6 +18,7 @@
 package walkingkooka.text.cursor.parser.json;
 
 import walkingkooka.Value;
+import walkingkooka.test.SkipPropertyNeverReturnsNullCheck;
 
 import java.util.Objects;
 
@@ -35,6 +36,7 @@ abstract class JsonNodeLeafParserToken<T> extends JsonNodeParserToken implements
         this.value = value;
     }
 
+    @SkipPropertyNeverReturnsNullCheck(JsonNodeNullParserToken.class)
     public final T value() {
         return this.value;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetAdditionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetAdditionParserToken.java
@@ -43,8 +43,8 @@ public final class SpreadsheetAdditionParserToken extends SpreadsheetBinaryParse
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetAdditionParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final boolean computeWithout){
-        super(value, text, left, right, computeWithout);
+    private SpreadsheetAdditionParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final List<ParserToken> valueWithout){
+        super(value, text, left, right, valueWithout);
     }
 
     @Override
@@ -63,7 +63,7 @@ public final class SpreadsheetAdditionParserToken extends SpreadsheetBinaryParse
     }
 
     private SpreadsheetAdditionParserToken replace(final List<ParserToken> tokens, final String text) {
-        return new SpreadsheetAdditionParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), WITHOUT_USE_THIS);
+        return new SpreadsheetAdditionParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserToken.java
@@ -39,8 +39,8 @@ abstract class SpreadsheetBinaryParserToken extends SpreadsheetParentParserToken
                                  final String text,
                                  final SpreadsheetParserToken left,
                                  final SpreadsheetParserToken right,
-                                 final boolean computeWithout) {
-        super(value, text, computeWithout);
+                                 final List<ParserToken> valueWithout) {
+        super(value, text, valueWithout);
         this.left = left;
         this.right = right;
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellParserToken.java
@@ -53,8 +53,8 @@ public final class SpreadsheetCellParserToken extends SpreadsheetParentParserTok
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetCellParserToken(final List<ParserToken> value, final String text, final SpreadsheetCell cell, final boolean computeWithout){
-        super(value, text, computeWithout);
+    private SpreadsheetCellParserToken(final List<ParserToken> value, final String text, final SpreadsheetCell cell, final List<ParserToken> valueWithout){
+        super(value, text, valueWithout);
         this.cell = cell;
     }
 
@@ -71,12 +71,12 @@ public final class SpreadsheetCellParserToken extends SpreadsheetParentParserTok
 
     @Override
     SpreadsheetCellParserToken replaceText(final String text) {
-        return new SpreadsheetCellParserToken(this.value, text, this.cell, WITHOUT_USE_THIS);
+        return new SpreadsheetCellParserToken(this.value, text, this.cell, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
     }
 
     @Override
     SpreadsheetParentParserToken replaceTokens(final List<ParserToken> tokens) {
-        return new SpreadsheetCellParserToken(tokens, this.text(), this.cell, WITHOUT_USE_THIS);
+        return new SpreadsheetCellParserToken(tokens, this.text(), this.cell, tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDivisionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDivisionParserToken.java
@@ -45,8 +45,8 @@ public final class SpreadsheetDivisionParserToken extends SpreadsheetBinaryParse
 
     private static final SpreadsheetNumericParserToken NO_NUMBER = null;
 
-    private SpreadsheetDivisionParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final boolean computeWithout){
-        super(value, text, left, right, computeWithout);
+    private SpreadsheetDivisionParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final List<ParserToken> valueWithout){
+        super(value, text, left, right, valueWithout);
     }
 
     @Override
@@ -65,7 +65,7 @@ public final class SpreadsheetDivisionParserToken extends SpreadsheetBinaryParse
     }
 
     private SpreadsheetDivisionParserToken replace(final List<ParserToken> tokens, final String text) {
-        return new SpreadsheetDivisionParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), WITHOUT_USE_THIS);
+        return new SpreadsheetDivisionParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetEqualsParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetEqualsParserToken.java
@@ -43,8 +43,8 @@ public final class SpreadsheetEqualsParserToken extends SpreadsheetBinaryParserT
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetEqualsParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final boolean computeWithout){
-        super(value, text, left, right, computeWithout);
+    private SpreadsheetEqualsParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final List<ParserToken> valueWithout){
+        super(value, text, left, right, valueWithout);
     }
 
     @Override
@@ -63,7 +63,7 @@ public final class SpreadsheetEqualsParserToken extends SpreadsheetBinaryParserT
     }
 
     private SpreadsheetEqualsParserToken replace(final List<ParserToken> tokens, final String text) {
-        return new SpreadsheetEqualsParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), WITHOUT_USE_THIS);
+        return new SpreadsheetEqualsParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParserToken.java
@@ -57,8 +57,8 @@ public final class SpreadsheetFunctionParserToken extends SpreadsheetParentParse
                                            final String text,
                                            final SpreadsheetFunctionName name,
                                            final List<ParserToken> parameters,
-                                           final boolean computeWithout){
-        super(value, text, computeWithout);
+                                           final List<ParserToken> valueWithout){
+        super(value, text, valueWithout);
 
         this.name = name;
         this.parameters = parameters;
@@ -86,7 +86,7 @@ public final class SpreadsheetFunctionParserToken extends SpreadsheetParentParse
 
     @Override
     SpreadsheetFunctionParserToken replaceText(final String text) {
-        return new SpreadsheetFunctionParserToken(this.value, text, this.name, this.parameters, WITHOUT_USE_THIS);
+        return new SpreadsheetFunctionParserToken(this.value, text, this.name, this.parameters, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
     }
 
     @Override
@@ -96,7 +96,7 @@ public final class SpreadsheetFunctionParserToken extends SpreadsheetParentParse
                 this.text(),
                 SpreadsheetFunctionNameParserToken.class.cast(tokens.get(0)).value(),
                 tokens.subList(1, tokens.size()),
-                WITHOUT_USE_THIS);
+                tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanEqualsParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanEqualsParserToken.java
@@ -43,8 +43,8 @@ public final class SpreadsheetGreaterThanEqualsParserToken extends SpreadsheetBi
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetGreaterThanEqualsParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final boolean computeWithout){
-        super(value, text, left, right, computeWithout);
+    private SpreadsheetGreaterThanEqualsParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final List<ParserToken> valueWithout){
+        super(value, text, left, right, valueWithout);
     }
 
     @Override
@@ -63,7 +63,7 @@ public final class SpreadsheetGreaterThanEqualsParserToken extends SpreadsheetBi
     }
 
     private SpreadsheetGreaterThanEqualsParserToken replace(final List<ParserToken> tokens, final String text) {
-        return new SpreadsheetGreaterThanEqualsParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), WITHOUT_USE_THIS);
+        return new SpreadsheetGreaterThanEqualsParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanParserToken.java
@@ -43,8 +43,8 @@ public final class SpreadsheetGreaterThanParserToken extends SpreadsheetBinaryPa
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetGreaterThanParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final boolean computeWithout){
-        super(value, text, left, right, computeWithout);
+    private SpreadsheetGreaterThanParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final List<ParserToken> valueWithout){
+        super(value, text, left, right, valueWithout);
     }
 
     @Override
@@ -63,7 +63,7 @@ public final class SpreadsheetGreaterThanParserToken extends SpreadsheetBinaryPa
     }
 
     private SpreadsheetGreaterThanParserToken replace(final List<ParserToken> tokens, final String text) {
-        return new SpreadsheetGreaterThanParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), WITHOUT_USE_THIS);
+        return new SpreadsheetGreaterThanParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGroupParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGroupParserToken.java
@@ -36,8 +36,8 @@ public final class SpreadsheetGroupParserToken extends SpreadsheetParentParserTo
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetGroupParserToken(final List<ParserToken> value, final String text, final boolean computeWithout){
-        super(value, text, computeWithout);
+    private SpreadsheetGroupParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout){
+        super(value, text, valueWithout);
     }
 
     @Override
@@ -47,12 +47,12 @@ public final class SpreadsheetGroupParserToken extends SpreadsheetParentParserTo
 
     @Override
     SpreadsheetGroupParserToken replaceText(final String text) {
-        return new SpreadsheetGroupParserToken(this.value, text, WITHOUT_USE_THIS);
+        return new SpreadsheetGroupParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
     }
 
     @Override
     SpreadsheetParentParserToken replaceTokens(final List<ParserToken> tokens) {
-        return new SpreadsheetGroupParserToken(tokens, this.text(), WITHOUT_USE_THIS);
+        return new SpreadsheetGroupParserToken(tokens, this.text(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanEqualsParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanEqualsParserToken.java
@@ -43,8 +43,8 @@ public final class SpreadsheetLessThanEqualsParserToken extends SpreadsheetBinar
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetLessThanEqualsParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final boolean computeWithout){
-        super(value, text, left, right, computeWithout);
+    private SpreadsheetLessThanEqualsParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final List<ParserToken> valueWithout){
+        super(value, text, left, right, valueWithout);
     }
 
     @Override
@@ -63,7 +63,7 @@ public final class SpreadsheetLessThanEqualsParserToken extends SpreadsheetBinar
     }
 
     private SpreadsheetLessThanEqualsParserToken replace(final List<ParserToken> tokens, final String text) {
-        return new SpreadsheetLessThanEqualsParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), WITHOUT_USE_THIS);
+        return new SpreadsheetLessThanEqualsParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanParserToken.java
@@ -43,8 +43,8 @@ public final class SpreadsheetLessThanParserToken extends SpreadsheetBinaryParse
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetLessThanParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final boolean computeWithout){
-        super(value, text, left, right, computeWithout);
+    private SpreadsheetLessThanParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final List<ParserToken> valueWithout){
+        super(value, text, left, right, valueWithout);
     }
 
     @Override
@@ -63,7 +63,7 @@ public final class SpreadsheetLessThanParserToken extends SpreadsheetBinaryParse
     }
 
     private SpreadsheetLessThanParserToken replace(final List<ParserToken> tokens, final String text) {
-        return new SpreadsheetLessThanParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), WITHOUT_USE_THIS);
+        return new SpreadsheetLessThanParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetMultiplicationParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetMultiplicationParserToken.java
@@ -45,8 +45,8 @@ public final class SpreadsheetMultiplicationParserToken extends SpreadsheetBinar
 
     private static final SpreadsheetNumericParserToken NO_NUMBER = null;
 
-    private SpreadsheetMultiplicationParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final boolean computeWithout){
-        super(value, text, left, right, computeWithout);
+    private SpreadsheetMultiplicationParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final List<ParserToken> valueWithout){
+        super(value, text, left, right, valueWithout);
     }
 
     @Override
@@ -65,7 +65,7 @@ public final class SpreadsheetMultiplicationParserToken extends SpreadsheetBinar
     }
 
     private SpreadsheetMultiplicationParserToken replace(final List<ParserToken> tokens, final String text) {
-        return new SpreadsheetMultiplicationParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), WITHOUT_USE_THIS);
+        return new SpreadsheetMultiplicationParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNegativeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNegativeParserToken.java
@@ -42,8 +42,8 @@ public final class SpreadsheetNegativeParserToken extends SpreadsheetUnaryParser
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetNegativeParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken parameter, final boolean computeWithout){
-        super(value, text, parameter, computeWithout);
+    private SpreadsheetNegativeParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken parameter, final List<ParserToken> valueWithout){
+        super(value, text, parameter, valueWithout);
     }
 
     @Override
@@ -53,12 +53,12 @@ public final class SpreadsheetNegativeParserToken extends SpreadsheetUnaryParser
 
     @Override
     SpreadsheetNegativeParserToken replaceText(final String text) {
-        return new SpreadsheetNegativeParserToken(this.value, text, this.parameter, WITHOUT_USE_THIS);
+        return new SpreadsheetNegativeParserToken(this.value, text, this.parameter, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
     }
 
     @Override
     SpreadsheetParentParserToken replaceTokens(final List<ParserToken> tokens) {
-        return new SpreadsheetNegativeParserToken(tokens, this.text(), this.parameter, WITHOUT_USE_THIS);
+        return new SpreadsheetNegativeParserToken(tokens, this.text(), tokens.get(0).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNotEqualsParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNotEqualsParserToken.java
@@ -43,8 +43,8 @@ public final class SpreadsheetNotEqualsParserToken extends SpreadsheetBinaryPars
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetNotEqualsParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final boolean computeWithout){
-        super(value, text, left, right, computeWithout);
+    private SpreadsheetNotEqualsParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final List<ParserToken> valueWithout){
+        super(value, text, left, right, valueWithout);
     }
 
     @Override
@@ -63,7 +63,7 @@ public final class SpreadsheetNotEqualsParserToken extends SpreadsheetBinaryPars
     }
 
     private SpreadsheetNotEqualsParserToken replace(final List<ParserToken> tokens, final String text) {
-        return new SpreadsheetNotEqualsParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), WITHOUT_USE_THIS);
+        return new SpreadsheetNotEqualsParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserToken.java
@@ -30,14 +30,13 @@ import java.util.Optional;
  */
 abstract class SpreadsheetParentParserToken extends SpreadsheetParserToken implements Value<List<ParserToken>> {
 
-    final static boolean WITHOUT_COMPUTE_REQUIRED = true;
-    final static boolean WITHOUT_USE_THIS = !WITHOUT_COMPUTE_REQUIRED;
+    final static List<ParserToken> WITHOUT_COMPUTE_REQUIRED = null;
 
-    SpreadsheetParentParserToken(final List<ParserToken> value, final String text, final boolean computeWithout) {
+    SpreadsheetParentParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
         super(text);
         this.value = value;
-        this.without = computeWithout ?
-                this.computeWithout(value) :
+        this.without =  null == valueWithout ?
+                computeWithout(value) :
                 Optional.of(this);
     }
 
@@ -58,6 +57,10 @@ abstract class SpreadsheetParentParserToken extends SpreadsheetParserToken imple
         return Optional.of(value.size() == without.size() ?
                 this :
                 this.replaceTokens(without));
+    }
+
+    final List<ParserToken> valueIfWithoutSymbolsOrWhitespaceOrNull() {
+        return this == this.without.get() ? this.value : null;
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserToken.java
@@ -19,6 +19,7 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.test.SkipPropertyNeverReturnsNullCheck;
 import walkingkooka.text.Whitespace;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
@@ -648,6 +649,7 @@ public abstract class SpreadsheetParserToken implements ParserToken, HasExpressi
     /**
      * Converts this token to its {@link ExpressionNode} equivalent.
      */
+    @SkipPropertyNeverReturnsNullCheck(SpreadsheetRangeParserToken.class)
     public final Optional<ExpressionNode> expressionNode() {
         return SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor.accept(this);
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor.java
@@ -269,7 +269,7 @@ final class SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor 
 
     @Override
     protected void visit(final SpreadsheetLabelNameParserToken token) {
-        this.exitReference(token.value(), token);
+        this.addReference(token.value(), token);
     }
 
     @Override
@@ -315,6 +315,11 @@ final class SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor 
     private void exitReference(final ExpressionReference reference, final SpreadsheetParserToken token) {
         final ExpressionNode node = ExpressionNode.reference(reference);
         this.exit();
+        this.add(node, token);
+    }
+
+    private void addReference(final ExpressionReference reference, final SpreadsheetParserToken token) {
+        final ExpressionNode node = ExpressionNode.reference(reference);
         this.add(node, token);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPercentageParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPercentageParserToken.java
@@ -42,8 +42,8 @@ public final class SpreadsheetPercentageParserToken extends SpreadsheetUnaryPars
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetPercentageParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken parameter, final boolean computeWithout){
-        super(value, text, parameter, computeWithout);
+    private SpreadsheetPercentageParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken parameter, final List<ParserToken> valueWithout){
+        super(value, text, parameter, valueWithout);
     }
 
     @Override
@@ -53,12 +53,12 @@ public final class SpreadsheetPercentageParserToken extends SpreadsheetUnaryPars
 
     @Override
     SpreadsheetPercentageParserToken replaceText(final String text) {
-        return new SpreadsheetPercentageParserToken(this.value, text, this.parameter, WITHOUT_USE_THIS);
+        return new SpreadsheetPercentageParserToken(this.value, text, this.parameter, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
     }
 
     @Override
     SpreadsheetParentParserToken replaceTokens(final List<ParserToken> tokens) {
-        return new SpreadsheetPercentageParserToken(tokens, this.text(), this.parameter, WITHOUT_USE_THIS);
+        return new SpreadsheetPercentageParserToken(tokens, this.text(), tokens.get(0).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPowerParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPowerParserToken.java
@@ -45,8 +45,8 @@ public final class SpreadsheetPowerParserToken extends SpreadsheetBinaryParserTo
     
     private static final SpreadsheetNumericParserToken NO_NUMBER = null;
 
-    private SpreadsheetPowerParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final boolean computeWithout){
-        super(value, text, left, right, computeWithout);
+    private SpreadsheetPowerParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final List<ParserToken> valueWithout){
+        super(value, text, left, right, valueWithout);
     }
 
     @Override
@@ -65,7 +65,7 @@ public final class SpreadsheetPowerParserToken extends SpreadsheetBinaryParserTo
     }
 
     private SpreadsheetPowerParserToken replace(final List<ParserToken> tokens, final String text) {
-        return new SpreadsheetPowerParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), WITHOUT_USE_THIS);
+        return new SpreadsheetPowerParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetRangeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetRangeParserToken.java
@@ -43,8 +43,8 @@ public final class SpreadsheetRangeParserToken extends SpreadsheetBinaryParserTo
                 WITHOUT_COMPUTE_REQUIRED);
     }
 
-    private SpreadsheetRangeParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final boolean computeWithout){
-        super(value, text, left, right, computeWithout);
+    private SpreadsheetRangeParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final List<ParserToken> valueWithout){
+        super(value, text, left, right, valueWithout);
     }
 
     @Override
@@ -63,7 +63,7 @@ public final class SpreadsheetRangeParserToken extends SpreadsheetBinaryParserTo
     }
 
     private SpreadsheetRangeParserToken replace(final List<ParserToken> tokens, final String text) {
-        return new SpreadsheetRangeParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), WITHOUT_USE_THIS);
+        return new SpreadsheetRangeParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSubtractionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSubtractionParserToken.java
@@ -45,8 +45,8 @@ public final class SpreadsheetSubtractionParserToken extends SpreadsheetBinaryPa
 
     private static final SpreadsheetNumericParserToken NO_NUMBER = null;
 
-    private SpreadsheetSubtractionParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final boolean computeWithout){
-        super(value, text, left, right, computeWithout);
+    private SpreadsheetSubtractionParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken left, final SpreadsheetParserToken right, final List<ParserToken> valueWithout){
+        super(value, text, left, right, valueWithout);
     }
 
     @Override
@@ -65,7 +65,7 @@ public final class SpreadsheetSubtractionParserToken extends SpreadsheetBinaryPa
     }
 
     private SpreadsheetSubtractionParserToken replace(final List<ParserToken> tokens, final String text) {
-        return new SpreadsheetSubtractionParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), WITHOUT_USE_THIS);
+        return new SpreadsheetSubtractionParserToken(tokens, text, tokens.get(0).cast(), tokens.get(1).cast(), tokens);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetUnaryParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetUnaryParserToken.java
@@ -35,8 +35,8 @@ abstract class SpreadsheetUnaryParserToken extends SpreadsheetParentParserToken 
         return checker;
     }
     
-    SpreadsheetUnaryParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken parameter, final boolean computeWithout) {
-        super(value, text, computeWithout);
+    SpreadsheetUnaryParserToken(final List<ParserToken> value, final String text, final SpreadsheetParserToken parameter, final List<ParserToken> valueWithout) {
+        super(value, text, valueWithout);
         this.parameter = parameter;
     }
 

--- a/src/main/java/walkingkooka/tree/NodeTestCase.java
+++ b/src/main/java/walkingkooka/tree/NodeTestCase.java
@@ -110,6 +110,11 @@ abstract public class NodeTestCase<N extends Node<N, NAME, ANAME, AVALUE>,
     }
 
     @Test
+    public void testPropertiesNeverReturnNull() throws Exception {
+        propertiesNeverReturnNullCheck(this.createNode());
+    }
+
+    @Test
     public void testEqualsNull(){
         assertNotEquals(this.createNode(), null);
     }

--- a/src/main/java/walkingkooka/tree/json/JsonLeafNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonLeafNode.java
@@ -21,6 +21,7 @@ package walkingkooka.tree.json;
 import walkingkooka.ShouldNeverHappenError;
 import walkingkooka.Value;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.test.SkipPropertyNeverReturnsNullCheck;
 
 import java.util.List;
 import java.util.Objects;
@@ -35,6 +36,7 @@ abstract class JsonLeafNode<V> extends JsonNode implements Value<V> {
         this.value = value;
     }
 
+    @SkipPropertyNeverReturnsNullCheck(JsonNullNode.class)
     @Override
     public final V value() {
         return this.value;

--- a/src/main/java/walkingkooka/xml/DomDocumentType.java
+++ b/src/main/java/walkingkooka/xml/DomDocumentType.java
@@ -21,6 +21,7 @@ import org.w3c.dom.DocumentType;
 import org.w3c.dom.Node;
 import walkingkooka.Cast;
 import walkingkooka.build.tostring.ToStringBuilder;
+import walkingkooka.test.SkipPropertyNeverReturnsNullCheck;
 
 import java.util.Map;
 import java.util.Objects;
@@ -94,6 +95,7 @@ public final class DomDocumentType extends DomLeafNode implements HasDomPublicId
 
     // internal subset .........................................................................................................
 
+    @SkipPropertyNeverReturnsNullCheck(DomDocumentType.class)
     public String internalSubset() {
         return this.documentTypeNode().getInternalSubset();
     }

--- a/src/main/java/walkingkooka/xml/DomLeafNode.java
+++ b/src/main/java/walkingkooka/xml/DomLeafNode.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.xml;
 
+import walkingkooka.test.SkipPropertyNeverReturnsNullCheck;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -94,10 +96,12 @@ abstract class DomLeafNode extends DomNode{
         throw new UnsupportedOperationException();
     }
 
+    @SkipPropertyNeverReturnsNullCheck(DomDocumentType.class)
     @Override
     public final DomDocument document() {
         DomDocument document = this.document;
         if(null==document){
+            // TODO sometimes a DomDocumentType may have no enclosing document.
             this.document = new DomDocument(this.documentNode());
         }
         return this.document;

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTokenTestCase.java
@@ -23,6 +23,7 @@ import walkingkooka.text.cursor.parser.ParserTokenTestCase;
 import walkingkooka.type.MethodAttributes;
 
 import java.lang.reflect.Method;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 
@@ -72,6 +73,14 @@ public abstract class EbnfParserTokenTestCase<T extends EbnfParserToken> extends
             assertEquals(method + " returned",
                     methodName.equals(isMethodName),
                     method.invoke(token));
+        }
+    }
+
+    @Test
+    public void testWithoutCommentsSymbolsOrWhitespacePropertiesNullCheck() throws Exception {
+        final Optional<EbnfParserToken> without = this.createToken().withoutCommentsSymbolsOrWhitespace();
+        if(without.isPresent()){
+            this.propertiesNeverReturnNullCheck(without.get());
         }
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeParentParserTokenTestCase.java
@@ -23,6 +23,7 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.ParserToken;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -77,6 +78,14 @@ public abstract class JsonNodeParentParserTokenTestCase<T extends JsonNodeParent
         assertEquals("children without", childrenWithout, differentWithout.value());
 
         assertNotEquals("without should have less tokens than with", token.value().size(), differentWithout.value().size());
+    }
+
+    @Test
+    public void testWithoutCommentsSymbolsOrWhitespacePropertiesNullCheck() throws Exception {
+        final Optional<JsonNodeParserToken> without = this.createToken().withoutSymbolsOrWhitespace();
+        if(without.isPresent()){
+            this.propertiesNeverReturnNullCheck(without.get());
+        }
     }
 
     abstract T createToken(final String text, final List<ParserToken> tokens);

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenTestCase.java
@@ -86,6 +86,14 @@ public abstract class SpreadsheetParserTokenTestCase<T extends SpreadsheetParser
     }
 
     @Test
+    public void testWithoutCommentsSymbolsOrWhitespacePropertiesNullCheck() throws Exception {
+        final Optional<SpreadsheetParserToken> without = this.createToken().withoutSymbolsOrWhitespace();
+        if(without.isPresent()){
+            this.propertiesNeverReturnNullCheck(without.get());
+        }
+    }
+
+    @Test
     public final void testToString() {
         assertEquals(this.text(), this.createToken().toString());
     }


### PR DESCRIPTION
…ever return null

- Added @SkipPropertyNeverReturnNullCheck skip support, tagged a few properties.
- Fixed EbnfRangeParserToken.withoutCommentOrSymbolOrWhitespace properties being null.
- Fixed SpreadsheetParserToken.withoutSymbolOrWhitespace some properties being null.
- DomDocumentType.document can return null.