### PR TITLE
Fixed SearchParentNode to use text of child nodes rather than toString

### DIFF
--- a/src/main/java/walkingkooka/tree/search/SearchLeafNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchLeafNode.java
@@ -47,6 +47,11 @@ abstract class SearchLeafNode<V> extends SearchNode implements Value<V> {
     private final String text;
 
     @Override
+    final void appendText(final StringBuilder b) {
+        b.append(this.text);
+    }
+
+    @Override
     public final V value() {
         return this.value;
     }

--- a/src/main/java/walkingkooka/tree/search/SearchNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchNode.java
@@ -231,6 +231,11 @@ public abstract class SearchNode implements Node<SearchNode, SearchNodeName, Nam
      */
     public abstract boolean isText();
 
+    /**
+     * Optimisation to help gather text for all {@link SearchNode} by parents.
+     */
+    abstract void appendText(final StringBuilder b);
+
     // helper............................................................................................................
 
     final <T extends SearchNode> T cast() {

--- a/src/main/java/walkingkooka/tree/search/SearchParentNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchParentNode.java
@@ -52,10 +52,15 @@ abstract class SearchParentNode extends SearchNode {
 
     public final String text() {
         final StringBuilder b = new StringBuilder();
-        for(SearchNode child : this.children()) {
-            child.toString0(b);
-        }
+        this.appendText(b);
         return b.toString();
+    }
+
+    @Override
+    void appendText(final StringBuilder b) {
+        for(SearchNode child : this.children()) {
+            child.appendText(b);
+        }
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/search/SearchLeafNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/search/SearchLeafNodeTestCase.java
@@ -133,6 +133,11 @@ public abstract class SearchLeafNodeTestCase<N extends SearchLeafNode, V> extend
         // Ignored
     }
 
+    @Test
+    public final void testText() {
+        assertEquals(this.text(), this.createSearchNode().text());
+    }
+
     @Override
     final N createSearchNode() {
         return this.createSearchNode(this.text(), this.value());

--- a/src/test/java/walkingkooka/tree/search/SearchSelectNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchSelectNodeTest.java
@@ -74,6 +74,11 @@ public final class SearchSelectNodeTest extends SearchParentNodeTestCase<SearchS
     }
 
     @Test
+    public void testText() {
+        assertEquals(this.child().text(), this.createSearchNode().text());
+    }
+
+    @Test
     public void testSelected() {
         final SearchNode node = this.createSearchNode();
         assertSame(node, node.selected());

--- a/src/test/java/walkingkooka/tree/search/SearchSequenceNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchSequenceNodeTest.java
@@ -50,6 +50,11 @@ public final class SearchSequenceNodeTest extends SearchParentNodeTestCase<Searc
     }
 
     @Test
+    public void testText() {
+        assertEquals("child-1child-2", this.createSearchNode().text());
+    }
+
+    @Test
     public void testAccept() {
         final StringBuilder b = new StringBuilder();
         final SearchSequenceNode node = this.createSearchNode();


### PR DESCRIPTION
- additional tests for every SearchNode sub type.