### PR TITLE
ExpressionUnaryNode.commonNumberType fix.

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionUnaryNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionUnaryNode.java
@@ -170,6 +170,6 @@ abstract class ExpressionUnaryNode extends ExpressionParentFixedNode implements 
 
     @Override
     Class<Number> commonNumberType(final Class<? extends Number> type) {
-        throw new UnsupportedOperationException();
+        return this.value().commonNumberType(type);
     }
 }


### PR DESCRIPTION
- forgot to implement by delegating to wrapped value (ExpressionNode).