### PR TITLE
Removed pkg private "hint" method ExpressionNode.commonNumberType.

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionArithmeticBinaryNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionArithmeticBinaryNode.java
@@ -18,26 +18,19 @@
 
 package walkingkooka.tree.expression;
 
-import walkingkooka.Cast;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
 /**
  * Base class for all arithmetic {@link ExpressionBinaryNode} nodes such as addition, power etc.
  */
-abstract class ExpressionArithmeticBinaryNode extends ExpressionBinaryNode {
+abstract class ExpressionArithmeticBinaryNode extends ExpressionBinaryNode2 {
 
     ExpressionArithmeticBinaryNode(final int index, final ExpressionNode left, final ExpressionNode right){
         super(index, left, right);
     }
 
     // is .........................................................................................................
-
-    @Override
-    public final boolean isAnd() {
-        return false;
-    }
 
     @Override
     public final boolean isEquals() {
@@ -69,28 +62,11 @@ abstract class ExpressionArithmeticBinaryNode extends ExpressionBinaryNode {
         return false;
     }
 
-    @Override
-    public final boolean isOr() {
-        return false;
-    }
-
-    @Override
-    public final boolean isXor() {
-        return false;
-    }
-
     // evaluation .....................................................................................................
 
     @Override
     public final Number toValue(final ExpressionEvaluationContext context) {
         return this.toNumber(context);
-    }
-
-    /**
-     * Arithmetic operations accept all number types.
-     */
-    final Class<Number> commonNumberType(final Class<? extends Number> type) {
-        return Cast.to(type);
     }
 
     final ExpressionNode applyBigDecimal(final BigDecimal left, final BigDecimal right, final ExpressionEvaluationContext context) {

--- a/src/main/java/walkingkooka/tree/expression/ExpressionBigDecimalNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionBigDecimalNode.java
@@ -103,16 +103,6 @@ public final class ExpressionBigDecimalNode extends ExpressionLeafNode2<BigDecim
         visitor.visit(this);
     }
 
-    // evaluation .....................................................................................................
-
-    /**
-     * Convert the other value to {@link BigDecimal}
-     */
-    @Override
-    final Class<Number> commonNumberType(final Class<? extends Number> type){
-        return BIG_DECIMAL;
-    }
-
     // Object ....................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionBigIntegerNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionBigIntegerNode.java
@@ -102,15 +102,6 @@ public final class ExpressionBigIntegerNode extends ExpressionLeafNode2<BigInteg
         visitor.visit(this);
     }
 
-    // evaluation .....................................................................................................
-
-    @Override
-    final Class<Number> commonNumberType(final Class<? extends Number> type){
-        return BigInteger.class == type || Long.class == type ?
-               BIG_INTEGER :
-               BIG_DECIMAL; // BigDecimal & Double -> BigDecimal.class
-    }
-
     // Object ....................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionBinaryNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionBinaryNode.java
@@ -18,7 +18,6 @@
 
 package walkingkooka.tree.expression;
 
-import walkingkooka.ShouldNeverHappenError;
 import walkingkooka.collect.list.Lists;
 
 import java.math.BigDecimal;
@@ -173,58 +172,11 @@ abstract class ExpressionBinaryNode extends ExpressionParentFixedNode {
                 .toText(context);
     }
 
-    final ExpressionNode apply(final ExpressionNode left,
-                               final ExpressionNode right,
-                               final ExpressionEvaluationContext context) {
-        final Number rightNumber = right.toNumber(context);
-        final Class<?> best = this.commonNumberType(left.commonNumberType(rightNumber.getClass()));
-
-        ExpressionNode result;
-
-        try {
-            for (; ; ) {
-                if (best == BigDecimal.class) {
-                    result = this.applyBigDecimal(
-                            left.toBigDecimal(context),
-                            context.convert(rightNumber, BigDecimal.class),
-                            context);
-                    break;
-                }
-                if (best == BigInteger.class) {
-                    result = this.applyBigInteger(
-                            left.toBigInteger(context),
-                            context.convert(rightNumber, BigInteger.class),
-                            context);
-                    break;
-                }
-                if (best == Double.class) {
-                    result = this.applyDouble(
-                            left.toDouble(context),
-                            context.convert(rightNumber, Double.class),
-                            context);
-                    break;
-                }
-                if (best == Long.class) {
-                    result = this.applyLong(
-                            left.toLong(context),
-                            context.convert(rightNumber, Long.class),
-                            context);
-                    break;
-                }
-                throw new ShouldNeverHappenError("Unexpected type=" + best.getName());
-            }
-        } catch (final ArithmeticException cause) {
-            throw new ExpressionEvaluationException(cause.getMessage() + "\n" + this.toString(), cause);
-        }
-
-        return result;
-    }
-
-    abstract ExpressionNode applyBigDecimal(final BigDecimal left, final BigDecimal right, final ExpressionEvaluationContext context);
+    abstract ExpressionNode apply(final ExpressionNode left,
+                         final ExpressionNode right,
+                         final ExpressionEvaluationContext context);
 
     abstract ExpressionNode applyBigInteger(final BigInteger left, final BigInteger right, final ExpressionEvaluationContext context);
-
-    abstract ExpressionNode applyDouble(final double left, final double right, final ExpressionEvaluationContext context);
 
     abstract ExpressionNode applyLong(final long left, final long right, final ExpressionEvaluationContext context);
 

--- a/src/main/java/walkingkooka/tree/expression/ExpressionBinaryNode2.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionBinaryNode2.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.expression;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Base class for any expression that accepts two parameters and accepts all types of numbers including {@link Double} and {@link BigDecimal}.
+ */
+abstract class ExpressionBinaryNode2 extends ExpressionBinaryNode {
+
+    ExpressionBinaryNode2(final int index, final ExpressionNode left, final ExpressionNode right){
+        super(index, left, right);
+    }
+
+    @Override
+    public final boolean isAnd() {
+        return false;
+    }
+    @Override
+    public final boolean isOr() {
+        return false;
+    }
+
+    @Override
+    public final boolean isXor() {
+        return false;
+    }
+
+    @Override
+    final ExpressionNode apply(final ExpressionNode left,
+                               final ExpressionNode right,
+                               final ExpressionEvaluationContext context) {
+        final Number leftNumber = left.toNumber(context);
+        final Number rightNumber = right.toNumber(context);
+
+        ExpressionNode result;
+
+        try {
+            for (; ; ) {
+                // both Long
+                final boolean leftLong = leftNumber instanceof Long;
+                final boolean rightLong = rightNumber instanceof Long;
+                if (leftLong && rightLong) {
+                    result = this.applyLong(
+                            context.convert(leftNumber, Long.class),
+                            context.convert(rightNumber, Long.class),
+                            context);
+                    break;
+                }
+                // BigInteger and Long or both BigInteger
+                final boolean leftBigInteger = leftNumber instanceof BigInteger;
+                final boolean rightBigInteger = rightNumber instanceof BigInteger;
+                if (leftBigInteger && rightBigInteger ||
+                    leftBigInteger && rightLong ||
+                    leftLong && rightBigInteger) {
+                    result = this.applyBigInteger(
+                            context.convert(leftNumber, BigInteger.class),
+                            context.convert(rightNumber, BigInteger.class),
+                            context);
+                    break;
+                }
+                // both must be double,
+                if (leftNumber instanceof Double && rightNumber instanceof Double) {
+                    result = this.applyDouble(
+                            context.convert(leftNumber, Double.class),
+                            context.convert(rightNumber, Double.class),
+                            context);
+                    break;
+                }
+                // default is to promote both to BigDecimal.
+                result = this.applyBigDecimal(
+                            context.convert(leftNumber, BigDecimal.class),
+                            context.convert(rightNumber, BigDecimal.class),
+                            context);
+                break;
+            }
+        } catch (final ArithmeticException cause) {
+            throw new ExpressionEvaluationException(cause.getMessage() + "\n" + this.toString(), cause);
+        }
+
+        return result;
+    }
+
+    abstract ExpressionNode applyBigDecimal(final BigDecimal left, final BigDecimal right, final ExpressionEvaluationContext context);
+
+    abstract ExpressionNode applyDouble(final double left, final double right, final ExpressionEvaluationContext context);
+}

--- a/src/main/java/walkingkooka/tree/expression/ExpressionBooleanNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionBooleanNode.java
@@ -18,8 +18,6 @@
 
 package walkingkooka.tree.expression;
 
-import walkingkooka.Cast;
-
 /**
  * A boolean value.
  */
@@ -98,13 +96,6 @@ public final class ExpressionBooleanNode extends ExpressionLeafNode2<Boolean> {
     @Override
     public void accept(final ExpressionNodeVisitor visitor){
         visitor.visit(this);
-    }
-
-    // evaluation .....................................................................................................
-
-    @Override
-    Class<Number> commonNumberType(final Class<? extends Number> type) {
-        return Cast.to(type);
     }
 
     // Object ....................................................................................................

--- a/src/main/java/walkingkooka/tree/expression/ExpressionComparisonBinaryNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionComparisonBinaryNode.java
@@ -18,15 +18,13 @@
 
 package walkingkooka.tree.expression;
 
-import walkingkooka.Cast;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
 /**
  * Base class for all comparison {@link ExpressionBinaryNode} nodes such as LT, GTE etc.
  */
-abstract class ExpressionComparisonBinaryNode extends ExpressionBinaryNode {
+abstract class ExpressionComparisonBinaryNode extends ExpressionBinaryNode2 {
 
     ExpressionComparisonBinaryNode(final int index, final ExpressionNode left, final ExpressionNode right){
         super(index, left, right);
@@ -36,11 +34,6 @@ abstract class ExpressionComparisonBinaryNode extends ExpressionBinaryNode {
 
     @Override
     public final boolean isAddition() {
-        return false;
-    }
-
-    @Override
-    public final boolean isAnd() {
         return false;
     }
 
@@ -60,11 +53,6 @@ abstract class ExpressionComparisonBinaryNode extends ExpressionBinaryNode {
     }
 
     @Override
-    public final boolean isOr() {
-        return false;
-    }
-
-    @Override
     public final boolean isPower() {
         return false;
     }
@@ -74,23 +62,11 @@ abstract class ExpressionComparisonBinaryNode extends ExpressionBinaryNode {
         return false;
     }
 
-    @Override
-    public final boolean isXor() {
-        return false;
-    }
-
     // evaluation .....................................................................................................
 
     @Override
     public final Boolean toValue(final ExpressionEvaluationContext context) {
         return this.toBoolean(context);
-    }
-
-    /**
-     * Comparison operations accept all number types.
-     */
-    final Class<Number> commonNumberType(final Class<? extends Number> type) {
-        return Cast.to(type);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionDoubleNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionDoubleNode.java
@@ -99,16 +99,6 @@ public final class ExpressionDoubleNode extends ExpressionLeafNode2<Double> {
         visitor.visit(this);
     }
 
-    // evaluation .....................................................................................................
-
-    /**
-     * If the type is {@link Double} return {@link Double} otherwise widen.
-     */
-    @Override
-    final Class<Number> commonNumberType(final Class<? extends Number> type){
-        return this.commonNumberTypeDouble(type);
-    }
-
     // Object ....................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionFunctionNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionFunctionNode.java
@@ -254,11 +254,6 @@ public final class ExpressionFunctionNode extends ExpressionVariableNode {
                         .collect(Collectors.toList()));
     }
 
-    @Override
-    Class<Number> commonNumberType(Class<? extends Number> type) {
-        return BIG_DECIMAL; // https://github.com/mP1/walkingkooka/issues/168
-    }
-
     // Object.........................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionLeafNode2.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionLeafNode2.java
@@ -83,24 +83,4 @@ abstract class ExpressionLeafNode2<V> extends ExpressionLeafNode<V> {
     public final String toText(final ExpressionEvaluationContext context) {
         return context.convert(this.value(), String.class);
     }
-
-    /**
-     * Shared common numbner type for values that prefer double as their number form.
-     */
-    final Class<Number> commonNumberTypeDouble(final Class<? extends Number> type){
-        return Double.class == type ?
-                DOUBLE :
-                BIG_DECIMAL;
-    }
-
-    /**
-     * Shared logic for value types that prefer long as their number form.
-     */
-    final Class<Number> commonNumberTypeLong(final Class<? extends Number> type){
-        return BigDecimal.class==type || Double.class == type ?
-                BIG_DECIMAL :
-                BigInteger.class == type ?
-                        BIG_INTEGER :
-                        LONG;
-    }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionLocalDateNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionLocalDateNode.java
@@ -103,16 +103,6 @@ public final class ExpressionLocalDateNode extends ExpressionLeafNode2<LocalDate
         visitor.visit(this);
     }
 
-    // evaluation .....................................................................................................
-
-    /**
-     * Convert the other value to {@link java.lang.Long}
-     */
-    @Override
-    final Class<Number> commonNumberType(final Class<? extends Number> type){
-        return this.commonNumberTypeLong(type);
-    }
-
     // Object ....................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionLocalDateTimeNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionLocalDateTimeNode.java
@@ -103,16 +103,6 @@ public final class ExpressionLocalDateTimeNode extends ExpressionLeafNode2<Local
         visitor.visit(this);
     }
 
-    // evaluation .....................................................................................................
-
-    /**
-     * Convert the other value to {@link java.lang.Long}
-     */
-    @Override
-    final Class<Number> commonNumberType(final Class<? extends Number> type){
-        return this.commonNumberTypeDouble(type);
-    }
-
     // Object ....................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionLocalTimeNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionLocalTimeNode.java
@@ -103,16 +103,6 @@ public final class ExpressionLocalTimeNode extends ExpressionLeafNode2<LocalTime
         visitor.visit(this);
     }
 
-    // evaluation .....................................................................................................
-
-    /**
-     * Convert the other value to {@link java.lang.Long}
-     */
-    @Override
-    final Class<Number> commonNumberType(final Class<? extends Number> type){
-        return this.commonNumberTypeLong(type);
-    }
-
     // Object ....................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionLongNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionLongNode.java
@@ -98,13 +98,6 @@ public final class ExpressionLongNode extends ExpressionLeafNode2<Long> {
         visitor.visit(this);
     }
 
-    // evaluation .....................................................................................................
-
-    @Override
-    final Class<Number> commonNumberType(final Class<? extends Number> type){
-        return this.commonNumberTypeLong(type);
-    }
-
     // Object ....................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNode.java
@@ -531,18 +531,6 @@ public abstract class ExpressionNode implements Node<ExpressionNode, ExpressionN
      */
     public abstract Object toValue(final ExpressionEvaluationContext context);
 
-    /**
-     * Only actually implemented by {@link ExpressionBinaryNode} allowing two types to find a common {@link Number}
-     * wide enough to represent both values.
-     * @param value
-     */
-    abstract Class<Number> commonNumberType(final Class<? extends Number> value);
-
-    final static Class<Number> BIG_DECIMAL = Cast.to(BigDecimal.class);
-    final static Class<Number> BIG_INTEGER = Cast.to(BigInteger.class);
-    final static Class<Number> DOUBLE = Cast.to(Double.class);
-    final static Class<Number> LONG = Cast.to(Long.class);
-
     // Object .......................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionReferenceNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionReferenceNode.java
@@ -18,8 +18,6 @@
 
 package walkingkooka.tree.expression;
 
-import walkingkooka.ShouldNeverHappenError;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
@@ -110,11 +108,6 @@ public final class ExpressionReferenceNode extends ExpressionLeafNode<Expression
     }
 
     // evaluation .....................................................................................................
-
-    @Override
-    final Class<Number> commonNumberType(final Class<? extends Number> type){
-        throw new ShouldNeverHappenError(this.getClass() + ".bestNumberType");
-    }
 
     @Override
     public final BigDecimal toBigDecimal(final ExpressionEvaluationContext context) {

--- a/src/main/java/walkingkooka/tree/expression/ExpressionTextNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionTextNode.java
@@ -18,7 +18,6 @@
 
 package walkingkooka.tree.expression;
 
-import walkingkooka.Cast;
 import walkingkooka.text.CharSequences;
 
 import java.util.Objects;
@@ -102,13 +101,6 @@ public final class ExpressionTextNode extends ExpressionLeafNode2<String> {
     @Override
     public void accept(final ExpressionNodeVisitor visitor){
         visitor.visit(this);
-    }
-
-    // evaluation .....................................................................................................
-
-    @Override
-    final Class<Number> commonNumberType(final Class<? extends Number> type){
-        return Cast.to(type);
     }
 
     // Object ....................................................................................................

--- a/src/main/java/walkingkooka/tree/expression/ExpressionUnaryNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionUnaryNode.java
@@ -185,9 +185,4 @@ abstract class ExpressionUnaryNode extends ExpressionParentFixedNode implements 
     public final Number toValue(final ExpressionEvaluationContext context) {
         return this.toNumber(context);
     }
-
-    @Override
-    Class<Number> commonNumberType(final Class<? extends Number> type) {
-        return this.value().commonNumberType(type);
-    }
 }

--- a/src/test/java/walkingkooka/tree/expression/ExpressionBinaryNode2Test.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionBinaryNode2Test.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.expression;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class ExpressionBinaryNode2Test extends PackagePrivateClassTestCase<ExpressionBinaryNode2> {
+
+    @Override
+    protected Class<ExpressionBinaryNode2> type() {
+        return ExpressionBinaryNode2.class;
+    }
+}


### PR DESCRIPTION
- Prior to eval binary and unary simply eval each child and then "pick" the common type.
- Solves #168