### PR TITLE
Introduced Parser.orFailIfCursorNotEmpty().

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/Parser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/Parser.java
@@ -98,11 +98,18 @@ public interface Parser<T extends ParserToken, C extends ParserContext> {
     }
 
     /**
-     * Returns a {@link ParserReporter} which will be triggered if this (original unwrapped) {@link Parser} fails.
+     * The {@link ParserReporter} will be triggered if this {@link Parser} failed and returned a {@link Optional#empty()}.
      */
     default Parser<T, C> orReport(final ParserReporter<T, C> reporter) {
         final Parser<ParserToken, C> that = this.cast();
-        return Parsers.alternatives(Lists.of(that, Parsers.report(Cast.to(reporter), that))).cast();
+        return Parsers.alternatives(Lists.of(that, Parsers.report(ParserReporterCondition.ALWAYS, Cast.to(reporter), that))).cast();
+    }
+
+    /**
+     * Returns a {@link Parser} which will use the {@link ParserReporter} if the {@link TextCursor} is not empty.
+     */
+    default Parser<T, C> orFailIfCursorNotEmpty(final ParserReporter<T, C> reporter) {
+        return Parsers.report(ParserReporterCondition.NOT_EMPTY, Cast.to(reporter), this);
     }
 
     /**

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserReporterCondition.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserReporterCondition.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import walkingkooka.text.cursor.TextCursor;
+
+import java.util.Optional;
+
+/**
+ * Several conditions that predicate the calling of a {@link ParserReporter}.
+ */
+public enum ParserReporterCondition {
+
+    /**
+     * Invoke the {@link ParserReporter} unconditionally.
+     */
+    ALWAYS{
+        <T extends ParserToken, C extends ParserContext> Optional<T> parse(final TextCursor cursor,
+                                                                           final ReportingParser<T, C> parser,
+                                                                           final C context) {
+            return parser.report(cursor, context);
+        }
+    },
+
+    /**
+     * The {@link ParserReporter} should only be triggered when the {@link TextCursor} is not empty.
+     */
+    NOT_EMPTY {
+        <T extends ParserToken, C extends ParserContext> Optional<T> parse(final TextCursor cursor,
+                                                                           final ReportingParser<T, C> parser,
+                                                                           final C context) {
+            return parser.reportIfNotEmpty(cursor, context);
+        }
+    };
+
+    abstract <T extends ParserToken, C extends ParserContext> Optional<T> parse(final TextCursor cursor,
+                                                                                final ReportingParser<T, C> parser,
+                                                                                final C context);
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/Parsers.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/Parsers.java
@@ -160,9 +160,10 @@ public final class Parsers implements PublicStaticHelper {
     /**
      * {@see ReportingParser}
      */
-    public static <T extends ParserToken, C extends ParserContext> Parser<T, C> report(final ParserReporter<T, C> reporter,
+    public static <T extends ParserToken, C extends ParserContext> Parser<T, C> report(final ParserReporterCondition condition,
+                                                                                       final ParserReporter<T, C> reporter,
                                                                                        final Parser<T, C> parser) {
-        return ReportingParser.with(reporter, parser);
+        return ReportingParser.with(condition, reporter, parser);
     }
 
     /**

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarLoader.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarLoader.java
@@ -21,8 +21,8 @@ package walkingkooka.text.cursor.parser.ebnf;
 import walkingkooka.Cast;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.TextCursor;
-import walkingkooka.text.cursor.TextCursorSavePoint;
 import walkingkooka.text.cursor.TextCursors;
+import walkingkooka.text.cursor.parser.ParserReporters;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -88,14 +88,11 @@ public final class EbnfGrammarLoader {
                         CharSequences.readerConsuming(
                                 new InputStreamReader(inputStream2, Charset.defaultCharset()),
                                 4096));
-                final Optional<EbnfGrammarParserToken> grammar = EbnfParserToken.grammarParser().parse(grammarFile, EbnfParserContexts.basic());
+                final Optional<EbnfGrammarParserToken> grammar = EbnfParserToken.grammarParser()
+                        .orFailIfCursorNotEmpty(ParserReporters.basic())
+                        .parse(grammarFile, EbnfParserContexts.basic());
                 if (grammar.isPresent()) {
                     result = grammar;
-                }
-                if (grammarFile.isEmpty()) {
-                    final TextCursorSavePoint save = grammarFile.save();
-                    grammarFile.end();
-                    throw new EbnfParserException("Unable to load file " + this + "\nGrammar...\n" + grammar + "\n\nRemaining...\n" + save.textBetween());
                 }
             }
         } catch (final Exception fail) {

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParser.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParser.java
@@ -428,6 +428,7 @@ final class EbnfGrammarParser implements Parser<EbnfGrammarParserToken, EbnfPars
                 .optional(WHITESPACE_OR_COMMENT)
                 .required(RULE.orReport(ParserReporters.basic()))
                 .optional(RULE.repeating().cast())
+                .optional(WHITESPACE_OR_COMMENT)
                 .build()
                 .transform(EbnfGrammarParser::grammarParserToken)
                 .cast();

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParsers.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParsers.java
@@ -299,7 +299,7 @@ public final class SpreadsheetParsers implements PublicStaticHelper {
                     .combinator(predefined,
                             new SpreadsheetEbnfParserCombinatorSyntaxTreeTransformer());
 
-            return result.get(parserName).orReport(ParserReporters.basic()).cast();
+            return result.get(parserName).cast();
         } catch (final SpreadsheetParserException rethrow) {
             throw rethrow;
         } catch (final Exception cause){

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserReporterConditionTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserReporterConditionTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import walkingkooka.test.PublicClassTestCase;
+
+public final class ParserReporterConditionTest extends PublicClassTestCase<ParserReporterCondition> {
+
+    @Override
+    protected Class<ParserReporterCondition> type() {
+        return ParserReporterCondition.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ReportingParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ReportingParserTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.predicate.character.CharPredicates;
+import walkingkooka.text.cursor.TextCursors;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public final class ReportingParserTest extends ParserTestCase2<ReportingParser<ParserToken, FakeParserContext>, ParserToken> {
+
+    private final static ParserReporterCondition CONDITION = ParserReporterCondition.ALWAYS;
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullConditionFails() {
+        ReportingParser.with(null, this.reporter(), this.parser2());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullReporterFails() {
+        ReportingParser.with(CONDITION, null, this.parser2());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullParserFails() {
+        ReportingParser.with(CONDITION, this.reporter(), null);
+    }
+
+    @Test
+    public void testReportFails() {
+        this.parseThrows("!", "Unrecognized");
+    }
+
+    @Test
+    public void testNotEmptyConditionCursorEmptyNotFails() {
+        this.parseThrows(this.createParser(ParserReporterCondition.NOT_EMPTY), "!", "Unrecognized");
+    }
+
+    @Test
+    public void testNotEmptyConditionCursorNotEmptyParserFail() {
+        this.parseThrows(this.createParser(ParserReporterCondition.NOT_EMPTY), "!", "Unrecognized");
+    }
+
+    @Test
+    public void testNotEmptyConditionCursorNotEmptyParserSuccessful() {
+        this.parseAndCheck(this.createParser(ParserReporterCondition.NOT_EMPTY),
+                "A",
+                ParserTokens.character('A',"A"),
+                "A");
+    }
+
+    @Test
+    public void testNotEmptyConditionCursorEmpty() {
+        assertEquals(Optional.empty(), this.createParser(ParserReporterCondition.NOT_EMPTY).parse(TextCursors.charSequence(""), this.createContext()));
+    }
+
+    @Test
+    @Override
+    public void testEmptyCursorFail() {
+        this.parseThrows("!", "Unrecognized");
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals(this.reporter().toString(), this.createParser().toString());
+    }
+
+    @Override
+    protected ReportingParser<ParserToken, FakeParserContext> createParser() {
+        return this.createParser(ParserReporterCondition.ALWAYS);
+    }
+
+    private ReportingParser<ParserToken, FakeParserContext> createParser(final ParserReporterCondition condition) {
+        return ReportingParser.with(condition, this.reporter(), this.parser2());
+    }
+
+    private ParserReporter<ParserToken, FakeParserContext> reporter() {
+        return ParserReporters.basic();
+    }
+
+    private Parser<ParserToken, FakeParserContext> parser2() {
+        return Parsers.character(CharPredicates.letter()).cast();
+    }
+
+    @Override
+    protected Class<ReportingParser<ParserToken, FakeParserContext>> type() {
+        return Cast.to(ReportingParser.class);
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserTest.java
@@ -51,14 +51,12 @@ public final class EbnfGrammarParserTest extends EbnfParserTestCase<EbnfGrammarP
 
     @Test
     public void testWhitespaceAfterRules() {
-        final String text = RULE1+RULE2;
-        final String textAfter = "   ";
-        this.parseAndCheck(text + textAfter,
+        final String text = RULE1+RULE2 +  "   ";
+        this.parseAndCheck(text,
                 grammar(text,
                         rule1(),
                         rule2()),
-                text,
-                textAfter);
+                text);
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParsersTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParsersTest.java
@@ -43,7 +43,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testCellReferencesParserOtherExpressionFails() {
-        this.parseThrows(SpreadsheetParsers.cellReferences(), "1+2", "Unrecognized character '1' at (1,1) \"1+2\"");
+        this.parseFailAndCheck(SpreadsheetParsers.cellReferences(), "1+2");
     }
 
     @Test
@@ -86,7 +86,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testRangeParserOtherExpressionFails() {
-        this.parseThrows(SpreadsheetParsers.range(), "1+2", "Unrecognized character '1' at (1,1) \"1+2\"");
+        this.parseFailAndCheck(SpreadsheetParsers.range(), "1+2");
     }
 
     @Test
@@ -602,7 +602,7 @@ public final class SpreadsheetParsersTest extends ParserTestCase3<Parser<Spreads
 
     @Test
     public void testFunctionParserOtherExpressionFails() {
-        this.parseThrows(this.functionParser(), "1+2", "Unrecognized character '1' at (1,1) \"1+2\"");
+        this.parseFailAndCheck(this.functionParser(), "1+2");
     }
 
     @Test


### PR DESCRIPTION
- Removed or fail from SpreadsheetParsers, and updated corresponding tests.