### PR TITLE
Added NodeTextCursor which can walk over text belonging to individual…

### DIFF
--- a/src/main/java/walkingkooka/text/HasText.java
+++ b/src/main/java/walkingkooka/text/HasText.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text;
+
+/**
+ * An object that has some text.
+ */
+public interface HasText {
+
+    /**
+     * Text getter
+     */
+    String text();
+}

--- a/src/main/java/walkingkooka/text/cursor/NodeTextCursor.java
+++ b/src/main/java/walkingkooka/text/cursor/NodeTextCursor.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor;
+
+import walkingkooka.naming.Name;
+import walkingkooka.text.HasText;
+import walkingkooka.tree.Node;
+
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * A {@link TextCursor} that consumes the text belonging to a {@link Node} and all its descendants.
+ * This will be useful to walk over a tree of nodes, where some or all or perhaps none contain text.
+ * Note that any parent node, that is a node with one or more children will have its text if any ignored. It is assumed
+ * that the text of a parent node, may be reconstructed from the text from child nodes.
+ */
+final class NodeTextCursor<N extends Node<N, NAME, ANAME, AVALUE> & HasText,
+        NAME extends Name,
+        ANAME extends Name,
+        AVALUE> implements TextCursor{
+
+    /**
+     * Factory that creates a {@link TextCursor} using the provided {@link Node}
+     */
+    static <N extends Node<N, NAME, ANAME, AVALUE> & HasText,
+            NAME extends Name,
+            ANAME extends Name,
+            AVALUE> NodeTextCursor<N, NAME, ANAME, AVALUE> with(final N node) {
+        Objects.requireNonNull(node, "node");
+
+        return new NodeTextCursor<>(node);
+    }
+
+    /**
+     * Private ctor use factory
+     */
+    private NodeTextCursor(final N node) {
+        this.nodes = node.treeIterator();
+        this.cursor = TextCursors.charSequence(this.text);
+    }
+
+    @Override
+    public boolean isEmpty() throws TextCursorException {
+        this.fillIfCursorEmpty();
+        return this.cursor.isEmpty();
+    }
+
+    @Override
+    public char at() throws TextCursorException {
+        this.fillIfCursorEmpty();
+        return this.cursor.at();
+    }
+
+    @Override
+    public TextCursor next() throws TextCursorException {
+        this.fillIfCursorEmpty();
+        this.cursor.next();
+        return this;
+    }
+
+    private void fillIfCursorEmpty() {
+        if(this.cursor.isEmpty()){
+            // grab next node, and fill StringBuilder $text.
+            for(;;){
+                if(!this.nodes.hasNext()){
+                    break;
+                }
+                final N node = this.nodes.next();
+
+                // only consume text from nodes without any children...
+                if(node.children().isEmpty()){
+                    this.text.append(node.text());
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public TextCursorSavePoint save() {
+        return cursor.save();
+    }
+
+    @Override
+    public TextCursorLineInfo lineInfo() {
+        return this.cursor.lineInfo();
+    }
+
+    /**
+     * Provides the next {@link Node} to add more text to {@link #text}
+     */
+    private final Iterator<N> nodes;
+
+    /**
+     * Filled with text whenever the wrapped cursor becomes empty.
+     */
+    private final StringBuilder text = new StringBuilder();
+
+    /**
+     * The wrapped {@link TextCursor} that provides individual characters, save points, line info etc.
+     */
+    private final TextCursor cursor;
+
+    @Override
+    public String toString() {
+        return this.cursor.toString();
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/TextCursors.java
+++ b/src/main/java/walkingkooka/text/cursor/TextCursors.java
@@ -17,6 +17,9 @@
 
 package walkingkooka.text.cursor;
 
+import walkingkooka.naming.Name;
+import walkingkooka.text.HasText;
+import walkingkooka.tree.Node;
 import walkingkooka.type.PublicStaticHelper;
 
 /**
@@ -36,6 +39,16 @@ final public class TextCursors implements PublicStaticHelper {
      */
     public static TextCursor fake() {
         return FakeTextCursor.create();
+    }
+
+    /**
+     * {@see NodeTextCursor}
+     */
+    public static <N extends Node<N, NAME, ANAME, AVALUE> & HasText,
+            NAME extends Name,
+            ANAME extends Name,
+            AVALUE> TextCursor textCursor(final N node) {
+        return NodeTextCursor.with(node);
     }
 
     /**

--- a/src/test/java/walkingkooka/text/cursor/NodeTextCursorTest.java
+++ b/src/test/java/walkingkooka/text/cursor/NodeTextCursorTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.naming.Name;
+import walkingkooka.naming.StringName;
+
+public final class NodeTextCursorTest extends TextCursorTestCase<NodeTextCursor<NodeTextCursorTestNode, StringName, Name, Object>> {
+
+    // in all tests below text with numbers should be skipped because nodes with children text is ignored.
+
+    @Test
+    public void testParentAndChild() {
+        final TextCursor cursor = NodeTextCursor.with(
+                new NodeTextCursorTestNode("parent", "123",
+                        new NodeTextCursorTestNode("child", "ABC")));
+        this.checkNotEmpty(cursor);
+
+        this.atAndCheck(cursor, 'A');
+        cursor.next();
+        this.atAndCheck(cursor, 'B');
+        cursor.next();
+        this.atAndCheck(cursor, 'C');
+        cursor.next();
+
+        this.checkEmpty(cursor);
+    }
+
+    @Test
+    public void testParentAndChild2() {
+        final TextCursor cursor = NodeTextCursor.with(
+                new NodeTextCursorTestNode("parent", "123",
+                        new NodeTextCursorTestNode("child", "A"),
+                        new NodeTextCursorTestNode("child", "B")));
+        this.checkNotEmpty(cursor);
+
+        this.atAndCheck(cursor, 'A');
+        cursor.next();
+        this.atAndCheck(cursor, 'B');
+        cursor.next();
+
+        this.checkEmpty(cursor);
+    }
+
+    @Test
+    public void testParentAndChildAndGrandchildren() {
+        final TextCursor cursor = NodeTextCursor.with(
+                new NodeTextCursorTestNode("parent", "123",
+                        new NodeTextCursorTestNode("child1", "A"),
+                        new NodeTextCursorTestNode("child2", "456",
+                                new NodeTextCursorTestNode("grandChild-1", "B"),
+                                new NodeTextCursorTestNode("grandChild-2", "C")),
+                        new NodeTextCursorTestNode("child3", "D")));
+        this.checkNotEmpty(cursor);
+
+        this.atAndCheck(cursor, 'A');
+        cursor.next();
+        this.atAndCheck(cursor, 'B');
+        cursor.next();
+        this.atAndCheck(cursor, 'C');
+        cursor.next();
+        this.atAndCheck(cursor, 'D');
+        cursor.next();
+
+        this.checkEmpty(cursor);
+    }
+
+    @Test
+    public void testGraphSaveAndRestores() {
+        final TextCursor cursor = NodeTextCursor.with(
+                new NodeTextCursorTestNode("parent", "123",
+                        new NodeTextCursorTestNode("child1", "A"),
+                        new NodeTextCursorTestNode("child2", "456",
+                                new NodeTextCursorTestNode("grandChild-1", "B"),
+                                new NodeTextCursorTestNode("grandChild-2", "C")),
+                        new NodeTextCursorTestNode("child3", "D")));
+        this.checkNotEmpty(cursor);
+        this.atAndCheck(cursor, 'A');
+        cursor.next();
+
+        final TextCursorSavePoint save = cursor.save();
+
+        this.atAndCheck(cursor, 'B');
+        cursor.next();
+        this.atAndCheck(cursor, 'C');
+        cursor.next();
+        this.atAndCheck(cursor, 'D');
+        cursor.next();
+
+        this.checkEmpty(cursor);
+
+        save.restore(); // BCD
+
+        this.atAndCheck(cursor, 'B');
+        cursor.next();
+
+        save.save();
+
+        this.atAndCheck(cursor, 'C');
+        cursor.next();
+        this.atAndCheck(cursor, 'D');
+        cursor.next();
+
+        this.checkEmpty(cursor);
+
+        save.restore(); // CD
+
+        this.atAndCheck(cursor, 'C');
+        cursor.next();
+        this.atAndCheck(cursor, 'D');
+        cursor.next();
+
+        this.checkEmpty(cursor);
+    }
+
+    @Override
+    protected NodeTextCursor<NodeTextCursorTestNode, StringName, Name, Object> createTextCursor(final String text) {
+        return NodeTextCursor.with(new NodeTextCursorTestNode("root-without-children", text));
+    }
+
+    @Override
+    protected Class<NodeTextCursor<NodeTextCursorTestNode, StringName, Name, Object>> type() {
+        return Cast.to(NodeTextCursor.class);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/NodeTextCursorTestNode.java
+++ b/src/test/java/walkingkooka/text/cursor/NodeTextCursorTestNode.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor;
+
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.naming.Name;
+import walkingkooka.naming.Names;
+import walkingkooka.naming.StringName;
+import walkingkooka.text.HasText;
+import walkingkooka.tree.FakeNode;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+final class NodeTextCursorTestNode extends FakeNode<NodeTextCursorTestNode, StringName, Name, Object> implements HasText {
+
+    NodeTextCursorTestNode(final String name, final String text, final NodeTextCursorTestNode...children) {
+        this.name = Names.string(name);
+        this.children = Lists.of(children);
+
+        int i = 0;
+        for(NodeTextCursorTestNode child : children) {
+            child.parent = Optional.of(this);
+            child.index = i;
+            i++;
+        }
+
+        this.children.stream().forEach( n -> n.parent = Optional.of(this));
+
+        this.text = text;
+    }
+
+    @Override
+    public StringName name() {
+        return this.name;
+    }
+
+    private final StringName name;
+
+    @Override
+    public Optional<NodeTextCursorTestNode> parent() {
+        return this.parent;
+    }
+
+    private Optional<NodeTextCursorTestNode> parent = Optional.empty();
+
+    @Override
+    public int index() {
+        return this.index;
+    }
+
+    private int index = -1;
+
+    @Override
+    public List<NodeTextCursorTestNode> children() {
+        return this.children;
+    }
+
+    private List<NodeTextCursorTestNode> children;
+
+    public String text() {
+        return this.text;
+    }
+
+    private final String text;
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.name(), this.children());
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other || other instanceof NodeTextCursorTestNode && this.equals0(Cast.to(other));
+    }
+
+    private boolean equals0(final NodeTextCursorTestNode other) {
+        return this.name.equals(other.name) && this.children.equals(other.children);
+    }
+
+    @Override
+    public String toString() {
+        return this.text;
+    }
+}


### PR DESCRIPTION
… Nodes in a Node tree.

- only text from leaf nodes is actually returned. It is assumed that parents which may text is a result of
concatenating the text of their ancestor nodes (including child nodes).
- This cursor requires that Nodes implement HasText which contains a text() property.
- TODO Update or tag Nodes that already have a text property.