### PR TITLE
Renamed types with Number -> BigInteger.

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/BigIntegerParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/BigIntegerParser.java
@@ -26,23 +26,23 @@ import java.util.Optional;
  * A {@link Parser} that matches a number using a given radix. Note it does not require or match a leading prefix.
  * Note this only parses numeric digits and not any leading minus sign.
  */
-final class NumberParser<C extends ParserContext> extends ParserTemplate2<NumberParserToken, C> {
+final class BigIntegerParser<C extends ParserContext> extends ParserTemplate2<BigIntegerParserToken, C> {
 
     /**
-     * Factory that creates a {@link NumberParser}
+     * Factory that creates a {@link BigIntegerParser}
      */
-    static <C extends ParserContext> NumberParser<C> with(final int radix) {
+    static <C extends ParserContext> BigIntegerParser<C> with(final int radix) {
         if(radix <= 0) {
             throw new IllegalArgumentException("Radix " + radix + " must be > 0");
         }
 
-        return new NumberParser<>(radix);
+        return new BigIntegerParser<>(radix);
     }
 
     /**
      * Private ctor to limit subclassing.
      */
-    private NumberParser(final int radix) {
+    private BigIntegerParser(final int radix) {
         this.radix = radix;
         this.radixBigInteger = BigInteger.valueOf(radix);
     }
@@ -51,8 +51,8 @@ final class NumberParser<C extends ParserContext> extends ParserTemplate2<Number
      * Reads character by character until a non digit is found, using a {@link BigInteger} to hold the value.
      */
     @Override
-    Optional<NumberParserToken> tryParse0(final TextCursor cursor, final C context, final TextCursorSavePoint save) {
-        Optional<NumberParserToken> token;
+    Optional<BigIntegerParserToken> tryParse0(final TextCursor cursor, final C context, final TextCursorSavePoint save) {
+        Optional<BigIntegerParserToken> token;
 
         final int radix = this.radix;
         BigInteger number = BigInteger.ZERO;
@@ -108,8 +108,8 @@ final class NumberParser<C extends ParserContext> extends ParserTemplate2<Number
         return token;
     }
 
-    private Optional<NumberParserToken> createToken(final BigInteger value, final TextCursorSavePoint save){
-        return NumberParserToken.with(value,
+    private Optional<BigIntegerParserToken> createToken(final BigInteger value, final TextCursorSavePoint save){
+        return BigIntegerParserToken.with(value,
                 save.textBetween().toString())
                 .success();
     }
@@ -120,6 +120,6 @@ final class NumberParser<C extends ParserContext> extends ParserTemplate2<Number
     @Override
     public String toString() {
         final int radix = this.radix;
-        return 10 == radix ? "number" : "number(base=" + radix+ ")";
+        return 10 == radix ? "BigInteger" : "BigInteger(base=" + radix+ ")";
     }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/BigIntegerParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/BigIntegerParserToken.java
@@ -22,28 +22,28 @@ import java.util.Objects;
 /**
  * The parser token for a number with the value contained in a {@link BigInteger}.
  */
-public final class NumberParserToken extends ParserTemplateToken<BigInteger> {
+public final class BigIntegerParserToken extends ParserTemplateToken<BigInteger> {
 
-    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(NumberParserToken.class);
+    public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(BigIntegerParserToken.class);
 
-    public static NumberParserToken with(final BigInteger value, final String text) {
+    public static BigIntegerParserToken with(final BigInteger value, final String text) {
         Objects.requireNonNull(value, "value");
         Objects.requireNonNull(text, "text");
 
-        return new NumberParserToken(value, text);
+        return new BigIntegerParserToken(value, text);
     }
 
-    private NumberParserToken(final BigInteger value, final String text) {
+    private BigIntegerParserToken(final BigInteger value, final String text) {
         super(value, text);
     }
 
     @Override
-    public NumberParserToken setText(final String text){
+    public BigIntegerParserToken setText(final String text){
         return this.setText0(text).cast();
     }
 
     @Override
-    NumberParserToken replaceText(final String text) {
+    BigIntegerParserToken replaceText(final String text) {
         return with(this.value(), text);
     }
 
@@ -59,7 +59,7 @@ public final class NumberParserToken extends ParserTemplateToken<BigInteger> {
 
     @Override
     boolean canBeEqual(final Object other) {
-        return other instanceof NumberParserToken;
+        return other instanceof BigIntegerParserToken;
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/FakeParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/FakeParserTokenVisitor.java
@@ -39,6 +39,11 @@ public class FakeParserTokenVisitor extends ParserTokenVisitor implements Fake {
     }
 
     @Override
+    protected void visit(final BigIntegerParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected void visit(final CharacterParserToken token) {
         throw new UnsupportedOperationException();
     }
@@ -60,11 +65,6 @@ public class FakeParserTokenVisitor extends ParserTokenVisitor implements Fake {
 
     @Override
     protected void visit(final MissingParserToken token) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void visit(final NumberParserToken token) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/LongParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/LongParser.java
@@ -119,6 +119,6 @@ final class LongParser<C extends ParserContext> extends ParserTemplate2<LongPars
     @Override
     public String toString() {
         final int radix = this.radix;
-        return 10 == radix ? "number" : "number(base=" + radix+ ")";
+        return 10 == radix ? "Long" : "Long(base=" + radix+ ")";
     }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokenVisitor.java
@@ -49,6 +49,10 @@ public abstract class ParserTokenVisitor extends Visitor<ParserToken> {
         // nop
     }
 
+    protected void visit(final BigIntegerParserToken token) {
+        // nop
+    }
+
     protected void visit(final CharacterParserToken token) {
         // nop
     }
@@ -66,10 +70,6 @@ public abstract class ParserTokenVisitor extends Visitor<ParserToken> {
     }
 
     protected void visit(final MissingParserToken token) {
-        // nop
-    }
-
-    protected void visit(final NumberParserToken token) {
         // nop
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokens.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokens.java
@@ -33,6 +33,13 @@ public final class ParserTokens implements PublicStaticHelper {
     }
 
     /**
+     * {@see BigIntegerParserToken}
+     */
+    public static BigIntegerParserToken bigInteger(final BigInteger value, final String text) {
+        return BigIntegerParserToken.with(value, text);
+    }
+
+    /**
      * {@see CharacterParserToken}
      */
     public static CharacterParserToken character(final char value, final String text) {
@@ -65,13 +72,6 @@ public final class ParserTokens implements PublicStaticHelper {
      */
     public static MissingParserToken missing(final ParserTokenNodeName name, final String text) {
         return MissingParserToken.with(name, text);
-    }
-    
-    /**
-     * {@see NumberParserToken}
-     */
-    public static NumberParserToken number(final BigInteger value, final String text) {
-        return NumberParserToken.with(value, text);
     }
 
     /**

--- a/src/main/java/walkingkooka/text/cursor/parser/Parsers.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/Parsers.java
@@ -51,6 +51,13 @@ public final class Parsers implements PublicStaticHelper {
     }
 
     /**
+     * {@see BigIntegerParser}
+     */
+    public static <C extends ParserContext> Parser<BigIntegerParserToken, C> bigInteger(final int radix) {
+        return BigIntegerParser.with(radix);
+    }
+
+    /**
      * {@see CharacterCharPredicateParser}
      */
     public static <C extends ParserContext> Parser<CharacterParserToken, C> character(final CharPredicate predicate) {
@@ -97,13 +104,6 @@ public final class Parsers implements PublicStaticHelper {
      */
     public static <C extends ParserContext> Parser<LongParserToken, C> longParser(final int radix) {
         return LongParser.with(radix);
-    }
-    
-    /**
-     * {@see NumberParser}
-     */
-    public static <C extends ParserContext> Parser<NumberParserToken, C> number(final int radix) {
-        return NumberParser.with(radix);
     }
 
     /**

--- a/src/main/java/walkingkooka/text/cursor/parser/function/ParserBiFunctions.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/function/ParserBiFunctions.java
@@ -16,7 +16,7 @@
  */
 package walkingkooka.text.cursor.parser.function;
 
-import walkingkooka.text.cursor.parser.NumberParserToken;
+import walkingkooka.text.cursor.parser.BigIntegerParserToken;
 import walkingkooka.text.cursor.parser.ParserContext;
 import walkingkooka.text.cursor.parser.Parsers;
 import walkingkooka.text.cursor.parser.SequenceParserToken;
@@ -32,7 +32,7 @@ public final class ParserBiFunctions implements PublicStaticHelper {
     /**
      * {@see PrefixedNumberParserTokenBiFunction}
      */
-    public static <C extends ParserContext> BiFunction<SequenceParserToken, C, NumberParserToken> prefixedNumber() {
+    public static <C extends ParserContext> BiFunction<SequenceParserToken, C, BigIntegerParserToken> prefixedNumber() {
         return PrefixedNumberParserTokenBiFunction.get();
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/function/PrefixedNumberParserTokenBiFunction.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/function/PrefixedNumberParserTokenBiFunction.java
@@ -17,7 +17,7 @@
 package walkingkooka.text.cursor.parser.function;
 
 import walkingkooka.Cast;
-import walkingkooka.text.cursor.parser.NumberParserToken;
+import walkingkooka.text.cursor.parser.BigIntegerParserToken;
 import walkingkooka.text.cursor.parser.ParserContext;
 import walkingkooka.text.cursor.parser.ParserException;
 import walkingkooka.text.cursor.parser.SequenceParserToken;
@@ -28,7 +28,7 @@ import java.util.function.BiFunction;
 /**
  * Assumes two tokens wrapped in a {@link SequenceParserToken}, and combines the text keeping the 2nd tokens value.
  */
-final class PrefixedNumberParserTokenBiFunction<C extends ParserContext> implements BiFunction<SequenceParserToken, C, NumberParserToken> {
+final class PrefixedNumberParserTokenBiFunction<C extends ParserContext> implements BiFunction<SequenceParserToken, C, BigIntegerParserToken> {
 
     /**
      * Type safe singleton getter.
@@ -47,7 +47,7 @@ final class PrefixedNumberParserTokenBiFunction<C extends ParserContext> impleme
     }
 
     @Override
-    public final NumberParserToken apply(final SequenceParserToken token, final C c) {
+    public final BigIntegerParserToken apply(final SequenceParserToken token, final C c) {
         try {
             return this.apply0(token, c);
         } catch (final ClassCastException | IllegalStateException | IndexOutOfBoundsException cause) {
@@ -55,11 +55,11 @@ final class PrefixedNumberParserTokenBiFunction<C extends ParserContext> impleme
         }
     }
 
-    private NumberParserToken apply0(final SequenceParserToken token, final C c) {
+    private BigIntegerParserToken apply0(final SequenceParserToken token, final C c) {
         token.checkTokenCount(2);
 
         final StringParserToken prefix = token.required(0, StringParserToken.class);
-        final NumberParserToken number = token.required(1, NumberParserToken.class);
+        final BigIntegerParserToken number = token.required(1, BigIntegerParserToken.class);
 
         return number.setText(prefix.text().concat(number.text()));
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBigDecimalParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBigDecimalParserToken.java
@@ -65,7 +65,7 @@ public final class SpreadsheetBigDecimalParserToken extends SpreadsheetNumericPa
     }
 
     @Override
-    public boolean isNumber() {
+    public boolean isBigInteger() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBigIntegerParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBigIntegerParserToken.java
@@ -22,36 +22,41 @@ import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 import java.math.BigInteger;
 
 /**
- * Holds a single integer number.
+ * Holds a single {@link BigInteger} number.
  */
-public final class SpreadsheetNumberParserToken extends SpreadsheetNumericParserToken<BigInteger> {
+public final class SpreadsheetBigIntegerParserToken extends SpreadsheetNumericParserToken<BigInteger> {
 
-    public final static ParserTokenNodeName NAME = parserTokenNodeName(SpreadsheetNumberParserToken.class);
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(SpreadsheetBigIntegerParserToken.class);
 
-    static SpreadsheetNumberParserToken with(final BigInteger value, final String text){
+    static SpreadsheetBigIntegerParserToken with(final BigInteger value, final String text){
         checkValue(value);
         checkText(text);
 
-        return new SpreadsheetNumberParserToken(value, text);
+        return new SpreadsheetBigIntegerParserToken(value, text);
     }
 
-    private SpreadsheetNumberParserToken(final BigInteger value, final String text){
+    private SpreadsheetBigIntegerParserToken(final BigInteger value, final String text){
         super(value, text);
     }
 
     @Override
-    public SpreadsheetNumberParserToken setText(final String text) {
+    public SpreadsheetBigIntegerParserToken setText(final String text) {
         return this.setText0(text).cast();
     }
 
     @Override
-    SpreadsheetNumberParserToken replaceText(final String text) {
-        return new SpreadsheetNumberParserToken(this.value, text);
+    SpreadsheetBigIntegerParserToken replaceText(final String text) {
+        return new SpreadsheetBigIntegerParserToken(this.value, text);
     }
 
     @Override
     public boolean isBigDecimal() {
         return false;
+    }
+
+    @Override
+    public boolean isBigInteger() {
+        return true;
     }
 
     @Override
@@ -62,11 +67,6 @@ public final class SpreadsheetNumberParserToken extends SpreadsheetNumericParser
     @Override
     public boolean isLong() {
         return false;
-    }
-
-    @Override
-    public boolean isNumber() {
-        return true;
     }
 
     @Override
@@ -91,7 +91,7 @@ public final class SpreadsheetNumberParserToken extends SpreadsheetNumericParser
 
     @Override
     boolean canBeEqual(final Object other) {
-        return other instanceof SpreadsheetNumberParserToken;
+        return other instanceof SpreadsheetBigIntegerParserToken;
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetColumnParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetColumnParserToken.java
@@ -61,6 +61,11 @@ public final class SpreadsheetColumnParserToken extends SpreadsheetLeafParserTok
     }
 
     @Override
+    public boolean isBigInteger() {
+        return false;
+    }
+
+    @Override
     public boolean isColumn() {
         return true;
     }
@@ -82,11 +87,6 @@ public final class SpreadsheetColumnParserToken extends SpreadsheetLeafParserTok
 
     @Override
     public boolean isLong() {
-        return false;
-    }
-
-    @Override
-    public boolean isNumber() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDoubleParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDoubleParserToken.java
@@ -62,7 +62,7 @@ public final class SpreadsheetDoubleParserToken extends SpreadsheetNumericParser
     }
 
     @Override
-    public boolean isNumber() {
+    public boolean isBigInteger() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionNameParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionNameParserToken.java
@@ -60,6 +60,11 @@ public final class SpreadsheetFunctionNameParserToken extends SpreadsheetLeafPar
     }
 
     @Override
+    public boolean isBigInteger() {
+        return false;
+    }
+
+    @Override
     public boolean isColumn() {
         return false;
     }
@@ -81,11 +86,6 @@ public final class SpreadsheetFunctionNameParserToken extends SpreadsheetLeafPar
 
     @Override
     public boolean isLong() {
-        return false;
-    }
-
-    @Override
-    public boolean isNumber() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLabelNameParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLabelNameParserToken.java
@@ -60,6 +60,11 @@ public final class SpreadsheetLabelNameParserToken extends SpreadsheetLeafParser
     }
 
     @Override
+    public boolean isBigInteger() {
+        return false;
+    }
+
+    @Override
     public boolean isColumn() {
         return false;
     }
@@ -81,11 +86,6 @@ public final class SpreadsheetLabelNameParserToken extends SpreadsheetLeafParser
 
     @Override
     public boolean isLong() {
-        return false;
-    }
-
-    @Override
-    public boolean isNumber() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLongParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLongParserToken.java
@@ -62,7 +62,7 @@ public final class SpreadsheetLongParserToken extends SpreadsheetNumericParserTo
     }
 
     @Override
-    public boolean isNumber() {
+    public boolean isBigInteger() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserToken.java
@@ -81,6 +81,11 @@ abstract class SpreadsheetParentParserToken extends SpreadsheetParserToken imple
     }
 
     @Override
+    public final boolean isBigInteger() {
+        return false;
+    }
+
+    @Override
     public final boolean isCloseParenthesisSymbol() {
         return false;
     }
@@ -157,11 +162,6 @@ abstract class SpreadsheetParentParserToken extends SpreadsheetParserToken imple
 
     @Override
     public final boolean isNotEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public final boolean isNumber() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserToken.java
@@ -69,6 +69,13 @@ public abstract class SpreadsheetParserToken implements ParserToken, HasExpressi
     }
 
     /**
+     * {@see SpreadsheetBigIntegerParserToken}
+     */
+    public static SpreadsheetBigIntegerParserToken bigInteger(final BigInteger value, final String text){
+        return SpreadsheetBigIntegerParserToken.with(value, text);
+    }
+
+    /**
      * {@see SpreadsheetCellParserToken}
      */
     public static SpreadsheetCellParserToken cell(final List<ParserToken> value, final String text){
@@ -262,13 +269,6 @@ public abstract class SpreadsheetParserToken implements ParserToken, HasExpressi
      */
     public static SpreadsheetNotEqualsSymbolParserToken notEqualsSymbol(final String value, final String text) {
         return SpreadsheetNotEqualsSymbolParserToken.with(value, text);
-    }
-    
-    /**
-     * {@see SpreadsheetNumberParserToken}
-     */
-    public static SpreadsheetNumberParserToken number(final BigInteger value, final String text){
-        return SpreadsheetNumberParserToken.with(value, text);
     }
 
     /**
@@ -550,9 +550,9 @@ public abstract class SpreadsheetParserToken implements ParserToken, HasExpressi
     public abstract boolean isNotEqualsSymbol();
 
     /**
-     * Only {@link SpreadsheetNumberParserToken} return true
+     * Only {@link SpreadsheetBigIntegerParserToken} return true
      */
-    public abstract boolean isNumber();
+    public abstract boolean isBigInteger();
 
     /**
      * Only {@link SpreadsheetOpenParenthesisSymbolParserToken} return true

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor.java
@@ -261,6 +261,11 @@ final class SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor 
     protected void visit(final SpreadsheetBigDecimalParserToken token) {
         this.add(ExpressionNode.bigDecimal(token.value()), token);
     }
+    
+    @Override
+    protected void visit(final SpreadsheetBigIntegerParserToken token) {
+        this.add(ExpressionNode.bigInteger(token.value()), token);
+    }
 
     @Override
     protected void visit(final SpreadsheetDoubleParserToken token) {
@@ -275,11 +280,6 @@ final class SpreadsheetParserTokenToExpressionNodeSpreadsheetParserTokenVisitor 
     @Override
     protected void visit(final SpreadsheetLongParserToken token) {
         this.add(ExpressionNode.longNode(token.value()), token);
-    }
-
-    @Override
-    protected void visit(final SpreadsheetNumberParserToken token) {
-        this.add(ExpressionNode.number(token.value()), token);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenVisitor.java
@@ -205,6 +205,10 @@ public abstract class SpreadsheetParserTokenVisitor extends ParserTokenVisitor {
         // nop
     }
 
+    protected void visit(final SpreadsheetBigIntegerParserToken token) {
+        // nop
+    }
+
     protected void visit(final SpreadsheetCloseParenthesisSymbolParserToken token) {
         // nop
     }
@@ -266,10 +270,6 @@ public abstract class SpreadsheetParserTokenVisitor extends ParserTokenVisitor {
     }
 
     protected void visit(final SpreadsheetNotEqualsSymbolParserToken token) {
-        // nop
-    }
-
-    protected void visit(final SpreadsheetNumberParserToken token) {
         // nop
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetRowParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetRowParserToken.java
@@ -61,6 +61,11 @@ public final class SpreadsheetRowParserToken extends SpreadsheetLeafParserToken2
     }
 
     @Override
+    public boolean isBigInteger() {
+        return false;
+    }
+
+    @Override
     public boolean isColumn() {
         return false;
     }
@@ -82,11 +87,6 @@ public final class SpreadsheetRowParserToken extends SpreadsheetLeafParserToken2
 
     @Override
     public boolean isLong() {
-        return false;
-    }
-
-    @Override
-    public boolean isNumber() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSymbolParserToken.java
@@ -39,6 +39,11 @@ abstract class SpreadsheetSymbolParserToken extends SpreadsheetLeafParserToken<S
     }
 
     @Override
+    public final boolean isBigInteger() {
+        return false;
+    }
+
+    @Override
     public final boolean isColumn() {
         return false;
     }
@@ -60,11 +65,6 @@ abstract class SpreadsheetSymbolParserToken extends SpreadsheetLeafParserToken<S
 
     @Override
     public final boolean isLong() {
-        return false;
-    }
-
-    @Override
-    public final boolean isNumber() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetTextParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetTextParserToken.java
@@ -61,6 +61,11 @@ public final class SpreadsheetTextParserToken extends SpreadsheetLeafParserToken
     }
 
     @Override
+    public boolean isBigInteger() {
+        return false;
+    }
+
+    @Override
     public boolean isColumn() {
         return false;
     }
@@ -82,11 +87,6 @@ public final class SpreadsheetTextParserToken extends SpreadsheetLeafParserToken
 
     @Override
     public boolean isLong() {
-        return false;
-    }
-
-    @Override
-    public boolean isNumber() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetWhitespaceParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetWhitespaceParserToken.java
@@ -61,6 +61,11 @@ public final class SpreadsheetWhitespaceParserToken extends SpreadsheetLeafParse
     }
 
     @Override
+    public boolean isBigInteger() {
+        return false;
+    }
+
+    @Override
     public boolean isColumn() {
         return false;
     }
@@ -84,12 +89,7 @@ public final class SpreadsheetWhitespaceParserToken extends SpreadsheetLeafParse
     public boolean isLong() {
         return false;
     }
-
-    @Override
-    public boolean isNumber() {
-        return false;
-    }
-
+    
     @Override
     public boolean isRow() {
         return false;

--- a/src/main/java/walkingkooka/tree/expression/ExpressionBigDecimalNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionBigDecimalNode.java
@@ -69,7 +69,7 @@ public final class ExpressionBigDecimalNode extends ExpressionLeafValueNode<BigD
     }
 
     @Override
-    public boolean isNumber() {
+    public boolean isBigInteger() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionBigIntegerNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionBigIntegerNode.java
@@ -24,16 +24,16 @@ import java.util.Objects;
 /**
  * A {@link BigInteger} number value.
  */
-public final class ExpressionNumberNode extends ExpressionLeafValueNode<BigInteger> {
+public final class ExpressionBigIntegerNode extends ExpressionLeafValueNode<BigInteger> {
 
-    public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionNumberNode.class);
+    public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionBigIntegerNode.class);
 
-    static ExpressionNumberNode with(final BigInteger value) {
+    static ExpressionBigIntegerNode with(final BigInteger value) {
         Objects.requireNonNull(value, "value");
-        return new ExpressionNumberNode(NO_PARENT_INDEX, value);
+        return new ExpressionBigIntegerNode(NO_PARENT_INDEX, value);
     }
 
-    private ExpressionNumberNode(final int index, final BigInteger value){
+    private ExpressionBigIntegerNode(final int index, final BigInteger value){
         super(index, value);
     }
 
@@ -43,13 +43,18 @@ public final class ExpressionNumberNode extends ExpressionLeafValueNode<BigInteg
     }
 
     @Override
-    ExpressionNumberNode wrap1(final int index, final BigInteger value) {
-        return new ExpressionNumberNode(index, value);
+    ExpressionBigIntegerNode wrap1(final int index, final BigInteger value) {
+        return new ExpressionBigIntegerNode(index, value);
     }
 
     @Override
     public boolean isBigDecimal() {
         return false;
+    }
+
+    @Override
+    public boolean isBigInteger() {
+        return true;
     }
 
     @Override
@@ -65,11 +70,6 @@ public final class ExpressionNumberNode extends ExpressionLeafValueNode<BigInteg
     @Override
     public boolean isLong() {
         return false;
-    }
-
-    @Override
-    public boolean isNumber() {
-        return true;
     }
 
     @Override
@@ -89,7 +89,7 @@ public final class ExpressionNumberNode extends ExpressionLeafValueNode<BigInteg
 
     @Override
     boolean canBeEqual(final Object other) {
-        return other instanceof ExpressionNumberNode;
+        return other instanceof ExpressionBigIntegerNode;
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionBooleanNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionBooleanNode.java
@@ -64,7 +64,7 @@ public final class ExpressionBooleanNode extends ExpressionLeafValueNode<Boolean
     }
 
     @Override
-    public boolean isNumber() {
+    public boolean isBigInteger() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionDoubleNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionDoubleNode.java
@@ -65,7 +65,7 @@ public final class ExpressionDoubleNode extends ExpressionLeafValueNode<Double> 
     }
 
     @Override
-    public boolean isNumber() {
+    public boolean isBigInteger() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionLongNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionLongNode.java
@@ -64,7 +64,7 @@ public final class ExpressionLongNode extends ExpressionLeafValueNode<Long> {
     }
 
     @Override
-    public boolean isNumber() {
+    public boolean isBigInteger() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNode.java
@@ -58,6 +58,13 @@ public abstract class ExpressionNode implements Node<ExpressionNode, ExpressionN
     }
 
     /**
+     * {@see ExpressionBigIntegerNode}
+     */
+    public static ExpressionBigIntegerNode bigInteger(final BigInteger value) {
+        return ExpressionBigIntegerNode.with(value);
+    }
+
+    /**
      * {@see ExpressionBooleanNode}
      */
     public static ExpressionBooleanNode booleanNode(final boolean value) {
@@ -167,13 +174,6 @@ public abstract class ExpressionNode implements Node<ExpressionNode, ExpressionN
      */
     public static ExpressionNotEqualsNode notEquals(final ExpressionNode left, final ExpressionNode right){
         return ExpressionNotEqualsNode.with(left, right);
-    }
-
-    /**
-     * {@see ExpressionNumberNode}
-     */
-    public static ExpressionNumberNode number(final BigInteger value) {
-        return ExpressionNumberNode.with(value);
     }
     
     /**
@@ -404,9 +404,9 @@ public abstract class ExpressionNode implements Node<ExpressionNode, ExpressionN
     public abstract boolean isNotEquals();
 
     /**
-     * Only {@link ExpressionNumberNode} returns true
+     * Only {@link ExpressionBigIntegerNode} returns true
      */
-    public abstract boolean isNumber();
+    public abstract boolean isBigInteger();
 
     /**
      * Only {@link ExpressionOrNode} returns true

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNodeVisitor.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNodeVisitor.java
@@ -63,7 +63,7 @@ public abstract class ExpressionNodeVisitor extends Visitor<ExpressionNode> {
         // nop
     }
 
-    protected void visit(final ExpressionNumberNode node) {
+    protected void visit(final ExpressionBigIntegerNode node) {
         // nop
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionParentNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionParentNode.java
@@ -122,7 +122,7 @@ abstract class ExpressionParentNode extends ExpressionNode {
     }
 
     @Override
-    public final boolean isNumber() {
+    public final boolean isBigInteger() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionReferenceNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionReferenceNode.java
@@ -68,7 +68,7 @@ public final class ExpressionReferenceNode extends ExpressionLeafValueNode<Expre
     }
 
     @Override
-    public boolean isNumber() {
+    public boolean isBigInteger() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionTextNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionTextNode.java
@@ -69,7 +69,7 @@ public final class ExpressionTextNode extends ExpressionLeafValueNode<String> {
     }
 
     @Override
-    public boolean isNumber() {
+    public boolean isBigInteger() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/tree/expression/FakeExpressionNodeVisitor.java
+++ b/src/main/java/walkingkooka/tree/expression/FakeExpressionNodeVisitor.java
@@ -56,7 +56,7 @@ public class FakeExpressionNodeVisitor extends ExpressionNodeVisitor implements 
     }
 
     @Override
-    protected void visit(final ExpressionNumberNode node) {
+    protected void visit(final ExpressionBigIntegerNode node) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/BigIntegerParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/BigIntegerParserTest.java
@@ -25,18 +25,18 @@ import java.math.BigInteger;
 
 import static org.junit.Assert.assertEquals;
 
-public class NumberParserTest extends ParserTemplateTestCase<NumberParser<FakeParserContext>, NumberParserToken> {
+public class BigIntegerParserTest extends ParserTemplateTestCase<BigIntegerParser<FakeParserContext>, BigIntegerParserToken> {
 
     private final static int RADIX = 10;
 
     @Test(expected = IllegalArgumentException.class)
     public void testWithNegativeRadixFails() {
-        NumberParser.with(-1);
+        BigIntegerParser.with(-1);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testWithZeroRadixFails() {
-        NumberParser.with(0);
+        BigIntegerParser.with(0);
     }
 
     @Test
@@ -111,17 +111,17 @@ public class NumberParserTest extends ParserTemplateTestCase<NumberParser<FakePa
 
     @Test
     public void testToString() {
-        assertEquals("number", this.createParser().toString());
+        assertEquals("BigInteger", this.createParser().toString());
     }
 
     @Test
     public void testToString2() {
-        assertEquals("number(base=8)", NumberParser.with(8).toString());
+        assertEquals("BigInteger(base=8)", BigIntegerParser.with(8).toString());
     }
 
     @Override
-    protected NumberParser createParser() {
-        return NumberParser.with(RADIX);
+    protected BigIntegerParser createParser() {
+        return BigIntegerParser.with(RADIX);
     }
 
     private TextCursor parseAndCheck2(final String in, final long value, final String text, final String textAfter){
@@ -129,20 +129,20 @@ public class NumberParserTest extends ParserTemplateTestCase<NumberParser<FakePa
     }
 
     private TextCursor parseAndCheck2(final String in, final BigInteger value, final String text, final String textAfter){
-        return this.parseAndCheck(in, NumberParserToken.with(value, text), text, textAfter);
+        return this.parseAndCheck(in, BigIntegerParserToken.with(value, text), text, textAfter);
     }
 
     private TextCursor parseAndCheck3(final int radix, final String from, final long value, final String text, final String textAfter){
-        return this.parseAndCheck(NumberParser.with(radix),
+        return this.parseAndCheck(BigIntegerParser.with(radix),
                 this.createContext(),
                 TextCursors.charSequence(from),
-                NumberParserToken.with(BigInteger.valueOf(value), text),
+                BigIntegerParserToken.with(BigInteger.valueOf(value), text),
                 text,
                 textAfter);
     }
 
     @Override
-    protected Class<NumberParser<FakeParserContext>> type() {
-        return Cast.to(NumberParser.class);
+    protected Class<BigIntegerParser<FakeParserContext>> type() {
+        return Cast.to(BigIntegerParser.class);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/BigIntegerParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/BigIntegerParserTokenTest.java
@@ -24,22 +24,22 @@ import java.math.BigInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
-public final class NumberParserTokenTest extends ParserTokenTestCase<NumberParserToken> {
+public final class BigIntegerParserTokenTest extends ParserTokenTestCase<BigIntegerParserToken> {
 
     @Test(expected = NullPointerException.class)
     public void testWithNullValueFails() {
-        NumberParserToken.with(null, "123");
+        BigIntegerParserToken.with(null, "123");
     }
 
     @Test(expected = NullPointerException.class)
     public void testWithNullTextFails() {
-        NumberParserToken.with(BigInteger.ZERO, null);
+        BigIntegerParserToken.with(BigInteger.ZERO, null);
     }
 
     @Test
     public void testAccept() {
         final StringBuilder b = new StringBuilder();
-        final NumberParserToken token = this.createToken();
+        final BigIntegerParserToken token = this.createToken();
 
         new FakeParserTokenVisitor() {
             @Override
@@ -56,7 +56,7 @@ public final class NumberParserTokenTest extends ParserTokenTestCase<NumberParse
             }
 
             @Override
-            protected void visit(final NumberParserToken t) {
+            protected void visit(final BigIntegerParserToken t) {
                 assertSame(token, t);
                 b.append("3");
             }
@@ -66,26 +66,26 @@ public final class NumberParserTokenTest extends ParserTokenTestCase<NumberParse
     
     @Test
     public void testIgnoresPrefix() {
-        NumberParserToken.with(BigInteger.valueOf(123), "+123");
+        BigIntegerParserToken.with(BigInteger.valueOf(123), "+123");
     }
 
     @Test
     public void testHex() {
-        NumberParserToken.with(BigInteger.valueOf(0x1234), "0x1234");
+        BigIntegerParserToken.with(BigInteger.valueOf(0x1234), "0x1234");
     }
 
     @Override
-    protected NumberParserToken createToken() {
-        return NumberParserToken.with(BigInteger.valueOf(123), "123");
+    protected BigIntegerParserToken createToken() {
+        return BigIntegerParserToken.with(BigInteger.valueOf(123), "123");
     }
 
     @Override
-    protected NumberParserToken createDifferentToken() {
-        return NumberParserToken.with(BigInteger.valueOf(987), "987");
+    protected BigIntegerParserToken createDifferentToken() {
+        return BigIntegerParserToken.with(BigInteger.valueOf(987), "987");
     }
 
     @Override
-    protected Class<NumberParserToken> type() {
-        return NumberParserToken.class;
+    protected Class<BigIntegerParserToken> type() {
+        return BigIntegerParserToken.class;
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/LongParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/LongParserTest.java
@@ -177,12 +177,12 @@ public class LongParserTest extends ParserTemplateTestCase<LongParser<FakeParser
 
     @Test
     public void testToString() {
-        assertEquals("number", this.createParser().toString());
+        assertEquals("Long", this.createParser().toString());
     }
 
     @Test
     public void testToString2() {
-        assertEquals("number(base=8)", LongParser.with(8).toString());
+        assertEquals("Long(base=8)", LongParser.with(8).toString());
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/MissingParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/MissingParserTokenTest.java
@@ -71,7 +71,7 @@ public final class MissingParserTokenTest extends ParserTokenTestCase<MissingPar
 
     @Override
     protected MissingParserToken createDifferentToken() {
-        return MissingParserToken.with(NumberParserToken.NAME, "xyz");
+        return MissingParserToken.with(BigIntegerParserToken.NAME, "xyz");
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/OptionalParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/OptionalParserTest.java
@@ -86,7 +86,7 @@ public class OptionalParserTest extends ParserTestCase2<OptionalParser<FakeParse
     public void testOptionalDifferentName() {
         final OptionalParser<FakeParserContext> parser = this.createParser();
 
-        final ParserTokenNodeName different = NumberParserToken.NAME;
+        final ParserTokenNodeName different = BigIntegerParserToken.NAME;
         final OptionalParser<FakeParserContext> parser2 = parser.optional(different);
 
         assertNotSame(parser, parser2);

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenNodeTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenNodeTest.java
@@ -135,7 +135,7 @@ public class SequenceParserTokenNodeTest extends ParserTokenNodeTestCase<Sequenc
 
         final SequenceParserTokenNode root = sequence("a1b2c3d4",
                 STRING1,
-                ParserTokens.sequence(Lists.of(STRING2, STRING3, ParserTokens.number(BigInteger.ZERO, "**")), "b2c3**"),
+                ParserTokens.sequence(Lists.of(STRING2, STRING3, ParserTokens.bigInteger(BigInteger.ZERO, "**")), "b2c3**"),
                 STRING4);
 
         assertEquals(Lists.of("a1", "b2", "c3", "d4"),

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenTest.java
@@ -67,7 +67,7 @@ public final class SequenceParserTokenTest extends ParserTokenTestCase<SequenceP
 
     @Test(expected = ClassCastException.class)
     public void testOptionalInvalidTypeFails() {
-        this.createToken().optional(0, NumberParserToken.class);
+        this.createToken().optional(0, BigIntegerParserToken.class);
     }
 
     @Test
@@ -101,7 +101,7 @@ public final class SequenceParserTokenTest extends ParserTokenTestCase<SequenceP
 
     @Test(expected = ClassCastException.class)
     public void testRequiredInvalidTypeFails() {
-        this.createToken().required(0, NumberParserToken.class);
+        this.createToken().required(0, BigIntegerParserToken.class);
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/TransformingParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/TransformingParserTest.java
@@ -27,12 +27,12 @@ import java.util.function.BiFunction;
 
 import static org.junit.Assert.assertEquals;
 
-public class TransformingParserTest extends ParserTestCase2<TransformingParser<StringParserToken, NumberParserToken, FakeParserContext>, NumberParserToken> {
+public class TransformingParserTest extends ParserTestCase2<TransformingParser<StringParserToken, BigIntegerParserToken, FakeParserContext>, BigIntegerParserToken> {
 
     private final static int RADIX = 10;
     private final static Parser<StringParserToken, FakeParserContext> PARSER = Parsers.stringCharPredicate(CharPredicates.digit(), 1, 10);
-    private final static BiFunction<StringParserToken, FakeParserContext, NumberParserToken> TRANSFORMER = (t, c) -> {
-        return ParserTokens.number(new BigInteger(t.value(), RADIX), t.text());
+    private final static BiFunction<StringParserToken, FakeParserContext, BigIntegerParserToken> TRANSFORMER = (t, c) -> {
+        return ParserTokens.bigInteger(new BigInteger(t.value(), RADIX), t.text());
     };
 
     @Test(expected = NullPointerException.class)
@@ -81,7 +81,7 @@ public class TransformingParserTest extends ParserTestCase2<TransformingParser<S
     }
 
     @Override
-    protected TransformingParser<StringParserToken, NumberParserToken, FakeParserContext> createParser() {
+    protected TransformingParser<StringParserToken, BigIntegerParserToken, FakeParserContext> createParser() {
         return TransformingParser.with(PARSER, TRANSFORMER);
     }
 
@@ -97,17 +97,17 @@ public class TransformingParserTest extends ParserTestCase2<TransformingParser<S
                 textAfter);
     }
 
-    private TextCursor parseAndCheck4(final Parser<NumberParserToken, FakeParserContext> parser, final String from, final long value, final String text, final String textAfter){
+    private TextCursor parseAndCheck4(final Parser<BigIntegerParserToken, FakeParserContext> parser, final String from, final long value, final String text, final String textAfter){
         return this.parseAndCheck(parser,
                 this.createContext(),
                 TextCursors.charSequence(from),
-                ParserTokens.number(BigInteger.valueOf(value), text),
+                ParserTokens.bigInteger(BigInteger.valueOf(value), text),
                 text,
                 textAfter);
     }
 
     @Override
-    protected Class<TransformingParser<StringParserToken, NumberParserToken, FakeParserContext>> type() {
+    protected Class<TransformingParser<StringParserToken, BigIntegerParserToken, FakeParserContext>> type() {
         return Cast.to(TransformingParser.class);
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorsParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorsParserTest.java
@@ -32,7 +32,7 @@ import walkingkooka.text.cursor.TextCursor;
 import walkingkooka.text.cursor.TextCursorSavePoint;
 import walkingkooka.text.cursor.TextCursors;
 import walkingkooka.text.cursor.parser.FakeParserContext;
-import walkingkooka.text.cursor.parser.NumberParserToken;
+import walkingkooka.text.cursor.parser.BigIntegerParserToken;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserTestCase3;
 import walkingkooka.text.cursor.parser.ParserToken;
@@ -482,8 +482,8 @@ public final class EbnfParserCombinatorsParserTest extends ParserTestCase3<Parse
         };
     }
 
-    private NumberParserToken number(final String text){
-        return ParserTokens.number(new BigInteger(text),text);
+    private BigIntegerParserToken number(final String text){
+        return ParserTokens.bigInteger(new BigInteger(text),text);
     }
 
     private StringParserToken string(final String text) {

--- a/src/test/java/walkingkooka/text/cursor/parser/function/PrefixedNumberParserTokenBiFunctionTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/function/PrefixedNumberParserTokenBiFunctionTest.java
@@ -18,15 +18,15 @@ package walkingkooka.text.cursor.parser.function;
 
 import org.junit.Test;
 import walkingkooka.Cast;
+import walkingkooka.text.cursor.parser.BigIntegerParserToken;
 import walkingkooka.text.cursor.parser.FakeParserContext;
-import walkingkooka.text.cursor.parser.NumberParserToken;
 import walkingkooka.text.cursor.parser.ParserException;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokens;
 
 import java.math.BigInteger;
 
-public final class PrefixedNumberParserTokenBiFunctionTest extends ParserBiFunctionTestCase2<PrefixedNumberParserTokenBiFunction<FakeParserContext>, NumberParserToken> {
+public final class PrefixedNumberParserTokenBiFunctionTest extends ParserBiFunctionTestCase2<PrefixedNumberParserTokenBiFunction<FakeParserContext>, BigIntegerParserToken> {
 
     @Test(expected = ParserException.class)
     public void testInvalidFirstToken() {
@@ -41,10 +41,10 @@ public final class PrefixedNumberParserTokenBiFunctionTest extends ParserBiFunct
     @Test
     public void testApply() {
         this.applyAndCheck(this.firstToken(), this.secondToken(),
-                ParserTokens.number(BigInteger.valueOf(31), "0x1f"));
+                ParserTokens.bigInteger(BigInteger.valueOf(31), "0x1f"));
     }
 
-    private void applyAndCheck(final ParserToken first, final ParserToken second, final NumberParserToken result) {
+    private void applyAndCheck(final ParserToken first, final ParserToken second, final BigIntegerParserToken result) {
         this.applyAndCheck(this.sequence(first, second), result);
     }
 
@@ -71,6 +71,6 @@ public final class PrefixedNumberParserTokenBiFunctionTest extends ParserBiFunct
     }
 
     private ParserToken secondToken() {
-        return ParserTokens.number(BigInteger.valueOf(31), "1f");
+        return ParserTokens.bigInteger(BigInteger.valueOf(31), "1f");
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/FakeSpreadsheetParserTokenVisitor.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/FakeSpreadsheetParserTokenVisitor.java
@@ -204,6 +204,11 @@ public class FakeSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVis
     }
 
     @Override
+    protected void visit(final SpreadsheetBigIntegerParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected void visit(final SpreadsheetColumnParserToken token) {
         throw new UnsupportedOperationException();
     }
@@ -280,11 +285,6 @@ public class FakeSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVis
 
     @Override
     protected void visit(final SpreadsheetNotEqualsSymbolParserToken token) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override 
-    protected void visit(final SpreadsheetNumberParserToken token) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetAdditionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetAdditionParserTokenTest.java
@@ -71,7 +71,7 @@ public final class SpreadsheetAdditionParserTokenTest extends SpreadsheetBinaryP
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 b.append("5");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBigIntegerParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBigIntegerParserTokenTest.java
@@ -27,12 +27,12 @@ import java.math.BigInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
-public final class SpreadsheetNumberParserTokenTest extends SpreadsheetNumericParserTokenTestCase<SpreadsheetNumberParserToken, BigInteger> {
+public final class SpreadsheetBigIntegerParserTokenTest extends SpreadsheetNumericParserTokenTestCase<SpreadsheetBigIntegerParserToken, BigInteger> {
 
     @Test
     public void testAccept() {
         final StringBuilder b = new StringBuilder();
-        final SpreadsheetNumberParserToken token = this.createToken();
+        final SpreadsheetBigIntegerParserToken token = this.createToken();
 
         new FakeSpreadsheetParserTokenVisitor() {
             @Override
@@ -62,7 +62,7 @@ public final class SpreadsheetNumberParserTokenTest extends SpreadsheetNumericPa
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 assertSame(token, t);
                 b.append("5");
             }
@@ -72,7 +72,7 @@ public final class SpreadsheetNumberParserTokenTest extends SpreadsheetNumericPa
 
     @Test
     public void testToExpressionNode() {
-        this.toExpressionNodeAndCheck(ExpressionNode.number(this.value()));
+        this.toExpressionNodeAndCheck(ExpressionNode.bigInteger(this.value()));
     }
 
     @Override
@@ -86,17 +86,17 @@ public final class SpreadsheetNumberParserTokenTest extends SpreadsheetNumericPa
     }
 
     @Override
-    protected SpreadsheetNumberParserToken createToken(final BigInteger value, final String text) {
-        return SpreadsheetNumberParserToken.with(value, text);
+    protected SpreadsheetBigIntegerParserToken createToken(final BigInteger value, final String text) {
+        return SpreadsheetBigIntegerParserToken.with(value, text);
     }
 
     @Override
-    protected SpreadsheetNumberParserToken createDifferentToken() {
-        return SpreadsheetNumberParserToken.with(BigInteger.valueOf(-1), "'different'");
+    protected SpreadsheetBigIntegerParserToken createDifferentToken() {
+        return SpreadsheetBigIntegerParserToken.with(BigInteger.valueOf(-1), "'different'");
     }
 
     @Override
-    protected Class<SpreadsheetNumberParserToken> type() {
-        return SpreadsheetNumberParserToken.class;
+    protected Class<SpreadsheetBigIntegerParserToken> type() {
+        return SpreadsheetBigIntegerParserToken.class;
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserTokenTestCase2.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserTokenTestCase2.java
@@ -28,15 +28,15 @@ public abstract class SpreadsheetBinaryParserTokenTestCase2<T extends Spreadshee
     @Test
     public final void testToExpressionNode() {
         this.toExpressionNodeAndCheck(this.expressionNode(
-                ExpressionNode.number(leftBigInteger()),
-                ExpressionNode.number(rightBigInteger())));
+                ExpressionNode.bigInteger(leftBigInteger()),
+                ExpressionNode.bigInteger(rightBigInteger())));
     }
 
     abstract ExpressionNode expressionNode(final ExpressionNode left, final ExpressionNode right);
 
     @Override
     final SpreadsheetParserToken leftToken() {
-        return SpreadsheetParserToken.number(leftBigInteger(), "1");
+        return SpreadsheetParserToken.bigInteger(leftBigInteger(), "1");
     }
 
     private BigInteger leftBigInteger() {
@@ -45,7 +45,7 @@ public abstract class SpreadsheetBinaryParserTokenTestCase2<T extends Spreadshee
 
     @Override
     final SpreadsheetParserToken rightToken() {
-        return SpreadsheetParserToken.number(rightBigInteger(), "22");
+        return SpreadsheetParserToken.bigInteger(rightBigInteger(), "22");
     }
 
     private BigInteger rightBigInteger() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDivisionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetDivisionParserTokenTest.java
@@ -71,7 +71,7 @@ public final class SpreadsheetDivisionParserTokenTest extends SpreadsheetBinaryP
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 b.append("5");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetEqualsParserTokenTest.java
@@ -71,7 +71,7 @@ public final class SpreadsheetEqualsParserTokenTest extends SpreadsheetBinaryPar
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 b.append("5");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParserTokenTest.java
@@ -102,7 +102,7 @@ public final class SpreadsheetFunctionParserTokenTest extends SpreadsheetParentP
     public void testToExpressionNode() {
         this.toExpressionNodeAndCheck(ExpressionNode.function(
                 ExpressionNodeName.with(FUNCTION),
-                Lists.of(ExpressionNode.number(new BigInteger(NUMBER1, 10)))));
+                Lists.of(ExpressionNode.bigInteger(new BigInteger(NUMBER1, 10)))));
     }
 
     private void checkFunction(final SpreadsheetFunctionParserToken function, final SpreadsheetFunctionName name) {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanEqualsParserTokenTest.java
@@ -71,7 +71,7 @@ public final class SpreadsheetGreaterThanEqualsParserTokenTest extends Spreadshe
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 b.append("5");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGreaterThanParserTokenTest.java
@@ -71,7 +71,7 @@ public final class SpreadsheetGreaterThanParserTokenTest extends SpreadsheetBina
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 b.append("5");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGroupParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGroupParserTokenTest.java
@@ -90,7 +90,7 @@ public final class SpreadsheetGroupParserTokenTest extends SpreadsheetParentPars
 
     @Test
     public void testToExpressionNode() {
-        this.toExpressionNodeAndCheck(ExpressionNode.group(ExpressionNode.number(new BigInteger(NUMBER1, 10))));
+        this.toExpressionNodeAndCheck(ExpressionNode.group(ExpressionNode.bigInteger(new BigInteger(NUMBER1, 10))));
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanEqualsParserTokenTest.java
@@ -71,7 +71,7 @@ public final class SpreadsheetLessThanEqualsParserTokenTest extends SpreadsheetB
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 b.append("5");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLessThanParserTokenTest.java
@@ -71,7 +71,7 @@ public final class SpreadsheetLessThanParserTokenTest extends SpreadsheetBinaryP
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 b.append("5");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNegativeParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNegativeParserTokenTest.java
@@ -71,7 +71,7 @@ public final class SpreadsheetNegativeParserTokenTest extends SpreadsheetUnaryPa
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 b.append("5");
                 visited.add(t);
             }
@@ -106,7 +106,7 @@ public final class SpreadsheetNegativeParserTokenTest extends SpreadsheetUnaryPa
 
     @Test
     public final void testToExpressionNode() {
-        this.toExpressionNodeAndCheck(ExpressionNode.negative(ExpressionNode.number(new BigInteger(NUMBER1, 10))));
+        this.toExpressionNodeAndCheck(ExpressionNode.negative(ExpressionNode.bigInteger(new BigInteger(NUMBER1, 10))));
     }
     
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNotEqualsParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNotEqualsParserTokenTest.java
@@ -71,7 +71,7 @@ public final class SpreadsheetNotEqualsParserTokenTest extends SpreadsheetBinary
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 b.append("5");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserTokenTestCase.java
@@ -105,16 +105,16 @@ public abstract class SpreadsheetParentParserTokenTestCase<T extends Spreadsheet
         return SpreadsheetParserToken.minusSymbol("-", "-");
     }
 
-    final SpreadsheetNumberParserToken number1() {
+    final SpreadsheetBigIntegerParserToken number1() {
         return this.number(1);
     }
 
-    final SpreadsheetNumberParserToken number2() {
+    final SpreadsheetBigIntegerParserToken number2() {
         return this.number(2);
     }
 
-    final SpreadsheetNumberParserToken number(final int value) {
-        return SpreadsheetParserToken.number(BigInteger.valueOf(value), String.valueOf(value));
+    final SpreadsheetBigIntegerParserToken number(final int value) {
+        return SpreadsheetParserToken.bigInteger(BigInteger.valueOf(value), String.valueOf(value));
     }
 
     final SpreadsheetPercentSymbolParserToken percentSymbol() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParsersTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParsersTest.java
@@ -122,7 +122,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
         final String text = "-1";
 
         this.parseAndCheck(text,
-                SpreadsheetParserToken.negative(Lists.of(minus(), number(1)), text),
+                SpreadsheetParserToken.negative(Lists.of(minus(), bigInteger(1)), text),
                 text);
     }
 
@@ -131,7 +131,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
         final String text = "-  1";
 
         this.parseAndCheck(text,
-                SpreadsheetParserToken.negative(Lists.of(minus(), whitespace(), number(1)), text),
+                SpreadsheetParserToken.negative(Lists.of(minus(), whitespace(), bigInteger(1)), text),
                 text);
     }
 
@@ -158,14 +158,14 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
         final String text = "1%";
 
         this.parseAndCheck(text,
-                SpreadsheetParserToken.percentage(Lists.of(number(1), percent()), text),
+                SpreadsheetParserToken.percentage(Lists.of(bigInteger(1), percent()), text),
                 text);
     }
 
     @Test
     public void testNegativeNumberPercentage() {
         final String text = "-1%";
-        final SpreadsheetParserToken percent = SpreadsheetParserToken.percentage(Lists.of(number(1), percent()), "1%");
+        final SpreadsheetParserToken percent = SpreadsheetParserToken.percentage(Lists.of(bigInteger(1), percent()), "1%");
 
         this.parseAndCheck(text,
                 SpreadsheetParserToken.negative(Lists.of(minus(), percent), text),
@@ -194,7 +194,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testGroupNegativeNumber() {
-        final SpreadsheetParserToken negative = negative(number(123));
+        final SpreadsheetParserToken negative = negative(bigInteger(123));
 
         final String groupText = "(-123)";
         final SpreadsheetGroupParserToken group = SpreadsheetParserToken.group(Lists.of(openParenthesis(), negative, closeParenthesis()), groupText);
@@ -205,7 +205,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
     @Test
     public void testNegativeGroupNumber() {
         final String groupText = "(123)";
-        final SpreadsheetGroupParserToken group = SpreadsheetParserToken.group(Lists.of(openParenthesis(), number(123), closeParenthesis()), groupText);
+        final SpreadsheetGroupParserToken group = SpreadsheetParserToken.group(Lists.of(openParenthesis(), bigInteger(123), closeParenthesis()), groupText);
 
         final String text = "-" + groupText;
         this.parseAndCheck(text, negative(group), text);
@@ -213,8 +213,8 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testAdd() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123+456";
         final SpreadsheetAdditionParserToken add = SpreadsheetParserToken.addition(Lists.of(left, plus(), right), text);
 
@@ -223,13 +223,13 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testAdd2() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123+456";
         final SpreadsheetAdditionParserToken add = SpreadsheetParserToken.addition(Lists.of(left, plus(), right), text);
 
         final String text2 = text + "+789";
-        final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(add, plus(), number(789)), text2);
+        final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(add, plus(), bigInteger(789)), text2);
 
         this.parseAndCheck(text2, add2, text2);
     }
@@ -237,21 +237,21 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
     @Test
     public void testAddNegative() {
         // 123+-456+789
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = negative(number(456));
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = negative(bigInteger(456));
         final String text = "123+-456";
         final SpreadsheetAdditionParserToken add = SpreadsheetParserToken.addition(Lists.of(left, plus(), right), text);
 
         final String text2 = text + "+789";
-        final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(add, plus(), number(789)), text2);
+        final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(add, plus(), bigInteger(789)), text2);
 
         this.parseAndCheck(text2, add2, text2);
     }
 
     @Test
     public void testSubtract() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123-456";
         final SpreadsheetSubtractionParserToken add = SpreadsheetParserToken.subtraction(Lists.of(left, minus(), right), text);
 
@@ -260,21 +260,21 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testSubtract2() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123-456";
         final SpreadsheetSubtractionParserToken sub = SpreadsheetParserToken.subtraction(Lists.of(left, minus(), right), text);
 
         final String text2 = text + "-789";
-        final SpreadsheetSubtractionParserToken add2 = SpreadsheetParserToken.subtraction(Lists.of(sub, minus(), number(789)), text2);
+        final SpreadsheetSubtractionParserToken add2 = SpreadsheetParserToken.subtraction(Lists.of(sub, minus(), bigInteger(789)), text2);
 
         this.parseAndCheck(text2, add2, text2);
     }
 
     @Test
     public void testSubtractNegative() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = negative(number(456));
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = negative(bigInteger(456));
         final String text = "123--456";
         final SpreadsheetSubtractionParserToken add = SpreadsheetParserToken.subtraction(Lists.of(left, minus(), right), text);
 
@@ -283,34 +283,34 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testSubtractAdd() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123-456";
         final SpreadsheetSubtractionParserToken sub = SpreadsheetParserToken.subtraction(Lists.of(left, minus(), right), text);
 
         final String text2 = text + "+789";
-        final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(sub, plus(), number(789)), text2);
+        final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(sub, plus(), bigInteger(789)), text2);
 
         this.parseAndCheck(text2, add2, text2);
     }
 
     @Test
     public void testSubtractWhitespaceAroundMinusSign() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123  -  456";
         final SpreadsheetSubtractionParserToken sub = SpreadsheetParserToken.subtraction(Lists.of(left, whitespace(), minus(), whitespace(), right), text);
 
         final String text2 = text + "+789";
-        final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(sub, plus(), number(789)), text2);
+        final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(sub, plus(), bigInteger(789)), text2);
 
         this.parseAndCheck(text2, add2, text2);
     }
 
     @Test
     public void testMultiply() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123*456";
         final SpreadsheetMultiplicationParserToken multiply = SpreadsheetParserToken.multiplication(Lists.of(left, multiply(), right), text);
 
@@ -319,21 +319,21 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testMultiply2() {
-        final SpreadsheetParserToken left = number(222);
-        final SpreadsheetParserToken right = number(333);
+        final SpreadsheetParserToken left = bigInteger(222);
+        final SpreadsheetParserToken right = bigInteger(333);
         final String text = "222*333";
         final SpreadsheetMultiplicationParserToken multiply = SpreadsheetParserToken.multiplication(Lists.of(left, multiply(), right), text);
 
         final String text2 = "111+" + text;
-        final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(number(111), plus(), multiply), text2);
+        final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(bigInteger(111), plus(), multiply), text2);
 
         this.parseAndCheck(text2, add2, text2);
     }
 
     @Test
     public void testNegativeMultiplyNegative() {
-        final SpreadsheetParserToken left = negative(number(123));
-        final SpreadsheetParserToken right = negative(number(456));
+        final SpreadsheetParserToken left = negative(bigInteger(123));
+        final SpreadsheetParserToken right = negative(bigInteger(456));
         final String text = "-123*-456";
         final SpreadsheetMultiplicationParserToken multiply = SpreadsheetParserToken.multiplication(Lists.of(left, multiply(), right), text);
 
@@ -342,8 +342,8 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testDivide() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123/456";
         final SpreadsheetDivisionParserToken divide = SpreadsheetParserToken.division(Lists.of(left, divide(), right), text);
 
@@ -352,21 +352,21 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testDivide2() {
-        final SpreadsheetParserToken left = number(222);
-        final SpreadsheetParserToken right = number(333);
+        final SpreadsheetParserToken left = bigInteger(222);
+        final SpreadsheetParserToken right = bigInteger(333);
         final String text = "222/333";
         final SpreadsheetDivisionParserToken divide = SpreadsheetParserToken.division(Lists.of(left, divide(), right), text);
 
         final String text2 = "111+" + text;
-        final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(number(111), plus(), divide), text2);
+        final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(bigInteger(111), plus(), divide), text2);
 
         this.parseAndCheck(text2, add2, text2);
     }
 
     @Test
     public void testNegativeDivideNegative() {
-        final SpreadsheetParserToken left = negative(number(123));
-        final SpreadsheetParserToken right = negative(number(456));
+        final SpreadsheetParserToken left = negative(bigInteger(123));
+        final SpreadsheetParserToken right = negative(bigInteger(456));
         final String text = "-123/-456";
         final SpreadsheetDivisionParserToken divide = SpreadsheetParserToken.division(Lists.of(left, divide(), right), text);
 
@@ -375,8 +375,8 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testPower() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123^456";
         final SpreadsheetPowerParserToken power = SpreadsheetParserToken.power(Lists.of(left, power(), right), text);
 
@@ -385,21 +385,21 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testPower2() {
-        final SpreadsheetParserToken left = number(222);
-        final SpreadsheetParserToken right = number(333);
+        final SpreadsheetParserToken left = bigInteger(222);
+        final SpreadsheetParserToken right = bigInteger(333);
         final String text = "222^333";
         final SpreadsheetPowerParserToken power = SpreadsheetParserToken.power(Lists.of(left, power(), right), text);
 
         final String text2 = "111*" + text;
-        final SpreadsheetMultiplicationParserToken multiply2 = SpreadsheetParserToken.multiplication(Lists.of(number(111), multiply(), power), text2);
+        final SpreadsheetMultiplicationParserToken multiply2 = SpreadsheetParserToken.multiplication(Lists.of(bigInteger(111), multiply(), power), text2);
 
         this.parseAndCheck(text2, multiply2, text2);
     }
 
     @Test
     public void testEquals() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123==456";
         final SpreadsheetEqualsParserToken equals = SpreadsheetParserToken.equalsParserToken(Lists.of(left, equals(), right), text);
 
@@ -408,12 +408,12 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testEqualsAdd() {
-        final SpreadsheetParserToken middle = number(456);
-        final SpreadsheetParserToken right = number(789);
+        final SpreadsheetParserToken middle = bigInteger(456);
+        final SpreadsheetParserToken right = bigInteger(789);
         final String addText = "456+789";
         final SpreadsheetAdditionParserToken add = SpreadsheetParserToken.addition(Lists.of(middle, plus(), right), addText);
 
-        final SpreadsheetParserToken left = number(123);
+        final SpreadsheetParserToken left = bigInteger(123);
         final String text = "123==" + addText;
         final SpreadsheetEqualsParserToken equals = SpreadsheetParserToken.equalsParserToken(Lists.of(left, equals(), add), text);
 
@@ -422,8 +422,8 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testNotEquals() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123!=456";
         final SpreadsheetNotEqualsParserToken ne = SpreadsheetParserToken.notEquals(Lists.of(left, notEquals(), right), text);
 
@@ -432,12 +432,12 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testNotEqualsAdd() {
-        final SpreadsheetParserToken middle = number(456);
-        final SpreadsheetParserToken right = number(789);
+        final SpreadsheetParserToken middle = bigInteger(456);
+        final SpreadsheetParserToken right = bigInteger(789);
         final String addText = "456+789";
         final SpreadsheetAdditionParserToken add = SpreadsheetParserToken.addition(Lists.of(middle, plus(), right), addText);
 
-        final SpreadsheetParserToken left = number(123);
+        final SpreadsheetParserToken left = bigInteger(123);
         final String text = "123!=" + addText;
         final SpreadsheetNotEqualsParserToken ne = SpreadsheetParserToken.notEquals(Lists.of(left, notEquals(), add), text);
 
@@ -446,8 +446,8 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testGreaterThan() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123>456";
         final SpreadsheetGreaterThanParserToken gt = SpreadsheetParserToken.greaterThan(Lists.of(left, greaterThan(), right), text);
 
@@ -456,12 +456,12 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testGreaterThanAdd() {
-        final SpreadsheetParserToken middle = number(456);
-        final SpreadsheetParserToken right = number(789);
+        final SpreadsheetParserToken middle = bigInteger(456);
+        final SpreadsheetParserToken right = bigInteger(789);
         final String addText = "456+789";
         final SpreadsheetAdditionParserToken add = SpreadsheetParserToken.addition(Lists.of(middle, plus(), right), addText);
 
-        final SpreadsheetParserToken left = number(123);
+        final SpreadsheetParserToken left = bigInteger(123);
         final String text = "123>" + addText;
         final SpreadsheetGreaterThanParserToken gt = SpreadsheetParserToken.greaterThan(Lists.of(left, greaterThan(), add), text);
 
@@ -470,8 +470,8 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testGreaterThanEquals() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123>=456";
         final SpreadsheetGreaterThanEqualsParserToken gte = SpreadsheetParserToken.greaterThanEquals(Lists.of(left, greaterThanEquals(), right), text);
 
@@ -480,12 +480,12 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testGreaterThanEqualsAdd() {
-        final SpreadsheetParserToken middle = number(456);
-        final SpreadsheetParserToken right = number(789);
+        final SpreadsheetParserToken middle = bigInteger(456);
+        final SpreadsheetParserToken right = bigInteger(789);
         final String addText = "456+789";
         final SpreadsheetAdditionParserToken add = SpreadsheetParserToken.addition(Lists.of(middle, plus(), right), addText);
 
-        final SpreadsheetParserToken left = number(123);
+        final SpreadsheetParserToken left = bigInteger(123);
         final String text = "123>=" + addText;
         final SpreadsheetGreaterThanEqualsParserToken gte = SpreadsheetParserToken.greaterThanEquals(Lists.of(left, greaterThanEquals(), add), text);
 
@@ -494,8 +494,8 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testLessThan() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123<456";
         final SpreadsheetLessThanParserToken lt = SpreadsheetParserToken.lessThan(Lists.of(left, lessThan(), right), text);
 
@@ -504,12 +504,12 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testLessThanAdd() {
-        final SpreadsheetParserToken middle = number(456);
-        final SpreadsheetParserToken right = number(789);
+        final SpreadsheetParserToken middle = bigInteger(456);
+        final SpreadsheetParserToken right = bigInteger(789);
         final String addText = "456+789";
         final SpreadsheetAdditionParserToken add = SpreadsheetParserToken.addition(Lists.of(middle, plus(), right), addText);
 
-        final SpreadsheetParserToken left = number(123);
+        final SpreadsheetParserToken left = bigInteger(123);
         final String text = "123<" + addText;
         final SpreadsheetLessThanParserToken lt = SpreadsheetParserToken.lessThan(Lists.of(left, lessThan(), add), text);
 
@@ -518,8 +518,8 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testLessThanEquals() {
-        final SpreadsheetParserToken left = number(123);
-        final SpreadsheetParserToken right = number(456);
+        final SpreadsheetParserToken left = bigInteger(123);
+        final SpreadsheetParserToken right = bigInteger(456);
         final String text = "123<=456";
         final SpreadsheetLessThanEqualsParserToken lte = SpreadsheetParserToken.lessThanEquals(Lists.of(left, lessThanEquals(), right), text);
 
@@ -528,12 +528,12 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testLessThanEqualsAdd() {
-        final SpreadsheetParserToken middle = number(456);
-        final SpreadsheetParserToken right = number(789);
+        final SpreadsheetParserToken middle = bigInteger(456);
+        final SpreadsheetParserToken right = bigInteger(789);
         final String addText = "456+789";
         final SpreadsheetAdditionParserToken add = SpreadsheetParserToken.addition(Lists.of(middle, plus(), right), addText);
 
-        final SpreadsheetParserToken left = number(123);
+        final SpreadsheetParserToken left = bigInteger(123);
         final String text = "123<=" + addText;
         final SpreadsheetLessThanEqualsParserToken lte = SpreadsheetParserToken.lessThanEquals(Lists.of(left, lessThanEquals(), add), text);
 
@@ -544,16 +544,16 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
     public void testComplexExpression() {
         //111+222+(-333)-444*555
         final String addText = "111+222";
-        final SpreadsheetAdditionParserToken add = SpreadsheetParserToken.addition(Lists.of(number(111), plus(),  number(222)), addText);
+        final SpreadsheetAdditionParserToken add = SpreadsheetParserToken.addition(Lists.of(bigInteger(111), plus(),  bigInteger(222)), addText);
 
         final String groupText = "(-333)";
-        final SpreadsheetGroupParserToken group = SpreadsheetParserToken.group(Lists.of(openParenthesis(), negative(number(333)), closeParenthesis()), groupText);
+        final SpreadsheetGroupParserToken group = SpreadsheetParserToken.group(Lists.of(openParenthesis(), negative(bigInteger(333)), closeParenthesis()), groupText);
 
         final String addText2 = add + "+" + groupText;
         final SpreadsheetAdditionParserToken add2 = SpreadsheetParserToken.addition(Lists.of(add, plus(), group), addText2);
 
         final String multiplyText = "444*555";
-        final SpreadsheetMultiplicationParserToken multiply = SpreadsheetParserToken.multiplication(Lists.of(number(444), multiply(),  number(555)), multiplyText);
+        final SpreadsheetMultiplicationParserToken multiply = SpreadsheetParserToken.multiplication(Lists.of(bigInteger(444), multiply(),  bigInteger(555)), multiplyText);
 
         final String subText = addText2 + "-" + multiplyText;
         final SpreadsheetSubtractionParserToken sub = SpreadsheetParserToken.subtraction(Lists.of(add2, minus(), multiply), subText);
@@ -580,7 +580,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
     @Test
     public void testFunctionWithOneArgument() {
         final String text = "xyz(123)";
-        final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), number(123), closeParenthesis()), text);
+        final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), bigInteger(123), closeParenthesis()), text);
 
         this.parseAndCheck(text, f, text);
     }
@@ -588,7 +588,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
     @Test
     public void testFunctionWithOneArgument2() {
         final String text = "xyz(  123)";
-        final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), whitespace(), number(123), closeParenthesis()), text);
+        final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), whitespace(), bigInteger(123), closeParenthesis()), text);
 
         this.parseAndCheck(text, f, text);
     }
@@ -596,7 +596,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
     @Test
     public void testFunctionWithOneArgument3() {
         final String text = "xyz(123  )";
-        final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), number(123), whitespace(), closeParenthesis()), text);
+        final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), bigInteger(123), whitespace(), closeParenthesis()), text);
 
         this.parseAndCheck(text, f, text);
     }
@@ -604,7 +604,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
     @Test
     public void testFunctionWithOneArgument4() {
         final String text = "xyz(  123  )";
-        final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), whitespace(), number(123), whitespace(), closeParenthesis()), text);
+        final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), whitespace(), bigInteger(123), whitespace(), closeParenthesis()), text);
 
         this.parseAndCheck(text, f, text);
     }
@@ -612,7 +612,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
     @Test
     public void testFunctionWithTwoArguments() {
         final String text = "xyz(123,456)";
-        final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), number(123), comma(), number(456), closeParenthesis()), text);
+        final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), bigInteger(123), comma(), bigInteger(456), closeParenthesis()), text);
 
         this.parseAndCheck(text, f, text);
     }
@@ -620,7 +620,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
     @Test
     public void testFunctionWithFourArguments() {
         final String text = "xyz(1,2,3,4)";
-        final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), number(1), comma(), number(2), comma(), number(3), comma(), number(4), closeParenthesis()), text);
+        final SpreadsheetFunctionParserToken f = SpreadsheetParserToken.function(Lists.of(functionName("xyz"), openParenthesis(), bigInteger(1), comma(), bigInteger(2), comma(), bigInteger(3), comma(), bigInteger(4), closeParenthesis()), text);
 
         this.parseAndCheck(text, f, text);
     }
@@ -628,7 +628,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
     @Test
     public void testFunctionWithinFunction() {
         final String yText = "y(123)";
-        final SpreadsheetFunctionParserToken y = SpreadsheetParserToken.function(Lists.of(functionName("y"), openParenthesis(), number(123), closeParenthesis()), yText);
+        final SpreadsheetFunctionParserToken y = SpreadsheetParserToken.function(Lists.of(functionName("y"), openParenthesis(), bigInteger(123), closeParenthesis()), yText);
 
         final String xText = "x(" + yText + ")";
         final SpreadsheetFunctionParserToken x = SpreadsheetParserToken.function(Lists.of(functionName("x"), openParenthesis(), y, closeParenthesis()), xText);
@@ -639,7 +639,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
     @Test
     public void testFunctionWithinFunctionWithinFunction() {
         final String zText = "z(123)";
-        final SpreadsheetFunctionParserToken z = SpreadsheetParserToken.function(Lists.of(functionName("z"), openParenthesis(), number(123), closeParenthesis()), zText);
+        final SpreadsheetFunctionParserToken z = SpreadsheetParserToken.function(Lists.of(functionName("z"), openParenthesis(), bigInteger(123), closeParenthesis()), zText);
 
         final String yText = "y(" + zText + ")";
         final SpreadsheetFunctionParserToken y = SpreadsheetParserToken.function(Lists.of(functionName("y"), openParenthesis(), z, closeParenthesis()), yText);
@@ -666,8 +666,8 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Override
     protected Parser<SpreadsheetParserToken, SpreadsheetParserContext> createParser() {
-        final Parser<SpreadsheetParserToken, SpreadsheetParserContext> number = Parsers.<SpreadsheetParserContext>number(10)
-                .transform((numberParserToken, parserContext) -> SpreadsheetParserToken.number(numberParserToken.value(), numberParserToken.text()))
+        final Parser<SpreadsheetParserToken, SpreadsheetParserContext> number = Parsers.<SpreadsheetParserContext>bigInteger(10)
+                .transform((numberParserToken, parserContext) -> SpreadsheetParserToken.bigInteger(numberParserToken.value(), numberParserToken.text()))
                 .cast(SpreadsheetParserToken.class);
 
         return SpreadsheetParsers.expression(number);
@@ -676,6 +676,10 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
     @Override
     protected SpreadsheetParserContext createContext() {
         return new SpreadsheetParserContext();
+    }
+
+    private SpreadsheetParserToken bigInteger(final int value){
+        return SpreadsheetParserToken.bigInteger(BigInteger.valueOf(value), String.valueOf(value));
     }
 
     private SpreadsheetCellParserToken cell(final int column, final String columnText, final int row) {
@@ -694,10 +698,6 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     private SpreadsheetParserToken negative(final SpreadsheetParserToken number){
         return SpreadsheetParserToken.negative(Lists.of(minus(), number), "-" + number.text());
-    }
-
-    private SpreadsheetParserToken number(final int value){
-        return SpreadsheetParserToken.number(BigInteger.valueOf(value), String.valueOf(value));
     }
 
     private SpreadsheetParserToken whitespace() {

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPercentageParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPercentageParserTokenTest.java
@@ -71,7 +71,7 @@ public final class SpreadsheetPercentageParserTokenTest extends SpreadsheetUnary
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 b.append("5");
                 visited.add(t);
             }
@@ -106,7 +106,7 @@ public final class SpreadsheetPercentageParserTokenTest extends SpreadsheetUnary
 
     @Test
     public final void testToExpressionNode() {
-        this.toExpressionNodeAndCheck(ExpressionNode.multiplication(ExpressionNode.number(new BigInteger(NUMBER1)),
+        this.toExpressionNodeAndCheck(ExpressionNode.multiplication(ExpressionNode.bigInteger(new BigInteger(NUMBER1)),
                 ExpressionNode.longNode(100L)));
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPowerParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetPowerParserTokenTest.java
@@ -71,7 +71,7 @@ public final class SpreadsheetPowerParserTokenTest extends SpreadsheetBinaryPars
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 b.append("5");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSubtractionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSubtractionParserTokenTest.java
@@ -71,7 +71,7 @@ public final class SpreadsheetSubtractionParserTokenTest extends SpreadsheetBina
             }
 
             @Override
-            protected void visit(final SpreadsheetNumberParserToken t) {
+            protected void visit(final SpreadsheetBigIntegerParserToken t) {
                 b.append("5");
                 visited.add(t);
             }

--- a/src/test/java/walkingkooka/tree/expression/ExpressionBigIntegerNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionBigIntegerNodeTest.java
@@ -26,12 +26,12 @@ import java.math.BigInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
-public final class ExpressionNumberNodeTest extends ExpressionLeafValueNodeTestCase<ExpressionNumberNode, BigInteger>{
+public final class ExpressionBigIntegerNodeTest extends ExpressionLeafValueNodeTestCase<ExpressionBigIntegerNode, BigInteger>{
 
     @Test
     public void testAccept() {
         final StringBuilder b = new StringBuilder();
-        final ExpressionNumberNode node = this.createExpressionNode();
+        final ExpressionBigIntegerNode node = this.createExpressionNode();
 
         new FakeExpressionNodeVisitor() {
             @Override
@@ -48,7 +48,7 @@ public final class ExpressionNumberNodeTest extends ExpressionLeafValueNodeTestC
             }
 
             @Override
-            protected void visit(final ExpressionNumberNode n) {
+            protected void visit(final ExpressionBigIntegerNode n) {
                 assertSame(node, n);
                 b.append("3");
             }
@@ -67,8 +67,8 @@ public final class ExpressionNumberNodeTest extends ExpressionLeafValueNodeTestC
     }
 
     @Override
-    ExpressionNumberNode createExpressionNode(final BigInteger value) {
-        return ExpressionNumberNode.with(value);
+    ExpressionBigIntegerNode createExpressionNode(final BigInteger value) {
+        return ExpressionBigIntegerNode.with(value);
     }
 
     @Override
@@ -82,7 +82,7 @@ public final class ExpressionNumberNodeTest extends ExpressionLeafValueNodeTestC
     }
 
     @Override
-    Class<ExpressionNumberNode> expressionNodeType() {
-        return ExpressionNumberNode.class;
+    Class<ExpressionBigIntegerNode> expressionNodeType() {
+        return ExpressionBigIntegerNode.class;
     }
 }


### PR DESCRIPTION
- renamed NumberParserToken -> BigIntegerParserToken
- renamed NumberParser -> BigIntegerParser.
- Changed LongParser.toString() from "number" to "Long".
- renamed factories from number to bigInteger