### PR TITLE
Added ParentParserToken.setTextFromValues and static ParserToken.text…

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParentParserToken.java
@@ -18,6 +18,7 @@
 
 package walkingkooka.text.cursor.parser;
 
+import walkingkooka.Cast;
 import walkingkooka.Value;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.tree.search.HasSearchNode;
@@ -34,6 +35,13 @@ public interface ParentParserToken<P extends ParentParserToken> extends ParserTo
      * Would be setter that returns an instance with the given tokens or value, creating a new instance if necessary.
      */
     P setValue(List<ParserToken> tokens);
+
+    /**
+     * Concatenates the text from all child values and returns an instance with that text.
+     */
+    default P setTextFromValues() {
+        return Cast.to(this.setText(ParserToken.text(this.value())));
+    }
 
     /**
      * Creates a {@link SearchNode#sequence(List)} from all the converted child tokens.

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
@@ -21,10 +21,25 @@ import walkingkooka.Cast;
 import walkingkooka.text.HasText;
 import walkingkooka.tree.search.HasSearchNode;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 /**
  * Represents a result of a parser attempt to consume a {@link walkingkooka.text.cursor.TextCursor}
  */
 public interface ParserToken extends HasText, HasSearchNode {
+
+    /**
+     * Concatenates the text from all given tokens into a single string.
+     */
+    static String text(final List<? extends ParserToken> tokens) {
+        Objects.requireNonNull(tokens, "tokens");
+
+        return tokens.stream()
+                .map(t -> t.text())
+                .collect(Collectors.joining());
+    }
 
     /**
      * Returns the raw text that produced the token.

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorParserTextCleaningEbnfParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorParserTextCleaningEbnfParserTokenVisitor.java
@@ -42,7 +42,6 @@ import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 /**
  * This visitor returns a new grammar, with comments removed, and text normalized, with a goal of reading compact
@@ -196,10 +195,7 @@ final class EbnfParserCombinatorParserTextCleaningEbnfParserTokenVisitor extends
         final List<ParserToken> children = this.children;
         this.children = this.previousChildren.peek();
         this.previousChildren = this.previousChildren.pop();
-        final String text = children.stream()
-                .map(t -> t.text())
-                .collect(Collectors.joining());
-        this.add(factory.apply(children, text));
+        this.add(factory.apply(children, ParserToken.text(children)));
     }
 
     private void add(final EbnfParserToken token) {

--- a/src/test/java/walkingkooka/text/cursor/parser/RepeatedParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/RepeatedParserTokenTest.java
@@ -20,9 +20,7 @@ import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.tree.visit.Visiting;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -195,9 +193,7 @@ public final class RepeatedParserTokenTest extends ParserTokenTestCase<RepeatedP
     }
 
     private RepeatedParserToken repeated(final ParserToken...tokens) {
-        return repeated(
-                Arrays.stream(tokens).map(t -> t.text()).collect(Collectors.joining()),
-                tokens);
+        return repeated(ParserToken.text(Lists.of(tokens)), tokens);
     }
 
     private RepeatedParserToken repeated(final String text, final ParserToken...tokens) {

--- a/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/SequenceParserTokenTest.java
@@ -20,10 +20,8 @@ import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.tree.visit.Visiting;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -316,10 +314,7 @@ public final class SequenceParserTokenTest extends ParserTokenTestCase<SequenceP
     }
 
     private static SequenceParserToken sequence(final ParserToken...tokens) {
-        final String text = Arrays.stream(tokens)
-                .map(t -> t.text())
-                .collect(Collectors.joining());
-        return SequenceParserToken.with(Lists.of(tokens), text);
+        return sequence(ParserToken.text(Lists.of(tokens)), tokens);
     }
 
     private static SequenceParserToken sequence(final String text, final ParserToken...tokens) {

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeParserTokenTestCase.java
@@ -25,8 +25,6 @@ import walkingkooka.text.cursor.parser.ParserTokenTestCase;
 import walkingkooka.type.MethodAttributes;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -150,9 +148,7 @@ public abstract class JsonNodeParserTokenTestCase<T extends JsonNodeParserToken>
     }
 
     private static String text(final JsonNodeParserToken...tokens){
-        return Arrays.stream(tokens)
-                .map(t -> t.text())
-                .collect(Collectors.joining());
+        return ParserToken.text(Lists.of(tokens));
     }
 
     final JsonNodeParserToken separator() {


### PR DESCRIPTION
…(List<ParserToken))

- Reworked most (all???) sites concatenating parser tokens into a string with no separator.