### PR TITLE
AlternativesParser now tries all its parsers even when TextCursor is …

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/AlternativesParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/AlternativesParser.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 /**
  * A {@link Parser} that tries all parsers until one is matched and then ignores the remainder.
  */
-final class AlternativesParser<C extends ParserContext> extends ParserTemplate<ParserToken, C> implements HashCodeEqualsDefined {
+final class AlternativesParser<C extends ParserContext> implements Parser<ParserToken, C>, HashCodeEqualsDefined {
 
     static <C extends ParserContext> Parser<ParserToken, C> with(final List<Parser<ParserToken, C>> parsers){
         Objects.requireNonNull(parsers, "parsers");
@@ -54,8 +54,12 @@ final class AlternativesParser<C extends ParserContext> extends ParserTemplate<P
         this.parsers = parsers;
     }
 
+    /**
+     * Try all parsers even when the {@link TextCursor} is empty. This is necessary,
+     * because one parser might be a {@link ReportingParser} which wants to report a parsing failure.
+     */
     @Override
-    Optional<ParserToken> tryParse(final TextCursor cursor, final C context) {
+    public Optional<ParserToken> parse(final TextCursor cursor, final C context) {
         Optional<ParserToken> token = null;
 
         for(Parser<ParserToken, C> parser : this.parsers) {

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTestCase.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTestCase.java
@@ -166,7 +166,22 @@ public abstract class ParserTestCase<P extends Parser<T, C>, T extends ParserTok
 
     protected final void parseThrowsEndOfText(final String cursorText, final int column, final int row) {
         // Message format from BasicParserReporter
-        this.parseThrows(cursorText, "End of text at (" + column + "," + row + ")");
+        this.parseThrows(cursorText, endOfText(column, row));
+    }
+
+    protected final void parseThrowsEndOfText(final Parser<T,C> parser, final String cursorText, final int column, final int row) {
+        this.parseThrowsEndOfText(parser, this.createContext(), cursorText, column, row);
+    }
+
+    protected final void parseThrowsEndOfText(final Parser<T,C> parser, final C context, final String cursorText, final int column, final int row) {
+        final TextCursor cursor = TextCursors.charSequence(cursorText);
+        cursor.end();
+
+        this.parseThrows(parser, context, cursor, endOfText(column, row));
+    }
+
+    protected final String endOfText(final int column, final int row) {
+        return "End of text at (" + column + "," + row + ")";
     }
 
     protected final void parseThrows(final String cursorText, final String messagePart) {

--- a/src/test/java/walkingkooka/text/cursor/parser/AlternativesParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/AlternativesParserTest.java
@@ -88,6 +88,12 @@ public class AlternativesParserTest extends ParserTemplateTestCase<AlternativesP
         final Parser<StringParserToken, FakeParserContext> parser3 = Parsers.string("text3");
         assertEquals(this.createParser0(PARSER1, PARSER2, parser3), parser.or(parser3));
     }
+
+    @Test
+    public void testEmptyParserReporter() {
+        // AlternativesParser must not short circuit and skip trying all its parsers when its empty.
+        this.parseThrowsEndOfText(PARSER1.orReport(ParserReporters.basic()).cast(), "abc", 4,1);
+    }
     
     @Test
     public void testToString() {


### PR DESCRIPTION
…empty.

- Previously it included a short circuit to skip all parsers if the TextCursor was empty.
- The new behaviour is necessary so ReportingParsers and similar can actually be
triggered if the cursor is empty.
- More parseThrowsEndOfText overloads in ParserTestCase.