### PR TITLE
Reporting Parser and ReportingParser with basic impl.

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/BasicParserReporter.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/BasicParserReporter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import walkingkooka.Cast;
+import walkingkooka.text.CharSequences;
+import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.TextCursorLineInfo;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A {@link ParserReporter} that builds an error message that looks something like:
+ * <pre>
+ * Unrecognized character 'X' at ... expected A | B | C
+ * </pre>
+ */
+final class BasicParserReporter<T extends ParserToken, C extends ParserContext> implements ParserReporter<T, C> {
+
+    /**
+     * Type safe getter.
+     */
+    static <T extends ParserToken, C extends ParserContext> BasicParserReporter<T, C> get() {
+        return Cast.to(INSTANCE);
+    }
+
+    /**
+     * Singleton
+     */
+    private final static BasicParserReporter<ParserToken, ParserContext> INSTANCE = new BasicParserReporter<>();
+
+    /**
+     * Private ctor use singleton getter.
+     */
+    private BasicParserReporter() {
+        super();
+    }
+
+    @Override
+    public Optional<T> report(final TextCursor cursor, final C context, final Parser<T, C> parser) throws ParserReporterException {
+        Objects.requireNonNull(cursor, "cursor");
+        Objects.requireNonNull(context, "context");
+        Objects.requireNonNull(parser, "parser");
+
+        final TextCursorLineInfo info = cursor.lineInfo();
+        throw new ParserReporterException("Unrecognized character " + CharSequences.quoteIfChars(cursor.at()) +
+                " at " + info.summary() +
+                " " + CharSequences.quoteAndEscape(info.text()) + " expected " + parser);
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/Parser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/Parser.java
@@ -98,6 +98,14 @@ public interface Parser<T extends ParserToken, C extends ParserContext> {
     }
 
     /**
+     * Returns a {@link ParserReporter} which will be triggered if this (original unwrapped) {@link Parser} fails.
+     */
+    default Parser<T, C> orReport(final ParserReporter<T, C> reporter) {
+        final Parser<ParserToken, C> that = this.cast();
+        return Parsers.alternatives(Lists.of(that, Parsers.report(Cast.to(reporter), that))).cast();
+    }
+
+    /**
      * Helper that makes casting and working around generics a little less noisy.
      */
     default <P extends Parser<?, ?>> P cast() {

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserReporter.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserReporter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import walkingkooka.text.cursor.TextCursor;
+
+import java.util.Optional;
+
+/**
+ * A reporter may be used to report a parse failure. Typically its the last in a chain, so if other {@link Parser parsers},
+ * fail the reporter will then be called.
+ */
+public interface ParserReporter<T extends ParserToken, C extends ParserContext> {
+
+    /**
+     * Handles a parse failure.
+     */
+    Optional<T> report(final TextCursor cursor, final C context, final Parser<T, C> parser) throws ParserReporterException;
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserReporterException.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserReporterException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser;
+
+/**
+ * This exception is used to report unrecoverable errors within text, such as an invalid escape character in a quoted string.
+ */
+public class ParserReporterException extends ParserException {
+
+    private final static long serialVersionUID = 1L;
+
+    protected ParserReporterException() {
+        super();
+    }
+
+    public ParserReporterException(final String message) {
+        super(message);
+    }
+
+    public ParserReporterException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserReporterTestCase.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserReporterTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import org.junit.Test;
+import walkingkooka.test.PackagePrivateClassTestCase;
+import walkingkooka.text.CharSequences;
+import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.TextCursorSavePoint;
+import walkingkooka.text.cursor.TextCursors;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public abstract class ParserReporterTestCase<R extends ParserReporter<T, C>, T extends ParserToken, C extends ParserContext> extends PackagePrivateClassTestCase<R> {
+
+    @Test(expected = NullPointerException.class)
+    public final void testNullTextCursorFails() {
+        this.report(null, this.createContext(), this.parser());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public final void testNullContextFails() {
+        this.report(TextCursors.fake(), null, this.parser());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public final void testNullParserFails() {
+        this.report(TextCursors.fake(), this.createContext(), null);
+    }
+
+    protected abstract R createParserReporter();
+
+    protected abstract C createContext();
+
+    private Parser<T, C> parser() {
+        return Parsers.fake();
+    }
+
+    protected void reportAndCheck(final String text,
+                                  final Parser<T, C> parser,
+                                  final String messageContains) {
+        this.reportAndCheck(text, this.createContext(), parser, messageContains);
+    }
+
+    protected void reportAndCheck(final String text,
+                                  final C context,
+                                  final Parser<T, C> parser,
+                                  final String messageContains) {
+        this.reportAndCheck(TextCursors.charSequence(text), context, parser, messageContains);
+    }
+
+    protected void reportAndCheck(final TextCursor cursor,
+                                  final C context,
+                                  final Parser<T, C> parser,
+                                  final String messageContains) {
+        this.reportAndCheck(this.createParserReporter(), cursor, context, parser, messageContains);
+    }
+
+    protected void reportAndCheck(final ParserReporter<T, C> reporter,
+                        final TextCursor cursor,
+                        final C context,
+                        final Parser<T, C> parser,
+                        final String messageContains) {
+        assertFalse("messageContains must not be null or empty", CharSequences.isNullOrEmpty(messageContains));
+
+        final TextCursorSavePoint save = cursor.save();
+        try {
+            this.report(reporter, cursor, context, parser);
+            fail("Reporter should have reported exception");
+        } catch (final ParserReporterException expected) {
+            save.restore();
+            final String message = expected.getMessage();
+            assertTrue("report message: " + message, message.contains(messageContains));
+        }
+    }
+
+    protected void report(final TextCursor cursor,
+                          final C context,
+                          final Parser<T, C> parser) {
+        this.report(this.createParserReporter(), cursor, context, parser);
+    }
+
+    protected void report(final ParserReporter<T, C> reporter,
+                                  final TextCursor cursor,
+                                  final C context,
+                                  final Parser<T, C> parser) {
+        reporter.report(cursor, context, parser);
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserReporters.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserReporters.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import walkingkooka.type.PublicStaticHelper;
+
+public final class ParserReporters implements PublicStaticHelper {
+
+    /**
+     * {@see BasicParserReporter}
+     */
+    public static <T extends ParserToken, C extends ParserContext> ParserReporter<T, C> basic() {
+        return BasicParserReporter.get();
+    }
+
+    /**
+     * Stop creation.
+     */
+    private ParserReporters() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/Parsers.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/Parsers.java
@@ -157,6 +157,14 @@ public final class Parsers implements PublicStaticHelper {
     }
 
     /**
+     * {@see ReportingParser}
+     */
+    public static <T extends ParserToken, C extends ParserContext> Parser<T, C> report(final ParserReporter<T, C> reporter,
+                                                                                       final Parser<T, C> parser) {
+        return ReportingParser.with(reporter, parser);
+    }
+
+    /**
      * {@see SequenceParserBuilder}
      */
     public static <C extends ParserContext> SequenceParserBuilder<C> sequenceParserBuilder() {

--- a/src/main/java/walkingkooka/text/cursor/parser/ReportingParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ReportingParser.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import walkingkooka.text.cursor.TextCursor;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A {@link Parser} that acts as a bridge invoking a {@link ParserReporter}. The reporter will
+ * typically throw an exception with a message noting a parse failure of the parser in this instance.
+ */
+final class ReportingParser<T extends ParserToken, C extends ParserContext> implements Parser<T, C> {
+
+    /**
+     * Static factory
+     */
+    static <T extends ParserToken, C extends ParserContext> ReportingParser<T, C> with(final ParserReporter<T, C> reporter,
+                                                             final Parser<T, C> parser) {
+        Objects.requireNonNull(reporter, "reporter");
+        Objects.requireNonNull(parser, "parser");
+
+        return new ReportingParser<>(reporter, parser);
+    }
+
+    /**
+     * Private ctor
+     */
+    private ReportingParser(final ParserReporter<T, C> reporter, final Parser<T, C> parser) {
+        this.reporter = reporter;
+        this.parser = parser;
+    }
+
+    @Override
+    public Optional<T> parse(final TextCursor cursor, final C context) {
+        return this.reporter.report(cursor, context, this.parser);
+    }
+
+    private final ParserReporter<T, C> reporter;
+
+    private final Parser<T, C> parser;
+
+    @Override
+    public String toString() {
+        return this.reporter.toString();
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/BasicParserReporterTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/BasicParserReporterTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+
+public final class BasicParserReporterTest extends ParserReporterTestCase<BasicParserReporter<StringParserToken, FakeParserContext>, StringParserToken, FakeParserContext>{
+
+    @Test
+    public void testReport() {
+        // has a dependency on the results of TextCursorLineInfo methods...
+        this.reportAndCheck("abc def ghi", Parsers.fake().setToString("ABC").cast(), "Unrecognized character 'a' at (1,1) \"abc def ghi\" expected ABC");
+    }
+
+    @Override
+    protected BasicParserReporter<StringParserToken, FakeParserContext> createParserReporter() {
+        return BasicParserReporter.get();
+    }
+
+    @Override
+    protected FakeParserContext createContext() {
+        return new FakeParserContext();
+    }
+
+    @Override
+    protected Class<BasicParserReporter<StringParserToken, FakeParserContext>> type() {
+        return Cast.to(BasicParserReporter.class);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserExceptionTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserExceptionTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import walkingkooka.test.PublicThrowableTestCase;
+
+public final class ParserExceptionTest extends PublicThrowableTestCase<ParserException> {
+    @Override
+    protected Class<ParserException> type() {
+        return ParserException.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserReporterExceptionTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserReporterExceptionTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import walkingkooka.test.PublicThrowableTestCase;
+
+public final class ParserReporterExceptionTest extends PublicThrowableTestCase<ParserReporterException> {
+    @Override
+    protected Class<ParserReporterException> type() {
+        return ParserReporterException.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserReportersTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserReportersTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser;
+
+import walkingkooka.test.PublicStaticHelperTestCase;
+
+import java.lang.reflect.Method;
+
+public final class ParserReportersTest extends PublicStaticHelperTestCase<ParserReporters> {
+
+    @Override
+    protected Class<ParserReporters> type() {
+        return ParserReporters.class;
+    }
+
+    @Override
+    protected boolean canHavePublicTypes(final Method method) {
+        return false;
+    }
+}


### PR DESCRIPTION
- No grammars updated to leverage new "paradigm" to report parse failures.
- added default Parser.orReport(ParserReporter).
- Added missing test for ParserException.