### PR TITLE
BasicParserReport empty TextCursor fix.

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/BasicParserReporter.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/BasicParserReporter.java
@@ -59,11 +59,27 @@ final class BasicParserReporter<T extends ParserToken, C extends ParserContext> 
         Objects.requireNonNull(context, "context");
         Objects.requireNonNull(parser, "parser");
 
+        final StringBuilder message = new StringBuilder();
+        if(cursor.isEmpty()){
+            message.append("End of text");
+        } else {
+            message.append("Unrecognized character ");
+            message.append(CharSequences.quoteAndEscape(cursor.at()));
+        }
+        message.append(" at ");
+
         final TextCursorLineInfo info = cursor.lineInfo();
-        throw new ParserReporterException("Unrecognized character " + CharSequences.quoteIfChars(cursor.at()) +
-                " at " + info.summary() +
-                " " + CharSequences.quoteAndEscape(info.text()) + " expected " + parser,
-                info);
+        message.append(info.summary());
+
+        final CharSequence text = info.text();
+        if(text.length() > 0) {
+            message.append(' ');
+            message.append(CharSequences.quoteAndEscape(info.text()));
+        }
+        message.append(" expected ");
+        message.append(parser);
+
+        throw new ParserReporterException(message.toString(), info);
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserReporterTestCase.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserReporterTestCase.java
@@ -68,6 +68,12 @@ public abstract class ParserReporterTestCase<R extends ParserReporter<T, C>, T e
     }
 
     protected void reportAndCheck(final TextCursor cursor,
+                                  final Parser<T, C> parser,
+                                  final String messageContains) {
+        this.reportAndCheck(cursor, this.createContext(), parser, messageContains);
+    }
+
+    protected void reportAndCheck(final TextCursor cursor,
                                   final C context,
                                   final Parser<T, C> parser,
                                   final String messageContains) {
@@ -88,7 +94,7 @@ public abstract class ParserReporterTestCase<R extends ParserReporter<T, C>, T e
         } catch (final ParserReporterException expected) {
             save.restore();
             final String message = expected.getMessage();
-            assertTrue("report message: " + message, message.contains(messageContains));
+            assertTrue("report message: " + CharSequences.quoteAndEscape(message) + " missing contains: " + CharSequences.quoteAndEscape(messageContains), message.contains(messageContains));
         }
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTestCase.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTestCase.java
@@ -151,9 +151,22 @@ public abstract class ParserTestCase<P extends Parser<T, C>, T extends ParserTok
         this.parseThrows(cursorText, "");
     }
 
+    protected final void parseThrows(final String cursorText, final char c, final String column, final int row) {
+        this.parseThrows(cursorText, c, column.length(), row);
+    }
+
     protected final void parseThrows(final String cursorText, final char c, final int column, final int row) {
         // Message format from BasicParserReporter
         this.parseThrows(cursorText, "Unrecognized character " + CharSequences.quoteAndEscape(c) + " at (" + column + "," + row + ")");
+    }
+
+    protected final void parseThrowsEndOfText(final String cursorText) {
+        this.parseThrowsEndOfText(cursorText, cursorText.length(), 1);
+    }
+
+    protected final void parseThrowsEndOfText(final String cursorText, final int column, final int row) {
+        // Message format from BasicParserReporter
+        this.parseThrows(cursorText, "End of text at (" + column + "," + row + ")");
     }
 
     protected final void parseThrows(final String cursorText, final String messagePart) {

--- a/src/test/java/walkingkooka/text/cursor/parser/BasicParserReporterTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/BasicParserReporterTest.java
@@ -20,6 +20,8 @@ package walkingkooka.text.cursor.parser;
 
 import org.junit.Test;
 import walkingkooka.Cast;
+import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.TextCursors;
 
 public final class BasicParserReporterTest extends ParserReporterTestCase<BasicParserReporter<StringParserToken, FakeParserContext>, StringParserToken, FakeParserContext>{
 
@@ -27,6 +29,23 @@ public final class BasicParserReporterTest extends ParserReporterTestCase<BasicP
     public void testReport() {
         // has a dependency on the results of TextCursorLineInfo methods...
         this.reportAndCheck("abc def ghi", Parsers.fake().setToString("ABC").cast(), "Unrecognized character 'a' at (1,1) \"abc def ghi\" expected ABC");
+    }
+
+    @Test
+    public void testReport2() {
+       // has a dependency on the results of TextCursorLineInfo methods...
+        final TextCursor cursor = TextCursors.charSequence("abc def ghi");
+        cursor.next();
+        cursor.next();
+
+        this.reportAndCheck(cursor, Parsers.fake().setToString("ABC").cast(), "Unrecognized character 'c' at (3,1) \"abc def ghi\" expected ABC");
+    }
+
+    @Test
+    public void testReportEmptyTextCursor() {
+        final TextCursor cursor = TextCursors.charSequence("abc");
+        cursor.end();
+        this.reportAndCheck(cursor, Parsers.fake().setToString("XYZ").cast(), "End of text at (4,1) \"abc\" expected XYZ");
     }
 
     @Override


### PR DESCRIPTION
- different message when TextCursor is empty, no longer attempts to say
"Unrecognized character 'CHAR'" simply reports "End of text".
- more overloads inParserReportTestCase.
- Fixed CharSequenceTextCursorLineInfo to handle when cursor is empty,
and return correct line/column.