### PR TITLE
Wrap all thrown DateTimeExceptions in a ConversionException.

### DIFF
--- a/src/main/java/walkingkooka/convert/Converter.java
+++ b/src/main/java/walkingkooka/convert/Converter.java
@@ -45,6 +45,10 @@ public interface Converter {
         throw new ConversionException("Failed to convert " + value.getClass().getName() + "=" + CharSequences.quoteIfChars(value) + " to " + target.getName());
     }
 
+    default <TT> TT failConversion(final Object value, final Class<TT> target, final Throwable cause) {
+        throw new ConversionException("Failed to convert " + value.getClass().getName() + "=" + CharSequences.quoteIfChars(value) + " to " + target.getName() + ", message: "+ cause.getMessage(), cause);
+    }
+
     default Converter setToString(final String toString) {
         return Converters.customToString(this, toString);
     }

--- a/src/main/java/walkingkooka/convert/DateTimeFormatterConverter.java
+++ b/src/main/java/walkingkooka/convert/DateTimeFormatterConverter.java
@@ -18,6 +18,7 @@
 
 package walkingkooka.convert;
 
+import java.time.DateTimeException;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
@@ -32,4 +33,19 @@ abstract class DateTimeFormatterConverter<S, T> extends FixedTypeConverter2<S, T
     }
 
     final DateTimeFormatter formatter;
+
+    /**
+     * Wraps the attempt to convert in {@link #convert3(Object)},
+     * capturing any exceptions thrown by the formatter.
+     */
+    @Override
+    final T convert2(final S value) {
+        try {
+            return this.convert3(value);
+        } catch (final DateTimeException cause) {
+            return this.failConversion(value, cause);
+        }
+    }
+
+    abstract T convert3(final S value) throws DateTimeException;
 }

--- a/src/main/java/walkingkooka/convert/FixedTypeConverter.java
+++ b/src/main/java/walkingkooka/convert/FixedTypeConverter.java
@@ -44,5 +44,9 @@ abstract class FixedTypeConverter<T> extends ConverterTemplate {
         return this.failConversion(value, this.targetType());
     }
 
+    final T failConversion(final Object value, final Throwable cause) {
+        return this.failConversion(value, this.targetType(), cause);
+    }
+
     abstract Class<T> targetType();
 }

--- a/src/main/java/walkingkooka/convert/LocalDateStringDateTimeFormatterConverter.java
+++ b/src/main/java/walkingkooka/convert/LocalDateStringDateTimeFormatterConverter.java
@@ -18,6 +18,7 @@
 
 package walkingkooka.convert;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
@@ -40,7 +41,7 @@ final class LocalDateStringDateTimeFormatterConverter extends StringDateTimeForm
     }
 
     @Override
-    String convert2(final LocalDate value) {
+    String convert3(final LocalDate value) throws DateTimeException {
         return value.format(this.formatter);
     }
 }

--- a/src/main/java/walkingkooka/convert/LocalDateTimeStringDateTimeFormatterConverter.java
+++ b/src/main/java/walkingkooka/convert/LocalDateTimeStringDateTimeFormatterConverter.java
@@ -18,6 +18,7 @@
 
 package walkingkooka.convert;
 
+import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -40,7 +41,7 @@ final class LocalDateTimeStringDateTimeFormatterConverter extends StringDateTime
     }
 
     @Override
-    String convert2(final LocalDateTime value) {
+    String convert3(final LocalDateTime value) throws DateTimeException {
         return value.format(this.formatter);
     }
 }

--- a/src/main/java/walkingkooka/convert/LocalTimeStringDateTimeFormatterConverter.java
+++ b/src/main/java/walkingkooka/convert/LocalTimeStringDateTimeFormatterConverter.java
@@ -18,6 +18,7 @@
 
 package walkingkooka.convert;
 
+import java.time.DateTimeException;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
@@ -40,7 +41,7 @@ final class LocalTimeStringDateTimeFormatterConverter extends StringDateTimeForm
     }
 
     @Override
-    String convert2(final LocalTime value) {
+    String convert3(final LocalTime value) throws DateTimeException {
         return value.format(this.formatter);
     }
 }

--- a/src/main/java/walkingkooka/convert/StringLocalDateDateTimeFormatterConverter.java
+++ b/src/main/java/walkingkooka/convert/StringLocalDateDateTimeFormatterConverter.java
@@ -20,6 +20,7 @@ package walkingkooka.convert;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * A {@link Converter} that parses a {@link String} into a {@link LocalDate}.
@@ -47,7 +48,7 @@ final class StringLocalDateDateTimeFormatterConverter extends DateTimeFormatterC
     }
 
     @Override
-    LocalDate convert2(final String value) {
+    LocalDate convert3(final String value) throws DateTimeParseException {
         return LocalDate.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/convert/StringLocalDateTimeDateTimeFormatterConverter.java
+++ b/src/main/java/walkingkooka/convert/StringLocalDateTimeDateTimeFormatterConverter.java
@@ -21,6 +21,7 @@ package walkingkooka.convert;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * A {@link Converter} that parses a {@link String} into a {@link LocalDate}.
@@ -48,7 +49,7 @@ final class StringLocalDateTimeDateTimeFormatterConverter extends DateTimeFormat
     }
 
     @Override
-    LocalDateTime convert2(final String value) {
+    LocalDateTime convert3(final String value) throws DateTimeParseException {
         return LocalDateTime.parse(value);
     }
 }

--- a/src/main/java/walkingkooka/convert/StringLocalTimeDateTimeFormatterConverter.java
+++ b/src/main/java/walkingkooka/convert/StringLocalTimeDateTimeFormatterConverter.java
@@ -20,6 +20,7 @@ package walkingkooka.convert;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * A {@link Converter} that parses a {@link String} into a {@link LocalTime}.
@@ -47,7 +48,7 @@ final class StringLocalTimeDateTimeFormatterConverter extends DateTimeFormatterC
     }
 
     @Override
-    LocalTime convert2(final String value) {
+    LocalTime convert3(final String value) throws DateTimeParseException {
         return LocalTime.parse(value);
     }
 }


### PR DESCRIPTION
- added default method Converter.failConversion which includes Throwable.
- Completes #199 