### PR TITLE
ParserToken sub class withoutSymbols naming consistency changes.

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeArrayParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeArrayParserToken.java
@@ -49,7 +49,7 @@ public final class JsonNodeArrayParserToken extends JsonNodeParentParserToken<Js
 
     @Override
     JsonNodeArrayParserToken replaceText(final String text) {
-        return new JsonNodeArrayParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new JsonNodeArrayParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeObjectParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeObjectParserToken.java
@@ -46,7 +46,7 @@ public final class JsonNodeObjectParserToken extends JsonNodeParentParserToken<J
     }
 
     private void checkKeys(final String text) {
-        final List<ParserToken> without = this.valueIfWithoutSymbolsOrWhitespaceOrNull();
+        final List<ParserToken> without = this.valueIfWithoutSymbolsOrNull();
         if (null != without) {
             int i = 0;
             JsonNodeParserToken j = null;
@@ -73,7 +73,7 @@ public final class JsonNodeObjectParserToken extends JsonNodeParentParserToken<J
 
     @Override
     JsonNodeObjectParserToken replaceText(final String text) {
-        return new JsonNodeObjectParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new JsonNodeObjectParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override
@@ -108,7 +108,7 @@ public final class JsonNodeObjectParserToken extends JsonNodeParentParserToken<J
         final JsonObjectNode object = JsonNode.object();
         final List<JsonNode> objectChildren = Lists.array();
 
-        for (ParserToken element : JsonNodeObjectParserToken.class.cast(this.withoutSymbolsOrWhitespace().get()).value()) {
+        for (ParserToken element : JsonNodeObjectParserToken.class.cast(this.withoutSymbols().get()).value()) {
             if (element instanceof JsonNodeParserToken) {
                 final JsonNodeParserToken j = JsonNodeParserToken.class.cast(element);
                 if (j.isNoise()) {

--- a/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeParentParserToken.java
@@ -50,7 +50,7 @@ abstract class JsonNodeParentParserToken<T extends JsonNodeParentParserToken> ex
     }
 
     @Override
-    public final Optional<JsonNodeParserToken> withoutSymbolsOrWhitespace() {
+    public final Optional<JsonNodeParserToken> withoutSymbols() {
         return this.without;
     }
 
@@ -60,7 +60,7 @@ abstract class JsonNodeParentParserToken<T extends JsonNodeParentParserToken> ex
 
     private final Optional<JsonNodeParserToken> without;
 
-    final List<ParserToken> valueIfWithoutSymbolsOrWhitespaceOrNull() {
+    final List<ParserToken> valueIfWithoutSymbolsOrNull() {
         return this == this.without.get() ? this.value : null;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeParserToken.java
@@ -174,7 +174,7 @@ public abstract class JsonNodeParserToken implements ParserToken {
      * Returns a copy without any symbols or whitespace tokens. The original text form will still contain
      * those tokens as text, but the tokens themselves will be removed.
      */
-    abstract public Optional<JsonNodeParserToken> withoutSymbolsOrWhitespace();
+    abstract public Optional<JsonNodeParserToken> withoutSymbols();
 
     /**
      * Only {@link JsonNodeArrayParserToken} return true

--- a/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeSymbolParserToken.java
@@ -32,7 +32,7 @@ abstract class JsonNodeSymbolParserToken extends JsonNodeLeafParserToken<String>
     }
 
     @Override
-    public final Optional<JsonNodeParserToken> withoutSymbolsOrWhitespace() {
+    public final Optional<JsonNodeParserToken> withoutSymbols() {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeValueParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/json/JsonNodeValueParserToken.java
@@ -29,7 +29,7 @@ abstract class JsonNodeValueParserToken<V> extends JsonNodeLeafParserToken<V> {
     }
 
     @Override
-    public final Optional<JsonNodeParserToken> withoutSymbolsOrWhitespace() {
+    public final Optional<JsonNodeParserToken> withoutSymbols() {
         return Optional.of(this);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorAndParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorAndParserToken.java
@@ -47,7 +47,7 @@ public final class NodeSelectorAndParserToken extends NodeSelectorBinaryParserTo
 
     @Override
     NodeSelectorAndParserToken replaceText(final String text) {
-        return new NodeSelectorAndParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new NodeSelectorAndParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorBinaryParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorBinaryParserToken.java
@@ -32,7 +32,7 @@ abstract class NodeSelectorBinaryParserToken<T extends NodeSelectorBinaryParserT
     NodeSelectorBinaryParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
         super(value, text, valueWithout);
 
-        final List<NodeSelectorParserToken> without = NodeSelectorParentParserToken.class.cast(this.withoutSymbolsOrWhitespace().get()).value();
+        final List<NodeSelectorParserToken> without = NodeSelectorParentParserToken.class.cast(this.withoutSymbols().get()).value();
         final int count = without.size();
         if (2 != count) {
             throw new IllegalArgumentException("Expected 2 tokens but got " + count + "=" + without);

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorEqualsParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorEqualsParserToken.java
@@ -48,7 +48,7 @@ public final class NodeSelectorEqualsParserToken extends NodeSelectorConditionPa
 
     @Override
     NodeSelectorEqualsParserToken replaceText(final String text) {
-        return new NodeSelectorEqualsParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new NodeSelectorEqualsParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorExpressionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorExpressionParserToken.java
@@ -47,7 +47,7 @@ public final class NodeSelectorExpressionParserToken extends NodeSelectorParentP
 
     @Override
     NodeSelectorExpressionParserToken replaceText(final String text) {
-        return new NodeSelectorExpressionParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new NodeSelectorExpressionParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorFunctionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorFunctionParserToken.java
@@ -47,7 +47,7 @@ public final class NodeSelectorFunctionParserToken extends NodeSelectorParentPar
 
     @Override
     NodeSelectorFunctionParserToken replaceText(final String text) {
-        return new NodeSelectorFunctionParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new NodeSelectorFunctionParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGreaterThanEqualsParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGreaterThanEqualsParserToken.java
@@ -48,7 +48,7 @@ public final class NodeSelectorGreaterThanEqualsParserToken extends NodeSelector
 
     @Override
     NodeSelectorGreaterThanEqualsParserToken replaceText(final String text) {
-        return new NodeSelectorGreaterThanEqualsParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new NodeSelectorGreaterThanEqualsParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGreaterThanParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGreaterThanParserToken.java
@@ -48,7 +48,7 @@ public final class NodeSelectorGreaterThanParserToken extends NodeSelectorCondit
 
     @Override
     NodeSelectorGreaterThanParserToken replaceText(final String text) {
-        return new NodeSelectorGreaterThanParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new NodeSelectorGreaterThanParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLessThanEqualsParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLessThanEqualsParserToken.java
@@ -48,7 +48,7 @@ public final class NodeSelectorLessThanEqualsParserToken extends NodeSelectorCon
 
     @Override
     NodeSelectorLessThanEqualsParserToken replaceText(final String text) {
-        return new NodeSelectorLessThanEqualsParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new NodeSelectorLessThanEqualsParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLessThanParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLessThanParserToken.java
@@ -48,7 +48,7 @@ public final class NodeSelectorLessThanParserToken extends NodeSelectorCondition
 
     @Override
     NodeSelectorLessThanParserToken replaceText(final String text) {
-        return new NodeSelectorLessThanParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new NodeSelectorLessThanParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNonSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNonSymbolParserToken.java
@@ -29,7 +29,7 @@ abstract class NodeSelectorNonSymbolParserToken<T> extends NodeSelectorLeafParse
     }
 
     @Override
-    public final Optional<NodeSelectorParserToken> withoutSymbolsOrWhitespace() {
+    public final Optional<NodeSelectorParserToken> withoutSymbols() {
         return Optional.of(this);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNotEqualsParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNotEqualsParserToken.java
@@ -48,7 +48,7 @@ public final class NodeSelectorNotEqualsParserToken extends NodeSelectorConditio
 
     @Override
     NodeSelectorNotEqualsParserToken replaceText(final String text) {
-        return new NodeSelectorNotEqualsParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new NodeSelectorNotEqualsParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorOrParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorOrParserToken.java
@@ -47,7 +47,7 @@ public final class NodeSelectorOrParserToken extends NodeSelectorBinaryParserTok
 
     @Override
     NodeSelectorOrParserToken replaceText(final String text) {
-        return new NodeSelectorOrParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new NodeSelectorOrParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParentParserToken.java
@@ -55,7 +55,7 @@ abstract class NodeSelectorParentParserToken<T extends NodeSelectorParentParserT
     }
 
     @Override
-    public final Optional<NodeSelectorParserToken> withoutSymbolsOrWhitespace() {
+    public final Optional<NodeSelectorParserToken> withoutSymbols() {
         return this.without;
     }
 
@@ -65,7 +65,7 @@ abstract class NodeSelectorParentParserToken<T extends NodeSelectorParentParserT
 
     private final Optional<NodeSelectorParserToken> without;
 
-    final List<ParserToken> valueIfWithoutSymbolsOrWhitespaceOrNull() {
+    final List<ParserToken> valueIfWithoutSymbolsOrNull() {
         return this == this.without.get() ? this.value : null;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParserToken.java
@@ -398,7 +398,7 @@ public abstract class NodeSelectorParserToken implements ParserToken {
      * Returns a copy without any symbols or whitespace tokens. The original text form will still contain
      * those tokens as text, but the tokens themselves will be removed.
      */
-    abstract public Optional<NodeSelectorParserToken> withoutSymbolsOrWhitespace();
+    abstract public Optional<NodeSelectorParserToken> withoutSymbols();
 
     /**
      * Only {@link NodeSelectorAbsoluteParserToken} return true

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorPredicateParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorPredicateParserToken.java
@@ -47,7 +47,7 @@ public final class NodeSelectorPredicateParserToken extends NodeSelectorParentPa
 
     @Override
     NodeSelectorPredicateParserToken replaceText(final String text) {
-        return new NodeSelectorPredicateParserToken(this.value, text, this.valueIfWithoutSymbolsOrWhitespaceOrNull());
+        return new NodeSelectorPredicateParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorSymbolParserToken.java
@@ -34,7 +34,7 @@ abstract class NodeSelectorSymbolParserToken extends NodeSelectorLeafParserToken
     }
 
     @Override
-    public final Optional<NodeSelectorParserToken> withoutSymbolsOrWhitespace() {
+    public final Optional<NodeSelectorParserToken> withoutSymbols() {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserToken.java
@@ -31,7 +31,7 @@ abstract class SpreadsheetBinaryParserToken<T extends SpreadsheetBinaryParserTok
                                  final List<ParserToken> valueWithout) {
         super(value, text, valueWithout);
 
-        final List<SpreadsheetParserToken> without = SpreadsheetParentParserToken.class.cast(this.withoutSymbolsOrWhitespace().get()).value();
+        final List<SpreadsheetParserToken> without = SpreadsheetParentParserToken.class.cast(this.withoutSymbols().get()).value();
         final int count = without.size();
         if (2 != count) {
             throw new IllegalArgumentException("Expected 2 tokens but got " + count + "=" + without);

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParserToken.java
@@ -45,7 +45,7 @@ public final class SpreadsheetFunctionParserToken extends SpreadsheetParentParse
                                            final List<ParserToken> valueWithout) {
         super(value, text, valueWithout);
 
-        final List<ParserToken> without = SpreadsheetParentParserToken.class.cast(this.withoutSymbolsOrWhitespace().get()).value();
+        final List<ParserToken> without = SpreadsheetParentParserToken.class.cast(this.withoutSymbols().get()).value();
         final int count = without.size();
         if (count < 1) {
             throw new IllegalArgumentException("Expected at least 1 tokens but got " + count + "=" + without);

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNonSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetNonSymbolParserToken.java
@@ -32,7 +32,7 @@ abstract class SpreadsheetNonSymbolParserToken<T> extends SpreadsheetLeafParserT
     }
 
     @Override
-    public final Optional<SpreadsheetParserToken> withoutSymbolsOrWhitespace() {
+    public final Optional<SpreadsheetParserToken> withoutSymbols() {
         return Optional.of(this);
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserToken.java
@@ -55,7 +55,7 @@ abstract class SpreadsheetParentParserToken<T extends SpreadsheetParentParserTok
     }
 
     @Override
-    public final Optional<SpreadsheetParserToken> withoutSymbolsOrWhitespace() {
+    public final Optional<SpreadsheetParserToken> withoutSymbols() {
         return this.without;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserToken.java
@@ -410,7 +410,7 @@ public abstract class SpreadsheetParserToken implements ParserToken, HasExpressi
      * Returns a copy without any symbols or whitespace tokens. The original text form will still contain
      * those tokens as text, but the tokens themselves will be removed.
      */
-    abstract public Optional<SpreadsheetParserToken> withoutSymbolsOrWhitespace();
+    abstract public Optional<SpreadsheetParserToken> withoutSymbols();
 
     /**
      * Only {@link SpreadsheetAdditionParserToken} return true

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetSymbolParserToken.java
@@ -36,7 +36,7 @@ abstract class SpreadsheetSymbolParserToken extends SpreadsheetLeafParserToken<S
     }
 
     @Override
-    public final Optional<SpreadsheetParserToken> withoutSymbolsOrWhitespace() {
+    public final Optional<SpreadsheetParserToken> withoutSymbols() {
         return Optional.empty();
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetUnaryParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetUnaryParserToken.java
@@ -29,7 +29,7 @@ abstract class SpreadsheetUnaryParserToken<T extends SpreadsheetUnaryParserToken
     SpreadsheetUnaryParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
         super(value, text, valueWithout);
 
-        final List<SpreadsheetParserToken> without = SpreadsheetParentParserToken.class.cast(this.withoutSymbolsOrWhitespace().get()).value();
+        final List<SpreadsheetParserToken> without = SpreadsheetParentParserToken.class.cast(this.withoutSymbols().get()).value();
         final int count = without.size();
         if (1 != count) {
             throw new IllegalArgumentException("Expected 1 tokens but got " + count + "=" + without);

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeArrayParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeArrayParserTokenTest.java
@@ -33,7 +33,7 @@ public final class JsonNodeArrayParserTokenTest extends JsonNodeParentParserToke
     @Test
     public void testWithoutWhitespace() {
         final JsonNodeArrayParserToken array = array(arrayBegin(), whitespace(), string("abc"), arrayEnd()).cast();
-        final JsonNodeArrayParserToken without = array.withoutSymbolsOrWhitespace().get().cast();
+        final JsonNodeArrayParserToken without = array.withoutSymbols().get().cast();
         assertEquals("value", Lists.of(string("abc")), without.value());
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeLeafParserTokenTestCase2.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeLeafParserTokenTestCase2.java
@@ -27,9 +27,9 @@ import static org.junit.Assert.assertEquals;
 public abstract class JsonNodeLeafParserTokenTestCase2<T extends JsonNodeLeafParserToken, V, N extends JsonNode> extends JsonNodeLeafParserTokenTestCase<T, V> {
 
     @Test
-    public final void testWithoutSymbolsOrWhitespace() {
+    public final void testWithoutSymbols() {
         final T token = this.createToken();
-        assertEquals(Optional.of(token), token.withoutSymbolsOrWhitespace());
+        assertEquals(Optional.of(token), token.withoutSymbols());
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeObjectParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeObjectParserTokenTest.java
@@ -73,7 +73,7 @@ public final class JsonNodeObjectParserTokenTest extends JsonNodeParentParserTok
         final JsonNodeParserToken key = string("key");
         final JsonNodeParserToken value = string("value");
         final JsonNodeObjectParserToken object = object(objectBegin(), whitespace(), key, objectAssignment(), value, objectEnd()).cast();
-        final JsonNodeObjectParserToken without = object.withoutSymbolsOrWhitespace().get().cast();
+        final JsonNodeObjectParserToken without = object.withoutSymbols().get().cast();
         assertEquals("value", Lists.of(key, value), without.value());
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeParentParserTokenTestCase.java
@@ -55,26 +55,26 @@ public abstract class JsonNodeParentParserTokenTestCase<T extends JsonNodeParent
     }
 
     @Test
-    public final void testWithoutSymbolsOrWhitespaceCached() {
+    public final void testWithoutSymbolsCached() {
         final T token = this.createToken();
-        assertSame(token.withoutSymbolsOrWhitespace(), token.withoutSymbolsOrWhitespace());
-        assertSame(token.withoutSymbolsOrWhitespace().get().withoutSymbolsOrWhitespace(), token.withoutSymbolsOrWhitespace().get().withoutSymbolsOrWhitespace());
+        assertSame(token.withoutSymbols(), token.withoutSymbols());
+        assertSame(token.withoutSymbols().get().withoutSymbols(), token.withoutSymbols().get().withoutSymbols());
     }
 
     @Test
-    public final void testWithoutSymbolsOrWhitespaceDoubleSame() {
+    public final void testWithoutSymbolsDoubleSame() {
         final T token = this.createToken();
-        assertSame(token.withoutSymbolsOrWhitespace(), token.withoutSymbolsOrWhitespace());
+        assertSame(token.withoutSymbols(), token.withoutSymbols());
     }
 
     @Test
     public final void testSetTextDifferentWithout() {
         final T token = this.createToken();
-        final List<?> childrenWithout = Cast.<T>to(token.withoutSymbolsOrWhitespace().get()).value();
+        final List<?> childrenWithout = Cast.<T>to(token.withoutSymbols().get()).value();
 
         final String differentText = this.createDifferentToken().text();
         final T different = token.setText(differentText).cast();
-        final T differentWithout = Cast.<T>to(different.withoutSymbolsOrWhitespace().get());
+        final T differentWithout = Cast.<T>to(different.withoutSymbols().get());
         assertEquals("children without", childrenWithout, differentWithout.value());
 
         assertNotEquals("without should have less tokens than with", token.value().size(), differentWithout.value().size());
@@ -82,7 +82,7 @@ public abstract class JsonNodeParentParserTokenTestCase<T extends JsonNodeParent
 
     @Test
     public void testWithoutCommentsSymbolsOrWhitespacePropertiesNullCheck() throws Exception {
-        final Optional<JsonNodeParserToken> without = this.createToken().withoutSymbolsOrWhitespace();
+        final Optional<JsonNodeParserToken> without = this.createToken().withoutSymbols();
         if (without.isPresent()) {
             this.propertiesNeverReturnNullCheck(without.get());
         }

--- a/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeSymbolParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/json/JsonNodeSymbolParserTokenTestCase.java
@@ -26,9 +26,9 @@ import static org.junit.Assert.assertEquals;
 public abstract class JsonNodeSymbolParserTokenTestCase<T extends JsonNodeSymbolParserToken, V> extends JsonNodeLeafParserTokenTestCase<T, V> {
 
     @Test
-    public final void testWithoutSymbolsOrWhitespace() {
+    public final void testWithoutSymbols() {
         final T token = this.createToken();
-        assertEquals(Optional.empty(), token.withoutSymbolsOrWhitespace());
+        assertEquals(Optional.empty(), token.withoutSymbols());
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorBinaryParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorBinaryParserTokenTestCase.java
@@ -68,7 +68,7 @@ public abstract class NodeSelectorBinaryParserTokenTestCase<T extends NodeSelect
         this.checkText(token, text);
         this.checkValue(token, left, right);
 
-        assertSame(token, token.withoutSymbolsOrWhitespace().get());
+        assertSame(token, token.withoutSymbols().get());
     }
 
     @Test
@@ -84,7 +84,7 @@ public abstract class NodeSelectorBinaryParserTokenTestCase<T extends NodeSelect
         this.checkText(token, text);
         this.checkValue(token, left, operator, right);
 
-        final T without = Cast.to(token.withoutSymbolsOrWhitespace().get());
+        final T without = Cast.to(token.withoutSymbols().get());
         assertNotSame(token, without);
 
         this.checkText(without, text);

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorExpressionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorExpressionParserTokenTest.java
@@ -88,7 +88,7 @@ public final class NodeSelectorExpressionParserTokenTest extends NodeSelectorPar
     @Test
     public void testWithoutSymbolsExpressionWhitespace() {
         final NodeSelectorExpressionParserToken expression = this.createToken();
-        final NodeSelectorExpressionParserToken without = expression.withoutSymbolsOrWhitespace().get().cast();
+        final NodeSelectorExpressionParserToken without = expression.withoutSymbols().get().cast();
         assertEquals("value", Lists.of(wildcard()), without.value());
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorFunctionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorFunctionParserTokenTest.java
@@ -33,9 +33,9 @@ public final class NodeSelectorFunctionParserTokenTest extends NodeSelectorParen
     // [ends-with(@href, '/')]
 
     @Test
-    public void testWithoutSymbolsExpressionWhitespace() {
+    public void testWithoutSymbols() {
         final NodeSelectorFunctionParserToken expression = this.createToken();
-        final NodeSelectorFunctionParserToken without = expression.withoutSymbolsOrWhitespace().get().cast();
+        final NodeSelectorFunctionParserToken without = expression.withoutSymbols().get().cast();
         assertEquals("value", Lists.of(functionName(), quotedText()), without.value());
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorNonSymbolParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorNonSymbolParserTokenTestCase.java
@@ -26,8 +26,8 @@ import static org.junit.Assert.assertEquals;
 public abstract class NodeSelectorNonSymbolParserTokenTestCase<T extends NodeSelectorLeafParserToken, V> extends NodeSelectorLeafParserTokenTestCase<T, V> {
 
     @Test
-    public final void testWithoutSymbolsOrWhitespace() {
+    public final void testWithoutSymbols() {
         final T token = this.createToken();
-        assertEquals(Optional.of(token), token.withoutSymbolsOrWhitespace());
+        assertEquals(Optional.of(token), token.withoutSymbols());
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorParentParserTokenTestCase.java
@@ -55,26 +55,26 @@ public abstract class NodeSelectorParentParserTokenTestCase<T extends NodeSelect
     }
 
     @Test
-    public final void testWithoutSymbolsOrWhitespaceCached() {
+    public final void testWithoutSymbolsCached() {
         final T token = this.createToken();
-        assertSame(token.withoutSymbolsOrWhitespace(), token.withoutSymbolsOrWhitespace());
-        assertSame(token.withoutSymbolsOrWhitespace().get().withoutSymbolsOrWhitespace(), token.withoutSymbolsOrWhitespace().get().withoutSymbolsOrWhitespace());
+        assertSame(token.withoutSymbols(), token.withoutSymbols());
+        assertSame(token.withoutSymbols().get().withoutSymbols(), token.withoutSymbols().get().withoutSymbols());
     }
 
     @Test
-    public final void testWithoutSymbolsOrWhitespaceDoubleSame() {
+    public final void testWithoutSymbolsDoubleSame() {
         final T token = this.createToken();
-        assertSame(token.withoutSymbolsOrWhitespace(), token.withoutSymbolsOrWhitespace());
+        assertSame(token.withoutSymbols(), token.withoutSymbols());
     }
 
     @Test
     public final void testSetTextDifferentWithout() {
         final T token = this.createToken();
-        final List<?> childrenWithout = Cast.<T>to(token.withoutSymbolsOrWhitespace().get()).value();
+        final List<?> childrenWithout = Cast.<T>to(token.withoutSymbols().get()).value();
 
         final String differentText = this.createDifferentToken().text();
         final T different = token.setText(differentText).cast();
-        final T differentWithout = Cast.<T>to(different.withoutSymbolsOrWhitespace().get());
+        final T differentWithout = Cast.<T>to(different.withoutSymbols().get());
         assertEquals("children without", childrenWithout, differentWithout.value());
 
         assertTrue("without " + token.value().size() + " should have less than or equal tokens than with " + differentWithout.value().size(),
@@ -83,7 +83,7 @@ public abstract class NodeSelectorParentParserTokenTestCase<T extends NodeSelect
 
     @Test
     public void testWithoutCommentsSymbolsOrWhitespacePropertiesNullCheck() throws Exception {
-        final Optional<NodeSelectorParserToken> without = this.createToken().withoutSymbolsOrWhitespace();
+        final Optional<NodeSelectorParserToken> without = this.createToken().withoutSymbols();
         if (without.isPresent()) {
             this.propertiesNeverReturnNullCheck(without.get());
         }

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorPredicateParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorPredicateParserTokenTest.java
@@ -33,9 +33,9 @@ public final class NodeSelectorPredicateParserTokenTest extends NodeSelectorPare
     // [ends-with(@href, '/')]
 
     @Test
-    public void testWithoutSymbolsOrWhitespace() {
+    public void testWithoutSymbols() {
         final NodeSelectorPredicateParserToken predicate = this.createToken();
-        final NodeSelectorPredicateParserToken without = predicate.withoutSymbolsOrWhitespace().get().cast();
+        final NodeSelectorPredicateParserToken without = predicate.withoutSymbols().get().cast();
         assertEquals("value", predicate.value(), without.value());
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorSymbolParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorSymbolParserTokenTestCase.java
@@ -26,8 +26,8 @@ import static org.junit.Assert.assertEquals;
 public abstract class NodeSelectorSymbolParserTokenTestCase<T extends NodeSelectorSymbolParserToken, V> extends NodeSelectorLeafParserTokenTestCase<T, V> {
 
     @Test
-    public final void testWithoutSymbolsOrWhitespace() {
+    public final void testWithoutSymbols() {
         final T token = this.createToken();
-        assertEquals(Optional.empty(), token.withoutSymbolsOrWhitespace());
+        assertEquals(Optional.empty(), token.withoutSymbols());
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserTokenTestCase.java
@@ -68,7 +68,7 @@ public abstract class SpreadsheetBinaryParserTokenTestCase<T extends Spreadsheet
         this.checkText(token, text);
         this.checkValue(token, left, right);
 
-        assertSame(token, token.withoutSymbolsOrWhitespace().get());
+        assertSame(token, token.withoutSymbols().get());
     }
 
     @Test
@@ -84,7 +84,7 @@ public abstract class SpreadsheetBinaryParserTokenTestCase<T extends Spreadsheet
         this.checkText(token, text);
         this.checkValue(token, left, operator, right);
 
-        final T without = Cast.to(token.withoutSymbolsOrWhitespace().get());
+        final T without = Cast.to(token.withoutSymbols().get());
         assertNotSame(token, without);
 
         this.checkText(without, text);

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserTokenTestCase2.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetBinaryParserTokenTestCase2.java
@@ -39,7 +39,7 @@ public abstract class SpreadsheetBinaryParserTokenTestCase2<T extends Spreadshee
         final T different = token.setValue(differentValues);
         this.checkValue(different, differentValues);
 
-        assertEquals(Optional.of(different), different.withoutSymbolsOrWhitespace());
+        assertEquals(Optional.of(different), different.withoutSymbols());
     }
 
     @Test
@@ -49,7 +49,7 @@ public abstract class SpreadsheetBinaryParserTokenTestCase2<T extends Spreadshee
         final T different = token.setValue(differentValues);
         this.checkValue(different, differentValues);
 
-        final Optional<SpreadsheetParserToken> differentWithout = different.withoutSymbolsOrWhitespace();
+        final Optional<SpreadsheetParserToken> differentWithout = different.withoutSymbols();
         assertNotEquals(Optional.of(different), differentWithout);
         this.checkValue(differentWithout.get(), differentValues.subList(0, 2));
     }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellReferenceParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetCellReferenceParserTokenTest.java
@@ -61,7 +61,7 @@ public final class SpreadsheetCellReferenceParserTokenTest extends SpreadsheetPa
         this.checkValue(cell, row, column);
         this.checkCell(cell, row, column);
 
-        assertSame(cell, cell.withoutSymbolsOrWhitespace().get());
+        assertSame(cell, cell.withoutSymbols().get());
     }
 
     @Test
@@ -81,7 +81,7 @@ public final class SpreadsheetCellReferenceParserTokenTest extends SpreadsheetPa
         this.checkValue(differentCell, differentRow, differentColumn);
         this.checkCell(differentCell, differentRow, differentColumn);
 
-        assertSame(cell, cell.withoutSymbolsOrWhitespace().get());
+        assertSame(cell, cell.withoutSymbols().get());
     }
 
     @Test

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionParserTokenTest.java
@@ -47,7 +47,7 @@ public final class SpreadsheetFunctionParserTokenTest extends SpreadsheetParentP
         final SpreadsheetFunctionNameParserToken name = this.function();
         final SpreadsheetFunctionParserToken token = this.createToken(text, name, this.number1());
         this.checkText(token, text);
-        assertSame(token, token.withoutSymbolsOrWhitespace().get());
+        assertSame(token, token.withoutSymbols().get());
     }
 
     @Test
@@ -65,7 +65,7 @@ public final class SpreadsheetFunctionParserTokenTest extends SpreadsheetParentP
         this.checkFunction(token, this.functionName());
         this.checkParameters(token, number);
 
-        final SpreadsheetFunctionParserToken token2 = Cast.to(token.withoutSymbolsOrWhitespace().get());
+        final SpreadsheetFunctionParserToken token2 = Cast.to(token.withoutSymbols().get());
         assertNotSame(token, token2);
         this.checkText(token2, text);
         this.checkValue(token2, name, number);
@@ -90,7 +90,7 @@ public final class SpreadsheetFunctionParserTokenTest extends SpreadsheetParentP
         this.checkFunction(token, this.functionName());
         this.checkParameters(token, number);
 
-        final SpreadsheetFunctionParserToken token2 = Cast.to(token.withoutSymbolsOrWhitespace().get());
+        final SpreadsheetFunctionParserToken token2 = Cast.to(token.withoutSymbols().get());
         assertNotSame(token, token2);
         this.checkText(token2, text);
         this.checkValue(token2, name, number);

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGroupParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetGroupParserTokenTest.java
@@ -47,7 +47,7 @@ public final class SpreadsheetGroupParserTokenTest extends SpreadsheetParentPars
         final String text = "(" + NUMBER1 + ")";
         final SpreadsheetGroupParserToken token = this.createToken(text, this.number1());
         this.checkText(token, text);
-        assertSame(token, token.withoutSymbolsOrWhitespace().get());
+        assertSame(token, token.withoutSymbols().get());
     }
 
     @Test
@@ -62,7 +62,7 @@ public final class SpreadsheetGroupParserTokenTest extends SpreadsheetParentPars
         this.checkText(token, text);
         this.checkValue(token, left, number, right);
 
-        final SpreadsheetGroupParserToken token2 = Cast.to(token.withoutSymbolsOrWhitespace().get());
+        final SpreadsheetGroupParserToken token2 = Cast.to(token.withoutSymbols().get());
         assertNotSame(token, token2);
         this.checkText(token2, text);
         this.checkValue(token2, number);
@@ -82,7 +82,7 @@ public final class SpreadsheetGroupParserTokenTest extends SpreadsheetParentPars
         this.checkText(token, text);
         this.checkValue(token, left, whitespace1, number, whitespace2, right);
 
-        final SpreadsheetGroupParserToken token2 = Cast.to(token.withoutSymbolsOrWhitespace().get());
+        final SpreadsheetGroupParserToken token2 = Cast.to(token.withoutSymbols().get());
         assertNotSame(token, token2);
         this.checkText(token2, text);
         this.checkValue(token2, number);

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParentParserTokenTestCase.java
@@ -59,16 +59,16 @@ public abstract class SpreadsheetParentParserTokenTestCase<T extends Spreadsheet
     }
 
     @Test
-    public void testWithoutSymbolsOrWhitespaceCached() {
+    public void testWithoutSymbolsCached() {
         final T token = this.createToken();
-        assertSame(token.withoutSymbolsOrWhitespace(), token.withoutSymbolsOrWhitespace());
-        assertSame(token.withoutSymbolsOrWhitespace().get().withoutSymbolsOrWhitespace(), token.withoutSymbolsOrWhitespace().get().withoutSymbolsOrWhitespace());
+        assertSame(token.withoutSymbols(), token.withoutSymbols());
+        assertSame(token.withoutSymbols().get().withoutSymbols(), token.withoutSymbols().get().withoutSymbols());
     }
 
     @Test
-    public void testWithoutSymbolsOrWhitespaceDoubleSame() {
+    public void testWithoutSymbolsDoubleSame() {
         final T token = this.createToken();
-        assertSame(token.withoutSymbolsOrWhitespace().get(), token.withoutSymbolsOrWhitespace().get());
+        assertSame(token.withoutSymbols().get(), token.withoutSymbols().get());
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetParserTokenTestCase.java
@@ -92,7 +92,7 @@ public abstract class SpreadsheetParserTokenTestCase<T extends SpreadsheetParser
 
     @Test
     public void testWithoutCommentsSymbolsOrWhitespacePropertiesNullCheck() throws Exception {
-        final Optional<SpreadsheetParserToken> without = this.createToken().withoutSymbolsOrWhitespace();
+        final Optional<SpreadsheetParserToken> without = this.createToken().withoutSymbols();
         if(without.isPresent()){
             this.propertiesNeverReturnNullCheck(without.get());
         }

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetUnaryParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetUnaryParserTokenTestCase.java
@@ -54,7 +54,7 @@ public abstract class SpreadsheetUnaryParserTokenTestCase<T extends SpreadsheetU
         assertNotSame(token, different);
         this.checkValue(different, value);
 
-        assertEquals(Optional.of(different), different.withoutSymbolsOrWhitespace());
+        assertEquals(Optional.of(different), different.withoutSymbols());
     }
 
     @Test
@@ -66,7 +66,7 @@ public abstract class SpreadsheetUnaryParserTokenTestCase<T extends SpreadsheetU
         assertNotSame(token, different);
         this.checkValue(different, values);
 
-        final Optional<SpreadsheetParserToken> differentWithout = different.withoutSymbolsOrWhitespace();
+        final Optional<SpreadsheetParserToken> differentWithout = different.withoutSymbols();
         assertNotEquals(Optional.of(different), differentWithout);
 
         this.checkValue(differentWithout.get(), values.subList(0, 1));

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/format/SpreadsheetFormatNonSymbolParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/format/SpreadsheetFormatNonSymbolParserTokenTestCase.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 public abstract class SpreadsheetFormatNonSymbolParserTokenTestCase<T extends SpreadsheetFormatNonSymbolParserToken<V>, V> extends SpreadsheetFormatLeafParserTokenTestCase<T, V> {
 
     @Test
-    public final void testWithoutSymbolsOrWhitespace() {
+    public final void testWithoutSymbols() {
         final T token = this.createToken();
         assertEquals(Optional.of(token), token.withoutSymbols());
     }


### PR DESCRIPTION
- withoutSymbolsOrWhitespace becomes withoutSymbols.