### PR TITLE
EbnfGrammarParser failure reporting.

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTestCase.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTestCase.java
@@ -161,7 +161,7 @@ public abstract class ParserTestCase<P extends Parser<T, C>, T extends ParserTok
     }
 
     protected final void parseThrowsEndOfText(final String cursorText) {
-        this.parseThrowsEndOfText(cursorText, cursorText.length(), 1);
+        this.parseThrowsEndOfText(cursorText, cursorText.length() + 1, 1);
     }
 
     protected final void parseThrowsEndOfText(final String cursorText, final int column, final int row) {

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserToken.java
@@ -33,14 +33,15 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * A grammar holds all the rules and is the root of the graph.
+ * A grammar holds all the rules and is the root of the graph. Note the {@link #value()} will contain a mixture of rules,
+ * comments and whitespace until {@link #withoutCommentsSymbolsOrWhitespace()} is invoked.
  */
 public final class EbnfGrammarParserToken extends EbnfParentParserToken {
 
     public final static ParserTokenNodeName NAME = ParserTokenNodeName.fromClass(EbnfGrammarParserToken.class);
 
     static EbnfGrammarParserToken with(final List<ParserToken> tokens, final String text) {
-        Objects.requireNonNull(tokens, "rules");
+        Objects.requireNonNull(tokens, "tokens");
         checkText(text);
 
         final List<ParserToken> copy = Lists.array();
@@ -50,13 +51,13 @@ public final class EbnfGrammarParserToken extends EbnfParentParserToken {
                 .filter(t -> t instanceof EbnfRuleParserToken)
                 .collect(Collectors.toList());
         if(onlyRules.isEmpty()){
-            throw new IllegalArgumentException("Missing rules=" + text);
+            throw new IllegalArgumentException("Missing at least 1 rule=" + text);
         }
 
         return new EbnfGrammarParserToken(copy, text, WITHOUT_COMPUTE_REQUIRED);
     }
 
-    EbnfGrammarParserToken(final List<ParserToken> tokens, final String text, final List<ParserToken> valueWithout) {
+    private EbnfGrammarParserToken(final List<ParserToken> tokens, final String text, final List<ParserToken> valueWithout) {
         super(tokens, text, valueWithout);
         this.checkAtLeastOneRule();
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorContext.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorContext.java
@@ -71,6 +71,8 @@ final public class EbnfParserCombinatorContext<C extends ParserContext> implemen
     private void preloadProxies() {
         this.grammar.value()
                 .stream()
+                .map(m -> EbnfParserToken.class.cast(m))
+                .filter(t -> t.isRule())
                 .forEach(t -> {
                     final EbnfRuleParserToken rule = t.cast();
                     this.identifierToParser.put(rule.identifier().value(), new EbnfParserCombinatorProxyParser(rule.identifier()));

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfExceptionParserTest.java
@@ -26,7 +26,7 @@ public final class EbnfExceptionParserTest extends EbnfParserTestCase2<EbnfExcep
 
     @Test
     public void testExceptionFails() {
-        this.parseFailAndCheck(EXCEPTION);
+        this.parseThrows(EXCEPTION, '-', 1, 1);
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTest.java
@@ -72,6 +72,36 @@ public final class EbnfGrammarParserTest extends EbnfParserTestCase<EbnfGrammarP
                 text);
     }
 
+    @Test
+    public void testInvalidRuleNameDefinitionFails() {
+        this.parseThrows("123", '1', 1, 1);
+    }
+
+    @Test
+    public void testInvalidRuleDefinitionFails() {
+        this.parseThrows("abc!", '!', 4, 1);
+    }
+
+    @Test
+    public void testInvalidRuleMissingRhsFails() {
+        this.parseThrowsEndOfText(IDENTIFIER1 + ASSIGNMENT);
+    }
+
+    @Test
+    public void testInvalidRuleMissingTerminatorFails() {
+        this.parseThrowsEndOfText(IDENTIFIER1 + ASSIGNMENT + TERMINAL1_TEXT);
+    }
+
+    @Test
+    public void testInvalidRuleRhsFails() {
+        this.parseThrows(IDENTIFIER1 + ASSIGNMENT + "123", '1', IDENTIFIER1 + ASSIGNMENT + '1', 1);
+    }
+
+    @Test
+    public void testInvalidExceptionTokenFails() {
+        this.parseThrows(IDENTIFIER1 + ASSIGNMENT +"'A'-123", '1', IDENTIFIER1 + ASSIGNMENT +"'A'-'", 1);
+    }
+
     private EbnfGrammarParserToken grammar(final String text, final EbnfRuleParserToken...rules) {
         return EbnfGrammarParserToken.with(Lists.of(rules), text);
     }

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfParserTestCase.java
@@ -16,7 +16,6 @@
  */
 package walkingkooka.text.cursor.parser.ebnf;
 
-import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserTestCase3;
@@ -61,16 +60,6 @@ public abstract class EbnfParserTestCase<T extends EbnfParserToken> extends Pars
 
     final static String OPEN_REPEAT = "{";
     final static String CLOSE_REPEAT = "}";
-
-    @Test
-    public void testOrphanedAssignmentFail() {
-        this.parseFailAndCheck("=");
-    }
-
-    @Test
-    public void testInvalidSymbolToken() {
-        this.parseFailAndCheck("$");
-    }
 
     @Override
     protected final EbnfParserContext createContext() {

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRangeParserTest.java
@@ -30,22 +30,22 @@ public final class EbnfRangeParserTest extends EbnfParserTestCase2<EbnfRangePars
 
     @Test
     public void testBeginBetweenFails() {
-        this.parseFailAndCheck(TERMINAL1_TEXT + BETWEEN);
+        this.parseThrowsEndOfText(TERMINAL1_TEXT + BETWEEN);
     }
 
     @Test
     public void testBetweenOnlyFails() {
-        this.parseFailAndCheck(BETWEEN);
+        this.parseThrows(BETWEEN, '.', 1, 1);
     }
 
     @Test
     public void testDoubleBetweenFails() {
-        this.parseFailAndCheck(TERMINAL1_TEXT + BETWEEN + BETWEEN);
+        this.parseThrows(TERMINAL1_TEXT + BETWEEN + BETWEEN, BETWEEN.charAt(0), 16, 1);
     }
 
     @Test
-    public void testDoubleBetweenFail2s() {
-        this.parseFailAndCheck(TERMINAL1_TEXT + BETWEEN + BETWEEN + TERMINAL2_TEXT);
+    public void testDoubleBetweenFails2() {
+        this.parseThrows(TERMINAL1_TEXT + BETWEEN + BETWEEN + TERMINAL2_TEXT, BETWEEN.charAt(0), 16, 1);
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfRuleParserTest.java
@@ -25,12 +25,12 @@ public final class EbnfRuleParserTest extends EbnfParserTestCase2<EbnfRuleParser
 
     @Test
     public void testIdentifierOnlyFails() {
-        this.parseFailAndCheck(IDENTIFIER1_TEXT);
+        this.parseThrowsEndOfText(IDENTIFIER1_TEXT);
     }
 
     @Test
     public void testIdentifierAndAssignmentOnlyFails() {
-        this.parseFailAndCheck(IDENTIFIER1_TEXT +ASSIGNMENT);
+        this.parseThrowsEndOfText(IDENTIFIER1_TEXT +ASSIGNMENT);
     }
 
     @Test
@@ -40,7 +40,7 @@ public final class EbnfRuleParserTest extends EbnfParserTestCase2<EbnfRuleParser
 
     @Test
     public void testDoubleTerminalFails() {
-        this.parseFailAndCheck(IDENTIFIER1_TEXT +ASSIGNMENT + TERMINAL1_TEXT + ASSIGNMENT + TERMINAL1_TEXT);
+        this.parseThrows(IDENTIFIER1_TEXT +ASSIGNMENT + TERMINAL1_TEXT + ASSIGNMENT + TERMINAL1_TEXT, ASSIGNMENT.charAt(0), 21, 1);
     }
 
     @Test
@@ -353,7 +353,7 @@ public final class EbnfRuleParserTest extends EbnfParserTestCase2<EbnfRuleParser
     @Test
     public void testExceptionFails() {
         final String text = IDENTIFIER1_TEXT +ASSIGNMENT + EXCEPTION + TERMINAL2_TEXT + TERMINATOR;
-        this.parseFailAndCheck(text);
+        this.parseThrows(text, EXCEPTION.charAt(0), 8, 1);
     }
 
     @Test


### PR DESCRIPTION
- reworked a few internal parsers, to accomodate parse failure reporting.
- Changed numerous Ebnf tests previous were parse failures(return nothing),
  but are now parse throws(error reporting)