### PR TITLE
Removed DomNode.asXXX methods.

### DIFF
--- a/src/main/java/walkingkooka/test/ClassTestCase.java
+++ b/src/main/java/walkingkooka/test/ClassTestCase.java
@@ -195,15 +195,13 @@ abstract public class ClassTestCase<T> extends TestCase {
     }
 
     /**
-     * Keep instance methods, that return something, take no parameters, arent a Object member, not in the skipList,
-     * and arent a asXXX method which are allowed to return null.
+     * Keep instance methods, that return something, take no parameters, arent a Object member or tagged with {@link SkipPropertyNeverReturnsNullCheck}
      */
     private boolean propertiesNeverReturnNullCheckFilter(final Method method, final Object object) {
         return !MethodAttributes.STATIC.is(method) &&
                 method.getReturnType() != Void.class &&
                 method.getParameterTypes().length == 0 &&
                 method.getDeclaringClass() != Object.class &&
-                !method.getName().startsWith("as") &&
                 !skipMethod(method, object);
     }
 

--- a/src/main/java/walkingkooka/xml/DomCDataSection.java
+++ b/src/main/java/walkingkooka/xml/DomCDataSection.java
@@ -34,7 +34,7 @@ final public class DomCDataSection extends DomTextNode {
   @Override
   public DomCDataSection setText(final String text) {
     checkCDataSectionText(text);
-    return this.setText0(text).asCDataSection();
+    return this.setText0(text).cast();
   }
 
   // DomNode...........................................................................................
@@ -47,11 +47,6 @@ final public class DomCDataSection extends DomTextNode {
   @Override
   DomCDataSection wrap0(final org.w3c.dom.Node node) {
     return new DomCDataSection(node);
-  }
-
-  @Override
-  public DomCDataSection asCDataSection() {
-    return this;
   }
 
   @Override

--- a/src/main/java/walkingkooka/xml/DomComment.java
+++ b/src/main/java/walkingkooka/xml/DomComment.java
@@ -35,7 +35,7 @@ final public class DomComment extends DomTextNode {
   @Override
   public DomComment setText(final String text) {
     checkCommentText(text);
-    return this.setText0(text).asComment();
+    return this.setText0(text).cast();
   }
 
   // DomNode.......................................................................................................
@@ -48,11 +48,6 @@ final public class DomComment extends DomTextNode {
   @Override
   DomComment wrap0(final org.w3c.dom.Node node) {
     return new DomComment(node);
-  }
-
-  @Override
-  public DomComment asComment() {
-    return this;
   }
 
   @Override

--- a/src/main/java/walkingkooka/xml/DomDocument.java
+++ b/src/main/java/walkingkooka/xml/DomDocument.java
@@ -46,11 +46,6 @@ public final class DomDocument extends DomParentNode{
     }
 
     @Override
-    public DomDocument asDocument() {
-        return this;
-    }
-
-    @Override
     public boolean isDocument() {
         return true;
     }
@@ -434,12 +429,12 @@ public final class DomDocument extends DomParentNode{
 
     @Override
     public DomDocument removeChild(final DomNode child) {
-        return super.removeChild(child).asDocument();
+        return super.removeChild(child).cast();
     }
 
     @Override
     public DomDocument removeChild(final int child) {
-        return super.removeChild(child).asDocument();
+        return super.removeChild(child).cast();
     }
 
     /**

--- a/src/main/java/walkingkooka/xml/DomDocumentType.java
+++ b/src/main/java/walkingkooka/xml/DomDocumentType.java
@@ -119,11 +119,6 @@ public final class DomDocumentType extends DomLeafNode implements HasDomPublicId
     }
 
     @Override
-    public DomDocumentType asDocumentType() {
-        return this;
-    }
-
-    @Override
     public boolean isDocumentType() {
         return true;
     }

--- a/src/main/java/walkingkooka/xml/DomElement.java
+++ b/src/main/java/walkingkooka/xml/DomElement.java
@@ -83,22 +83,22 @@ public final class DomElement extends DomParentNode2 implements HasDomPrefix{
 
     @Override
     public DomElement setChildren(final List<DomNode> children) {
-        return this.setChildren0(children).asElement();
+        return this.setChildren0(children).cast();
     }
 
     @Override
     public DomElement appendChild(final DomNode child) {
-        return super.appendChild(child).asElement();
+        return super.appendChild(child).cast();
     }
 
     @Override
     public DomElement removeChild(final DomNode child) {
-        return super.removeChild(child).asElement();
+        return super.removeChild(child).cast();
     }
 
     @Override
     public DomElement removeChild(final int child) {
-        return super.removeChild(child).asElement();
+        return super.removeChild(child).cast();
     }
 
     // attributes................................................................................
@@ -155,11 +155,6 @@ public final class DomElement extends DomParentNode2 implements HasDomPrefix{
     @Override
     DomElement wrap0(final Node node) {
         return new DomElement(node);
-    }
-
-    @Override
-    public DomElement asElement() {
-        return this;
     }
 
     @Override

--- a/src/main/java/walkingkooka/xml/DomEntity.java
+++ b/src/main/java/walkingkooka/xml/DomEntity.java
@@ -143,14 +143,6 @@ final public class DomEntity extends DomParentNode2 implements HasDomPublicId, H
      * Always returns this.
      */
     @Override
-    public DomEntity asEntity() {
-        return this;
-    }
-
-    /**
-     * Always returns this.
-     */
-    @Override
     public boolean isEntity() {
         return true;
     }
@@ -168,7 +160,7 @@ final public class DomEntity extends DomParentNode2 implements HasDomPublicId, H
     }
 
     @Override boolean equalsIgnoringParentAndChildren(final DomNode other) {
-        return equalsIgnoringParentAndChildren0(other.asEntity());
+        return equalsIgnoringParentAndChildren0(other.cast());
     }
 
     private boolean equalsIgnoringParentAndChildren0(final DomEntity other) {

--- a/src/main/java/walkingkooka/xml/DomEntityReference.java
+++ b/src/main/java/walkingkooka/xml/DomEntityReference.java
@@ -74,14 +74,6 @@ final public class DomEntityReference extends DomParentNode2 {
     return new DomEntityReference(node);
   }
 
-  /**
-   * Always returns this.
-   */
-  @Override
-  public DomEntityReference asEntityReference() {
-    return this;
-  }
-
   @Override
   public boolean isEntityReference() {
     return true;

--- a/src/main/java/walkingkooka/xml/DomNode.java
+++ b/src/main/java/walkingkooka/xml/DomNode.java
@@ -31,6 +31,7 @@ import walkingkooka.collect.map.Maps;
 import walkingkooka.naming.PathSeparator;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.Whitespace;
+import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.select.NodeSelectorBuilder;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -421,74 +422,8 @@ public abstract class DomNode implements walkingkooka.tree.Node<DomNode, DomName
         return false;
     }
 
-    /**
-     * Returns this if a {@link DomCDataSection} otherwise throws {@link ClassCastException}.
-     */
-    public DomCDataSection asCDataSection() {
-        return DomCDataSection.class.cast(this);
-    }
-
-    /**
-     * Returns this if a {@link DomComment} otherwise throws {@link ClassCastException}.
-     */
-    public DomComment asComment() {
-        return DomComment.class.cast(this);
-    }
-
-    /**
-     * Returns this if a {@link DomDocument} otherwise throws {@link ClassCastException}.
-     */
-    public DomDocument asDocument() {
-        return DomDocument.class.cast(this);
-    }
-
-    /**
-     * Returns this if a {@link DomDocumentType} otherwise throws {@link ClassCastException}.
-     */
-    public DomDocumentType asDocumentType() {
-        return DomDocumentType.class.cast(this);
-    }
-
-    /**
-     * Returns this if a {@link walkingkooka.xml.DomElement} otherwise throws {@link ClassCastException}.
-     */
-    public DomElement asElement() {
-        return DomElement.class.cast(this);
-    }
-
-    /**
-     * Returns this if a {@link DomEntity} otherwise throws {@link ClassCastException}.
-     */
-    public DomEntity asEntity() {
-        return DomEntity.class.cast(this);
-    }
-
-    /**
-     * Returns this if a {@link DomEntityReference} otherwise throws {@link ClassCastException}.
-     */
-    public DomEntityReference asEntityReference() {
-        return DomEntityReference.class.cast(this);
-    }
-
-    /**
-     * Returns this if a {@link DomNotation} otherwise throws {@link ClassCastException}.
-     */
-    public DomNotation asNotation() {
-        return DomNotation.class.cast(DomNotation.class);
-    }
-
-    /**
-     * Returns this if a {@link DomProcessingInstruction} otherwise throws {@link ClassCastException}.
-     */
-    public DomProcessingInstruction asProcessingInstruction() {
-        return DomProcessingInstruction.class.cast(this);
-    }
-
-    /**
-     * Returns this if a {@link DomText} otherwise throws {@link ClassCastException}.
-     */
-    public DomText asText() {
-        throw new ClassCastException(this.getClass().getName());
+    final <T extends DomNode> T cast() {
+        return Cast.to(this);
     }
 
     // text.......................................................................................................

--- a/src/main/java/walkingkooka/xml/DomNotation.java
+++ b/src/main/java/walkingkooka/xml/DomNotation.java
@@ -81,14 +81,6 @@ final public class DomNotation extends DomLeafNode implements HasDomPublicId, Ha
     return DomNodeKind.NOTATION;
   }
 
-  /**
-   * Always returns this.
-   */
-  @Override
-  public DomNotation asNotation() {
-    return this;
-  }
-
   @Override
   public boolean isNotation() {
     return true;
@@ -108,7 +100,7 @@ final public class DomNotation extends DomLeafNode implements HasDomPublicId, Ha
 
   @Override
   boolean equalsIgnoringParentAndChildren(final DomNode other) {
-    return equalsIgnoringParentAndChildren0(other.asNotation());
+    return equalsIgnoringParentAndChildren0(other.cast());
   }
 
   private boolean equalsIgnoringParentAndChildren0(final DomNotation other) {

--- a/src/main/java/walkingkooka/xml/DomProcessingInstruction.java
+++ b/src/main/java/walkingkooka/xml/DomProcessingInstruction.java
@@ -81,14 +81,6 @@ final public class DomProcessingInstruction extends DomLeafNode implements Value
    * Always returns this.
    */
   @Override
-  public DomProcessingInstruction asProcessingInstruction() {
-    return this;
-  }
-
-  /**
-   * Always returns this.
-   */
-  @Override
   public boolean isProcessingInstruction() {
     return true;
   }
@@ -107,7 +99,7 @@ final public class DomProcessingInstruction extends DomLeafNode implements Value
 
   @Override
   final boolean equalsIgnoringParentAndChildren(final DomNode other) {
-    return this.equalsIgnoringParentAndChildren0(other.asProcessingInstruction());
+    return this.equalsIgnoringParentAndChildren0(other.cast());
   }
 
   private boolean equalsIgnoringParentAndChildren0(final DomProcessingInstruction other) {

--- a/src/main/java/walkingkooka/xml/DomText.java
+++ b/src/main/java/walkingkooka/xml/DomText.java
@@ -40,7 +40,7 @@ public final class DomText extends DomTextNode {
     @Override
     public DomText setText(final String text) {
         checkTextText(text);
-        return this.setText0(text).asText();
+        return this.setText0(text).cast();
     }
 
     // DomNode....................................................................................................
@@ -53,11 +53,6 @@ public final class DomText extends DomTextNode {
     @Override
     DomText wrap0(final org.w3c.dom.Node node) {
         return new DomText(node);
-    }
-
-    @Override
-    public DomText asText() {
-        return this;
     }
 
     @Override

--- a/src/test/java/walkingkooka/xml/DomDocumentTest.java
+++ b/src/test/java/walkingkooka/xml/DomDocumentTest.java
@@ -584,9 +584,9 @@ public final class DomDocumentTest extends DomParentNodeTestCase<DomDocument> {
     public void testFromXml() throws Exception{
         final DomDocument document = this.fromXml();
 
-        final DomElement root = document.children().get(0).asElement();
-        final DomElement abc = root.children().get(1).asElement();
-        final DomText text = abc.children().get(0).asText();
+        final DomElement root = document.children().get(0).cast();
+        final DomElement abc = root.children().get(1).cast();
+        final DomText text = abc.children().get(0).cast();
 
         this.checkText(text,TEXT);
         this.checkName(document, DomName.DOCUMENT);
@@ -601,9 +601,9 @@ public final class DomDocumentTest extends DomParentNodeTestCase<DomDocument> {
     public void testFromXmlNamespace() throws Exception{
         final DomDocument document = this.fromXml();
 
-        final DomElement root = document.children().get(0).asElement();
-        final DomElement abc = root.children().get(1).asElement();
-        final DomText text = abc.children().get(0).asText();
+        final DomElement root = document.children().get(0).cast();
+        final DomElement abc = root.children().get(1).cast();
+        final DomText text = abc.children().get(0).cast();
 
         this.checkText(text, TEXT);
     }
@@ -754,7 +754,7 @@ public final class DomDocumentTest extends DomParentNodeTestCase<DomDocument> {
     public void testInlineEntity() throws Exception{
         final DomDocument document = this.fromXml(this.documentBuilder(false, false)); //namespace, expandEntities
         final DomElement root = document.element().get();
-        final DomEntityReference reference = root.children().get(0).asEntityReference();
+        final DomEntityReference reference = root.children().get(0).cast();
         assertEquals("entity name", DomName.entityReference("magic"), reference.name());
     }
 

--- a/src/test/java/walkingkooka/xml/DomNodeTestCase.java
+++ b/src/test/java/walkingkooka/xml/DomNodeTestCase.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.xml;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -39,7 +38,6 @@ import java.io.StringWriter;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -91,81 +89,6 @@ public abstract class DomNodeTestCase<N extends DomNode> extends NodeTestCase<Do
     public final void testText() {
         final N node = this.createNode();
         this.checkText(node, this.text());
-    }
-
-    // asXXX ..................................................................................................
-
-    @Test
-    public final void testAsCDataSection() {
-        final N node = this.createNode();
-        this.asAndCheck(node, () -> node.asCDataSection(), DomCDataSection.class);
-    }
-
-    @Test
-    public final void testAsComment() {
-        final N node = this.createNode();
-        this.asAndCheck(node, () -> node.asComment(), DomComment.class);
-    }
-
-    @Test
-    public final void testAsDocument() {
-        final N node = this.createNode();
-        this.asAndCheck(node, () -> node.asDocument(), DomDocument.class);
-    }
-
-    @Test
-    public final void testAsDocumentType() {
-        final N node = this.createNode();
-        this.asAndCheck(node, () -> node.asDocumentType(), DomDocumentType.class);
-    }
-
-    @Test
-    public final void testAsElement() {
-        final N node = this.createNode();
-        this.asAndCheck(node, () -> node.asElement(), DomElement.class);
-    }
-
-    @Test
-    public final void testAsEntity() {
-        final N node = this.createNode();
-        this.asAndCheck(node, () -> node.asEntity(), DomEntity.class);
-    }
-
-    @Test
-    public final void testAsEntityReference() {
-        final N node = this.createNode();
-        this.asAndCheck(node, () -> node.asEntityReference(), DomEntityReference.class);
-    }
-
-    @Test
-    public final void testAsNotation() {
-        final N node = this.createNode();
-        this.asAndCheck(node, () -> node.asNotation(), DomNotation.class);
-    }
-
-    @Test
-    public final void testAsProcessingInstruction() {
-        final N node = this.createNode();
-        this.asAndCheck(node, () -> node.asProcessingInstruction(), DomProcessingInstruction.class);
-    }
-
-    @Test
-    public final void testAsText() {
-        final N node = this.createNode();
-        this.asAndCheck(node, () -> node.asText(), DomText.class);
-    }
-
-    private <T extends DomNode> void asAndCheck(final N node, final Supplier<T> as, final Class<T> type){
-        final boolean shouldWork = node.getClass().equals(type);
-        if(shouldWork){
-            assertEquals(node, as.get());
-        } else {
-            try{
-                as.get();
-                Assert.fail("Should have failed");
-            } catch (final ClassCastException expected){
-            }
-        }
     }
 
     // isXXX ..................................................................................................


### PR DESCRIPTION
- Removed tests for asXXX, replaced package usage by a package private cast().
- Removed "asXXX" from being skipped by ClassTestCase.propertiesNeverReturnNullCheckFilter