### PR TITLE
Iterables.equal(Iterable, Iterable, BiPredicate) also updated JsonPar…

### DIFF
--- a/src/main/java/walkingkooka/collect/iterable/Iterables.java
+++ b/src/main/java/walkingkooka/collect/iterable/Iterables.java
@@ -21,6 +21,8 @@ import walkingkooka.type.PublicStaticHelper;
 
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.Objects;
+import java.util.function.BiPredicate;
 
 final public class Iterables implements PublicStaticHelper {
 
@@ -29,6 +31,25 @@ final public class Iterables implements PublicStaticHelper {
      */
     public static <T> Iterable<T> enumeration(final Enumeration<T> enumeration) {
         return EnumerationIterable.with(enumeration);
+    }
+
+    /**
+     * Tests if the elements belonging to the two {@link Iterables} are all equal in the order given.
+     */
+    public static <T> boolean equals(final Iterable<T> iterable, final Iterable<T> other, final BiPredicate<? super T, ? super T> equivalency) {
+        Objects.requireNonNull(iterable,  "iterable");
+        Objects.requireNonNull(other,  "other");
+        Objects.requireNonNull(equivalency,  "equivalency");
+
+        boolean equals = true;
+
+        final Iterator<T> iterator = iterable.iterator();
+        final Iterator<T> otherIterator = other.iterator();
+        while(equals && iterator.hasNext() && otherIterator.hasNext()) {
+             equals = equals && equivalency.test(iterator.next(), otherIterator.next());
+        }
+
+        return equals && !iterator.hasNext() && !otherIterator.hasNext();
     }
 
     /**

--- a/src/main/java/walkingkooka/collect/list/Lists.java
+++ b/src/main/java/walkingkooka/collect/list/Lists.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.collect.list;
 
+import walkingkooka.collect.iterable.Iterables;
 import walkingkooka.type.PublicStaticHelper;
 
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiPredicate;
 
 final public class Lists implements PublicStaticHelper {
     /**
@@ -47,6 +49,13 @@ final public class Lists implements PublicStaticHelper {
      */
     public static <T> List<T> empty() {
         return Collections.emptyList();
+    }
+
+    /**
+     * Tests if both {@list List} are equal using the {@link BiPredicate} to test each and every element.
+     */
+    public static <T> boolean equals(final List<T> list, final List<T> other, final BiPredicate<? super T, ? super T> equivalency) {
+        return Iterables.equals(list, other, equivalency);
     }
 
     /**

--- a/src/main/java/walkingkooka/collect/set/Sets.java
+++ b/src/main/java/walkingkooka/collect/set/Sets.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.collect.set;
 
+import walkingkooka.collect.iterable.Iterables;
 import walkingkooka.type.PublicStaticHelper;
 
 import java.util.Collections;
@@ -28,6 +29,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.BiPredicate;
 
 final public class Sets implements PublicStaticHelper {
     /**
@@ -35,6 +37,13 @@ final public class Sets implements PublicStaticHelper {
      */
     public static <T> Set<T> empty() {
         return Collections.emptySet();
+    }
+
+    /**
+     * Tests if both {@Set Set} are equal using the {@link BiPredicate} to test each and every element.
+     */
+    public static <T> boolean equals(final Set<T> Set, final Set<T> other, final BiPredicate<? super T, ? super T> equivalency) {
+        return Iterables.equals(Set, other, equivalency);
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/expression/ExpressionParentNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionParentNode.java
@@ -61,7 +61,7 @@ abstract class ExpressionParentNode extends ExpressionNode {
         Objects.requireNonNull(children, "children");
 
         final List<ExpressionNode> copy = copy(children);
-        return this.children().equals(copy) ?
+        return Lists.equals(this.children(), copy, (first, other) -> first.equalsIgnoringParentAndChildren(other) && first.equalsDescendants0(other)) ?
                 this :
                 this.replaceChildren(copy);
     }
@@ -70,7 +70,7 @@ abstract class ExpressionParentNode extends ExpressionNode {
     final ExpressionNode setChild(final ExpressionNode newChild) {
         final int index = newChild.index();
         final ExpressionNode previous = this.children().get(index);
-        return previous.equalsDescendants(newChild) ?
+        return previous.equalsIgnoringParentAndChildren(newChild) && previous.equalsDescendants(newChild) ?
                 this :
                 this.replaceChild0(newChild, index);
     }

--- a/src/main/java/walkingkooka/tree/json/JsonParentNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonParentNode.java
@@ -57,7 +57,7 @@ abstract class JsonParentNode extends JsonNode {
     final List<JsonNode> children;
 
     final JsonNode setChildren1(final List<JsonNode> children) {
-        return this.children.equals(children) ?
+        return Lists.equals(this.children, children, (first, other) -> first.equalsIgnoringParentAndChildren0(other) && first.equalsDescendants(other)) ?
                 this :
                 this.replaceChildren(children);
     }
@@ -66,7 +66,7 @@ abstract class JsonParentNode extends JsonNode {
     final JsonNode setChild(final JsonNode newChild) {
         final int index = newChild.index();
         final JsonNode previous = this.children.get(index);
-        return previous.equalsDescendants(newChild) ?
+        return previous.equalsIgnoringParentAndChildren0(newChild) && previous.equalsDescendants(newChild) ?
               this :
                this.replaceChild0(newChild, index);
     }

--- a/src/test/java/walkingkooka/collect/iterable/IterablesTest.java
+++ b/src/test/java/walkingkooka/collect/iterable/IterablesTest.java
@@ -17,11 +17,92 @@
 
 package walkingkooka.collect.iterable;
 
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.test.PublicStaticHelperTestCase;
 
 import java.lang.reflect.Method;
+import java.util.function.BiPredicate;
+
+import static org.junit.Assert.assertEquals;
 
 final public class IterablesTest extends PublicStaticHelperTestCase<Iterables> {
+
+    private final static BiPredicate<String, String> EQUIVALENCY = (first, other)->first.equalsIgnoreCase(other);
+    private final static String A = "a";
+    private final static String B = "b";
+    private final static String C = "c";
+
+    @Test(expected = NullPointerException.class)
+    public void testEqualsNullIterableFails() {
+        Iterables.equals(null, Iterables.fake(), EQUIVALENCY);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testEqualsNullOtherIterableFails() {
+        Iterables.equals(Iterables.fake(), null, EQUIVALENCY);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testEqualsNullEquivalenceFunctionFails() {
+        Iterables.equals(Iterables.fake(), Iterables.fake(), null);
+    }
+
+    @Test
+    public void testEqualsEmpty() {
+        this.notEqualsAndCheck();
+    }
+
+    @Test
+    public void testEqualsDifferent() {
+        this.notEqualsAndCheck("different", B, C);
+    }
+
+    @Test
+    public void testEqualsDifferent2() {
+        this.notEqualsAndCheck("different");
+    }
+
+    @Test
+    public void testEqualsDifferent3() {
+        this.notEqualsAndCheck(A, B, "different");
+    }
+
+    @Test
+    public void testEqualsShorter() {
+        this.notEqualsAndCheck(A, B);
+    }
+
+    @Test
+    public void testEqualsLonger() {
+        this.notEqualsAndCheck(A, B, C, "Z");
+    }
+
+    @Test
+    public void testEquals() {
+        this.equalsAndCheck(A, B, "C");
+    }
+
+    @Test
+    public void testEqualsBothEmpty() {
+        this.equalsAndCheck0(Lists.empty(), Lists.empty(), true);
+    }
+
+    private void equalsAndCheck(final String...other) {
+        this.equalsAndCheck0(Lists.of(other), true);
+    }
+
+    private void notEqualsAndCheck(final String...other) {
+        this.equalsAndCheck0(Lists.of(other), false);
+    }
+
+    private void equalsAndCheck0(final Iterable<String> other, final boolean equals) {
+        equalsAndCheck0(Lists.of(A, B, C), other, equals);
+    }
+
+    private void equalsAndCheck0(final Iterable<String> iterable, final Iterable<String> other, final boolean equals) {
+        assertEquals(iterable + " AND " + other, equals, Iterables.equals(iterable, other, EQUIVALENCY));
+    }
 
     @Override
     protected Class<Iterables> type() {

--- a/src/test/java/walkingkooka/tree/expression/ExpressionParentNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionParentNodeTestCase.java
@@ -18,6 +18,7 @@
 
 package walkingkooka.tree.expression;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
@@ -34,7 +35,19 @@ public abstract class ExpressionParentNodeTestCase<N extends ExpressionParentNod
     }
 
     @Test
-    public final void testSameChildren() {
+    @Ignore
+    public void testSameChildren() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    public final void testSetChildrenSame() {
+        final N expression = this.createExpressionNode();
+        assertSame(expression, expression.setChildren(expression.children()));
+    }
+
+    @Test
+    public final void testSetChildrenEqvuivalent() {
         final N expression = this.createExpressionNode();
         assertSame(expression, expression.setChildren(this.children()));
     }

--- a/src/test/java/walkingkooka/tree/json/JsonArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonArrayNodeTest.java
@@ -90,6 +90,26 @@ public final class JsonArrayNodeTest extends JsonParentNodeTestCase<JsonArrayNod
     }
 
     @Test
+    public void testSetChildrenSame() {
+        final String[] values = new String[]{ "A1", "B2"};
+        final JsonNode first = JsonNode.string(values[0]);
+        final JsonNode second = JsonNode.string(values[1]);
+
+        final JsonArrayNode array = JsonNode.array().appendChild(first).appendChild(second);
+        assertSame(array, array.setChildren(array.children()));
+    }
+
+    @Test
+    public void testSetChildrenEquivalent() {
+        final String[] values = new String[]{ "A1", "B2"};
+        final JsonNode first = JsonNode.string(values[0]);
+        final JsonNode second = JsonNode.string(values[1]);
+
+        final JsonArrayNode array = JsonNode.array().appendChild(first).appendChild(second);
+        assertSame(array, array.setChildren(Lists.of(first, second)));
+    }
+
+    @Test
     public void testSetSame() {
         final String[] values = new String[]{ "A1", "B2"};
         final JsonNode first = JsonNode.string(values[0]);

--- a/src/test/java/walkingkooka/tree/json/JsonObjectNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonObjectNodeTest.java
@@ -48,6 +48,32 @@ public final class JsonObjectNodeTest extends JsonParentNodeTestCase<JsonObjectN
     private final static String VALUE2 = "value2";
     private final static String VALUE3 = "value3";
 
+    @Test
+    public void testSetChildrenSame() {
+        final JsonNodeName key1 = this.key1();
+        final JsonStringNode value1 = this.value1();
+        final JsonObjectNode empty = JsonNode.object();
+
+        final JsonObjectNode object = empty.set(key1, value1);
+        this.childrenCheck(object);
+        this.getAndCheck(object, key1, VALUE1);
+
+        assertSame(object, object.setChildren(object.children()));
+    }
+
+    @Test
+    public void testSetChildrenEquivalent() {
+        final JsonNodeName key1 = this.key1();
+        final JsonStringNode value1 = this.value1();
+        final JsonObjectNode empty = JsonNode.object();
+
+        final JsonObjectNode object = empty.set(key1, value1);
+        this.childrenCheck(object);
+        this.getAndCheck(object, key1, VALUE1);
+
+        assertSame(object, object.setChildren(Lists.of(JsonNode.string(VALUE1).setName(key1))));
+    }
+
     // set and get
 
     @Test


### PR DESCRIPTION
…entNode.setChildren & ExpressionParentNode.setChildren.

- Added delegates to Iterables.equals in Lists & Sets.
- Added a few more tests for JsonParentNodes and ExpressionParentNodes setChildren
- Improved JsonParentNode & ExpressionParentNode setChild methods.