### PR TITLE
Fixed SpreadsheetLabelName.isCellReference checking.

### DIFF
--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLabelNameParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLabelNameParserTest.java
@@ -28,8 +28,8 @@ public final class SpreadsheetLabelNameParserTest extends SpreadsheetParserTestC
     }
 
     @Test
-    public void testColumnFail() {
-        this.parseFailAndCheck("A");
+    public void testColumnOnly() {
+        this.parseAndCheck2("A");
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLabelNameTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLabelNameTest.java
@@ -73,17 +73,37 @@ final public class SpreadsheetLabelNameTest extends NameTestCase<SpreadsheetLabe
 
     @Test
     public void testWith3() {
-        this.createNameAndCheck("A" + (SpreadsheetRowReference.MAX + 1));
-    }
-
-    @Test
-    public void testWith4() {
         this.createNameAndCheck("A123Hello");
     }
 
     @Test
-    public void testWith5() {
+    public void testWith4() {
         this.createNameAndCheck("A1B2C2");
+    }
+
+    @Test
+    public void testWithMissingRow() {
+        this.createNameAndCheck("A");
+    }
+
+    @Test
+    public void testWithMissingRow2() {
+        this.createNameAndCheck("ABC");
+    }
+
+    @Test
+    public void testWithEnormousColumn() {
+        this.createNameAndCheck("ABCDEF1");
+    }
+
+    @Test
+    public void testWithEnormousColumn2() {
+        this.createNameAndCheck("ABCDEF");
+    }
+
+    @Test
+    public void testWithEnormousRow() {
+        this.createNameAndCheck("A" + (SpreadsheetRowReference.MAX + 1));
     }
 
     @Test


### PR DESCRIPTION
- Now accepts letters only "Strings" as valid.