### PR TITLE
ExpressionNode introduced SYMBOL constants for all toString literals …

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionAdditionNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionAdditionNode.java
@@ -32,6 +32,8 @@ public final class ExpressionAdditionNode extends ExpressionArithmeticBinaryNode
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionAdditionNode.class);
 
+    public final static String SYMBOL = "+";
+
     static ExpressionAdditionNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionAdditionNode(NO_PARENT_INDEX, left, right);
@@ -131,6 +133,6 @@ public final class ExpressionAdditionNode extends ExpressionArithmeticBinaryNode
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('+');
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionAndNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionAndNode.java
@@ -27,6 +27,8 @@ public final class ExpressionAndNode extends ExpressionLogicalBinaryNode {
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionAndNode.class);
 
+    public final static String SYMBOL = "&";
+
     static ExpressionAndNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionAndNode(NO_PARENT_INDEX, left, right);
@@ -99,6 +101,6 @@ public final class ExpressionAndNode extends ExpressionLogicalBinaryNode {
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('&');
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionDivisionNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionDivisionNode.java
@@ -30,6 +30,8 @@ public final class ExpressionDivisionNode extends ExpressionArithmeticBinaryNode
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionDivisionNode.class);
 
+    public final static String SYMBOL = "/";
+
     static ExpressionDivisionNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionDivisionNode(NO_PARENT_INDEX, left, right);
@@ -126,6 +128,6 @@ public final class ExpressionDivisionNode extends ExpressionArithmeticBinaryNode
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append("/");
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEqualsNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEqualsNode.java
@@ -26,6 +26,8 @@ public final class ExpressionEqualsNode extends ExpressionComparisonBinaryNode {
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionEqualsNode.class);
 
+    public final static String SYMBOL = "=";
+
     static ExpressionEqualsNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionEqualsNode(NO_PARENT_INDEX, left, right);
@@ -108,6 +110,6 @@ public final class ExpressionEqualsNode extends ExpressionComparisonBinaryNode {
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('&');
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionGreaterThanEqualsNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionGreaterThanEqualsNode.java
@@ -26,6 +26,8 @@ public final class ExpressionGreaterThanEqualsNode extends ExpressionComparisonB
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionGreaterThanEqualsNode.class);
 
+    public final static String SYMBOL = ">=";
+
     static ExpressionGreaterThanEqualsNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionGreaterThanEqualsNode(NO_PARENT_INDEX, left, right);
@@ -108,6 +110,6 @@ public final class ExpressionGreaterThanEqualsNode extends ExpressionComparisonB
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('&');
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionGreaterThanNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionGreaterThanNode.java
@@ -26,6 +26,8 @@ public final class ExpressionGreaterThanNode extends ExpressionComparisonBinaryN
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionGreaterThanNode.class);
 
+    public final static String SYMBOL = ">";
+
     static ExpressionGreaterThanNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionGreaterThanNode(NO_PARENT_INDEX, left, right);
@@ -108,6 +110,6 @@ public final class ExpressionGreaterThanNode extends ExpressionComparisonBinaryN
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('&');
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionLessThanEqualsNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionLessThanEqualsNode.java
@@ -26,6 +26,8 @@ public final class ExpressionLessThanEqualsNode extends ExpressionComparisonBina
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionLessThanEqualsNode.class);
 
+    public final static String SYMBOL = "<=";
+
     static ExpressionLessThanEqualsNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionLessThanEqualsNode(NO_PARENT_INDEX, left, right);
@@ -108,6 +110,6 @@ public final class ExpressionLessThanEqualsNode extends ExpressionComparisonBina
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('&');
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionLessThanNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionLessThanNode.java
@@ -26,6 +26,8 @@ public final class ExpressionLessThanNode extends ExpressionComparisonBinaryNode
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionLessThanNode.class);
 
+    public final static String SYMBOL = "<";
+
     static ExpressionLessThanNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionLessThanNode(NO_PARENT_INDEX, left, right);
@@ -108,6 +110,6 @@ public final class ExpressionLessThanNode extends ExpressionComparisonBinaryNode
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('&');
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionModuloNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionModuloNode.java
@@ -31,6 +31,8 @@ public final class ExpressionModuloNode extends ExpressionArithmeticBinaryNode {
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionModuloNode.class);
 
+    public final static String SYMBOL = "%";
+
     static ExpressionModuloNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionModuloNode(NO_PARENT_INDEX, left, right);
@@ -127,6 +129,6 @@ public final class ExpressionModuloNode extends ExpressionArithmeticBinaryNode {
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('%');
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionMultiplicationNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionMultiplicationNode.java
@@ -31,6 +31,8 @@ public final class ExpressionMultiplicationNode extends ExpressionArithmeticBina
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionMultiplicationNode.class);
 
+    public final static String SYMBOL = "*";
+
     static ExpressionMultiplicationNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionMultiplicationNode(NO_PARENT_INDEX, left, right);
@@ -127,6 +129,6 @@ public final class ExpressionMultiplicationNode extends ExpressionArithmeticBina
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('*');
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNegativeNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNegativeNode.java
@@ -33,6 +33,8 @@ public final class ExpressionNegativeNode extends ExpressionUnaryNode {
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionNegativeNode.class);
 
+    public final static String SYMBOL = "-";
+
     static ExpressionNegativeNode with(final ExpressionNode value){
         Objects.requireNonNull(value, "value");
         return new ExpressionNegativeNode(NO_PARENT_INDEX, value);
@@ -150,7 +152,7 @@ public final class ExpressionNegativeNode extends ExpressionUnaryNode {
 
     @Override
     void toString0(final StringBuilder b) {
-        b.append('-');
+        b.append(SYMBOL);
         this.value().toString0(b);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNotEqualsNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNotEqualsNode.java
@@ -26,6 +26,8 @@ public final class ExpressionNotEqualsNode extends ExpressionComparisonBinaryNod
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionNotEqualsNode.class);
 
+    public final static String SYMBOL = "!=";
+
     static ExpressionNotEqualsNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionNotEqualsNode(NO_PARENT_INDEX, left, right);
@@ -108,6 +110,6 @@ public final class ExpressionNotEqualsNode extends ExpressionComparisonBinaryNod
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('&');
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNotNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNotNode.java
@@ -32,6 +32,8 @@ public final class ExpressionNotNode extends ExpressionUnaryNode {
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionNotNode.class);
 
+    public final static String SYMBOL = "!";
+
     static ExpressionNotNode with(final ExpressionNode value){
         Objects.requireNonNull(value, "value");
         return new ExpressionNotNode(NO_PARENT_INDEX, value);
@@ -131,7 +133,7 @@ public final class ExpressionNotNode extends ExpressionUnaryNode {
 
     @Override
     void toString0(final StringBuilder b) {
-        b.append('!');
+        b.append(SYMBOL);
         this.value().toString0(b);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionOrNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionOrNode.java
@@ -30,6 +30,8 @@ public final class ExpressionOrNode extends ExpressionLogicalBinaryNode {
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionOrNode.class);
 
+    public final static String SYMBOL = "|";
+
     static ExpressionOrNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionOrNode(NO_PARENT_INDEX, left, right);
@@ -101,6 +103,6 @@ public final class ExpressionOrNode extends ExpressionLogicalBinaryNode {
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('|');
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionPowerNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionPowerNode.java
@@ -31,6 +31,8 @@ public final class ExpressionPowerNode extends ExpressionArithmeticBinaryNode {
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionPowerNode.class);
 
+    public final static String SYMBOL = "^^";
+
     static ExpressionPowerNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionPowerNode(NO_PARENT_INDEX, left, right);
@@ -136,6 +138,6 @@ public final class ExpressionPowerNode extends ExpressionArithmeticBinaryNode {
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append("^^");
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionSubtractionNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionSubtractionNode.java
@@ -31,6 +31,8 @@ public final class ExpressionSubtractionNode extends ExpressionArithmeticBinaryN
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionSubtractionNode.class);
 
+    public final static String SYMBOL = "-";
+
     static ExpressionSubtractionNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionSubtractionNode(NO_PARENT_INDEX, left, right);
@@ -128,6 +130,6 @@ public final class ExpressionSubtractionNode extends ExpressionArithmeticBinaryN
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('-');
+        b.append(SYMBOL);
     }
 }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionXorNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionXorNode.java
@@ -30,6 +30,8 @@ public final class ExpressionXorNode extends ExpressionLogicalBinaryNode {
 
     public final static ExpressionNodeName NAME = ExpressionNodeName.fromClass(ExpressionXorNode.class);
 
+    public final static String SYMBOL = "^";
+
     static ExpressionXorNode with(final ExpressionNode left, final ExpressionNode right){
         check(left, right);
         return new ExpressionXorNode(NO_PARENT_INDEX, left, right);
@@ -102,6 +104,6 @@ public final class ExpressionXorNode extends ExpressionLogicalBinaryNode {
 
     @Override
     void appendSymbol(final StringBuilder b) {
-        b.append('^');
+        b.append(SYMBOL);
     }
 }

--- a/src/test/java/walkingkooka/tree/expression/ExpressionEqualsNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionEqualsNodeTest.java
@@ -289,7 +289,7 @@ public final class ExpressionEqualsNodeTest extends ExpressionComparisonBinaryNo
 
     @Override
     String expectedToString(){
-        return LEFT_TO_STRING + "&" + RIGHT_TO_STRING;
+        return LEFT_TO_STRING + "=" + RIGHT_TO_STRING;
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/ExpressionGreaterThanEqualsNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionGreaterThanEqualsNodeTest.java
@@ -385,7 +385,7 @@ public final class ExpressionGreaterThanEqualsNodeTest extends ExpressionCompari
 
     @Override
     String expectedToString(){
-        return LEFT_TO_STRING + "&" + RIGHT_TO_STRING;
+        return LEFT_TO_STRING + ">=" + RIGHT_TO_STRING;
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/ExpressionGreaterThanNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionGreaterThanNodeTest.java
@@ -385,7 +385,7 @@ public final class ExpressionGreaterThanNodeTest extends ExpressionComparisonBin
 
     @Override
     String expectedToString(){
-        return LEFT_TO_STRING + "&" + RIGHT_TO_STRING;
+        return LEFT_TO_STRING + ">" + RIGHT_TO_STRING;
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/ExpressionLessThanEqualsNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionLessThanEqualsNodeTest.java
@@ -385,7 +385,7 @@ public final class ExpressionLessThanEqualsNodeTest extends ExpressionComparison
 
     @Override
     String expectedToString(){
-        return LEFT_TO_STRING + "&" + RIGHT_TO_STRING;
+        return LEFT_TO_STRING + "<=" + RIGHT_TO_STRING;
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/ExpressionLessThanNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionLessThanNodeTest.java
@@ -385,7 +385,7 @@ public final class ExpressionLessThanNodeTest extends ExpressionComparisonBinary
 
     @Override
     String expectedToString(){
-        return LEFT_TO_STRING + "&" + RIGHT_TO_STRING;
+        return LEFT_TO_STRING + "<" + RIGHT_TO_STRING;
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNotEqualsNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNotEqualsNodeTest.java
@@ -289,7 +289,7 @@ public final class ExpressionNotEqualsNodeTest extends ExpressionComparisonBinar
 
     @Override
     String expectedToString(){
-        return LEFT_TO_STRING + "&" + RIGHT_TO_STRING;
+        return LEFT_TO_STRING + "!=" + RIGHT_TO_STRING;
     }
 
     @Override


### PR DESCRIPTION
…+ fix.

- Fixed many ExpressionBinaryNode.toStrings which were incorrectly using '&'.