### PR TITLE
Fixed ExpressionReferenceNode.toValue to follow reference rather than…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionLeafNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionLeafNode.java
@@ -179,13 +179,6 @@ abstract class ExpressionLeafNode<V> extends ExpressionNode implements Value<V> 
         return false;
     }
 
-    // Evaluation ....................................................................................................
-
-    @Override
-    public final V toValue(final ExpressionEvaluationContext context) {
-        return this.value();
-    }
-
     // Object ......................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/ExpressionLeafNode2.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionLeafNode2.java
@@ -83,4 +83,9 @@ abstract class ExpressionLeafNode2<V> extends ExpressionLeafNode<V> {
     public final String toText(final ExpressionEvaluationContext context) {
         return context.convert(this.value(), String.class);
     }
+
+    @Override
+    public final V toValue(final ExpressionEvaluationContext context) {
+        return this.value();
+    }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionReferenceNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionReferenceNode.java
@@ -121,42 +121,51 @@ public final class ExpressionReferenceNode extends ExpressionLeafNode<Expression
 
     @Override
     public final boolean toBoolean(final ExpressionEvaluationContext context) {
-        return context.reference(this.value).toBoolean(context);
+        return this.toExpressionNode(context).toBoolean(context);
     }
 
     @Override
     public final double toDouble(final ExpressionEvaluationContext context) {
-        return context.reference(this.value).toDouble(context);
+        return this.toExpressionNode(context).toDouble(context);
     }
 
     @Override
     public final LocalDate toLocalDate(final ExpressionEvaluationContext context) {
-        return context.reference(this.value).toLocalDate(context);
+        return this.toExpressionNode(context).toLocalDate(context);
     }
 
     @Override
     public final LocalDateTime toLocalDateTime(final ExpressionEvaluationContext context) {
-        return context.reference(this.value).toLocalDateTime(context);
+        return this.toExpressionNode(context).toLocalDateTime(context);
     }
 
     @Override
     public final LocalTime toLocalTime(final ExpressionEvaluationContext context) {
-        return context.reference(this.value).toLocalTime(context);
+        return this.toExpressionNode(context).toLocalTime(context);
     }
-    
+
     @Override
     public final long toLong(final ExpressionEvaluationContext context) {
-        return context.reference(this.value).toLong(context);
+        return this.toExpressionNode(context).toLong(context);
     }
 
     @Override
     public final Number toNumber(final ExpressionEvaluationContext context) {
-        return context.reference(this.value).toNumber(context);
+        return this.toExpressionNode(context).toNumber(context);
     }
 
     @Override
     public final String toText(final ExpressionEvaluationContext context) {
-        return context.reference(this.value).toText(context);
+        return this.toExpressionNode(context).toText(context);
+    }
+
+    @Override
+    public final Object toValue(final ExpressionEvaluationContext context) {
+        return this.toExpressionNode(context).toValue(context);
+    }
+
+    private ExpressionNode toExpressionNode(final ExpressionEvaluationContext context) {
+        return context.reference(this.value);
     }
 
     // Object ....................................................................................................

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNodeTestCase.java
@@ -317,6 +317,19 @@ public abstract class ExpressionNodeTestCase<N extends ExpressionNode> extends N
         this.checkEquals("toText of " + node + " failed", expected, node.toText(context));
     }
 
+    final void evaluateAndCheckValue(final ExpressionNode node, final Object expected) {
+        this.evaluateAndCheckValue(node, this.context(), expected);
+    }
+
+    final void evaluateAndCheckValue(final ExpressionNode node, final ExpressionEvaluationContext context, final Object expected) {
+        final Object value = node.toValue(context);
+        if(expected instanceof Comparable && value instanceof Comparable) {
+            this.checkEquals("toValue of " + node + " failed", Cast.to(expected), Cast.to(value));
+        } else {
+            assertEquals("toValue of " + node + " failed", expected, value);
+        }
+    }
+
     private <T extends Comparable<T>> void checkEquals(final String message, final T expected, final T actual) {
         // necessary because BigDecimals of different precisions (extra zeros) will not be equal.
         if(0!=expected.compareTo(actual)){

--- a/src/test/java/walkingkooka/tree/expression/ExpressionReferenceNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionReferenceNodeTest.java
@@ -102,6 +102,11 @@ public final class ExpressionReferenceNodeTest extends ExpressionLeafNodeTestCas
         this.evaluateAndCheckText(this.createExpressionNode(), this.context("123"), "123");
     }
 
+    @Test
+    public void testToValue() {
+        this.evaluateAndCheckValue(this.createExpressionNode(), this.context("123"), "123");
+    }
+
     // ToString ...................................................................................................
 
     @Test


### PR DESCRIPTION
… return Reference.

- toValue behaviour matches all other toXXX methods.