### PR TITLE
EbnfParserCombinatorSyntaxTreeTransformer.identifier is now called fo…

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorParserCompilingEbnfParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinatorParserCompilingEbnfParserTokenVisitor.java
@@ -124,11 +124,18 @@ final class EbnfParserCombinatorParserCompilingEbnfParserTokenVisitor extends Eb
         this.enter();
         this.accept(rule.token());
 
+        final EbnfIdentifierParserToken name = rule.identifier();
+
         // update the proxy holding all references to this rule...
-        final EbnfParserCombinatorProxyParser<?, ParserContext> proxy = Cast.to(this.identifierToParser.get(rule.identifier().value()));
-        proxy.parser = Cast.to(this.children.get(0));
+        final EbnfParserCombinatorProxyParser<?, ParserContext> proxy = Cast.to(this.identifierToParser.get(name.value()));
+        proxy.parser = this.transformer.identifier(name, this.children.get(0)).cast();
 
         return Visiting.SKIP; // skip because we dont want to visit LHS of rule.
+    }
+
+    @Override
+    protected void endVisit(EbnfRuleParserToken token) {
+        this.exit();
     }
 
     /**
@@ -281,10 +288,7 @@ final class EbnfParserCombinatorParserCompilingEbnfParserTokenVisitor extends Eb
 
     @Override
     protected void visit(final EbnfIdentifierParserToken identifier) {
-        this.add(
-                this.transformer.identifier(identifier,
-                        this.identifierToParser.get(identifier.value())),
-                identifier);
+        this.add(this.identifierToParser.get(identifier.value()), identifier);
     }
 
     // TERMINAL ........................................................................................................

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeParsersTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeParsersTest.java
@@ -312,7 +312,7 @@ public final class JsonNodeParsersTest extends ParserTestCase3<Parser<JsonNodePa
 
     @Test
     public void testInvalidObjectPropertyAssignmentSymbolReported() {
-        this.parseThrows("{\"key1\":true,\"key2\":false,\"key3\"!true}", '!', 33, 1);
+        this.parseThrows("{\"key1\":true,\"key2\":false,\"key3\"!true}", '"', 27, 1);
     }
 
     @Test


### PR DESCRIPTION
…r all rules rather than references.

- Unsure why error reporting in test in JsonNodeParsersTest failed, changed so it passes.