### PR TITLE
ExpressionEvaluationContext.reference returns Optional<ExpressionNode>.

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/BasicExpressionEvaluationContext.java
@@ -27,6 +27,7 @@ import walkingkooka.math.DecimalNumberContext;
 import java.math.MathContext;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -39,7 +40,7 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
      * Factory that creates a {@link BasicExpressionEvaluationContext}
      */
     static BasicExpressionEvaluationContext with(final BiFunction<ExpressionNodeName, List<Object>, Object> functions,
-                                                 final Function<ExpressionReference, ExpressionNode> references,
+                                                 final Function<ExpressionReference, Optional<ExpressionNode>> references,
                                                  final MathContext mathContext,
                                                  final Converter converter,
                                                  final DecimalNumberContext context) {
@@ -56,7 +57,7 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
      * Private ctor use factory
      */
     private BasicExpressionEvaluationContext(final BiFunction<ExpressionNodeName, List<Object>, Object> functions,
-                                             final Function<ExpressionReference, ExpressionNode> references,
+                                             final Function<ExpressionReference, Optional<ExpressionNode>> references,
                                              final MathContext mathContext,
                                              final Converter converter,
                                              final DecimalNumberContext context) {
@@ -115,11 +116,15 @@ final class BasicExpressionEvaluationContext implements ExpressionEvaluationCont
     private final BiFunction<ExpressionNodeName, List<Object>, Object> functions;
 
     @Override
-    public ExpressionNode reference(final ExpressionReference reference) {
-        return this.references.apply(reference);
+    public Optional<ExpressionNode> reference(final ExpressionReference reference) {
+        final Optional<ExpressionNode> node = this.references.apply(reference);
+        if (!node.isPresent()) {
+            new ExpressionEvaluationReferenceException("Missing reference: " + reference);
+        }
+        return node;
     }
 
-    private final Function<ExpressionReference, ExpressionNode> references;
+    private final Function<ExpressionReference, Optional<ExpressionNode>> references;
 
     @Override
     public MathContext mathContext() {

--- a/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContext.java
@@ -25,6 +25,7 @@ import walkingkooka.util.variable.Variables;
 import java.math.MathContext;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -96,21 +97,21 @@ final class CycleDetectingExpressionEvaluationContext implements ExpressionEvalu
     }
 
     @Override
-    public ExpressionNode reference(final ExpressionReference reference) {
+    public Optional<ExpressionNode> reference(final ExpressionReference reference) {
         final Set<ExpressionReference> cycles = this.cycles();
 
         this.cycleCheck(reference, cycles);
 
         try {
            cycles.add(reference);
-           final ExpressionNode result =  this.context.reference(reference);
+           final ExpressionNode result =  this.context.referenceOrFail(reference);
 
             if(result.isReference()) {
                 final ExpressionReferenceNode referenceNode = result.cast();
                 this.cycleCheck(referenceNode.value(), cycles);
             }
 
-           return result;
+           return Optional.of(result);
         } finally {
             cycles.remove(reference);
         }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContext.java
@@ -24,6 +24,7 @@ import walkingkooka.math.DecimalNumberContext;
 
 import java.math.MathContext;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Context that travels during any expression evaluation.
@@ -43,7 +44,15 @@ public interface ExpressionEvaluationContext extends Context, DecimalNumberConte
     /**
      * Locates the value or a {@link ExpressionNode} for the given {@link ExpressionReference}
      */
-    ExpressionNode reference(final ExpressionReference reference);
+    Optional<ExpressionNode> reference(final ExpressionReference reference);
+
+    /**
+     * Locates the value or a {@link ExpressionNode} for the given {@link ExpressionReference} or throws a
+     * {@link ExpressionEvaluationReferenceException}.
+     */
+    default ExpressionNode referenceOrFail(final ExpressionReference reference) {
+        return this.reference(reference).orElseThrow(() -> new ExpressionEvaluationReferenceException("Unable to find " + reference));
+    }
 
     /**
      * The {@link MathContext} to be used with math operations.

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContexts.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationContexts.java
@@ -25,6 +25,7 @@ import walkingkooka.util.variable.Variable;
 
 import java.math.MathContext;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -35,7 +36,7 @@ public final class ExpressionEvaluationContexts implements PublicStaticHelper {
      * {@see BasicExpressionEvaluationContext}
      */
     public static ExpressionEvaluationContext basic(final BiFunction<ExpressionNodeName, List<Object>, Object> functions,
-                                                    final Function<ExpressionReference, ExpressionNode> references,
+                                                    final Function<ExpressionReference, Optional<ExpressionNode>> references,
                                                     final MathContext mathContext,
                                                     final Converter converter,
                                                     final DecimalNumberContext context) {

--- a/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationReferenceException.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionEvaluationReferenceException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.expression;
+
+/**
+ * This exception is thrown whenever a reference lookup fails.
+ */
+public class ExpressionEvaluationReferenceException extends ExpressionException {
+
+    private static final long serialVersionUID = 1;
+
+    protected ExpressionEvaluationReferenceException() {
+        super();
+    }
+
+    public ExpressionEvaluationReferenceException(final String message) {
+        super(message);
+    }
+
+    public ExpressionEvaluationReferenceException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/walkingkooka/tree/expression/ExpressionReferenceNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionReferenceNode.java
@@ -111,12 +111,12 @@ public final class ExpressionReferenceNode extends ExpressionLeafNode<Expression
 
     @Override
     public final BigDecimal toBigDecimal(final ExpressionEvaluationContext context) {
-        return context.reference(this.value).toBigDecimal(context);
+        return context.referenceOrFail(this.value).toBigDecimal(context);
     }
 
     @Override
     public final BigInteger toBigInteger(final ExpressionEvaluationContext context) {
-        return context.reference(this.value).toBigInteger(context);
+        return context.referenceOrFail(this.value).toBigInteger(context);
     }
 
     @Override
@@ -165,7 +165,7 @@ public final class ExpressionReferenceNode extends ExpressionLeafNode<Expression
     }
 
     private ExpressionNode toExpressionNode(final ExpressionEvaluationContext context) {
-        return context.reference(this.value);
+        return context.referenceOrFail(this.value);
     }
 
     // Object ....................................................................................................

--- a/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/tree/expression/FakeExpressionEvaluationContext.java
@@ -23,6 +23,7 @@ import walkingkooka.math.FakeDecimalNumberContext;
 import java.math.MathContext;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class FakeExpressionEvaluationContext extends FakeDecimalNumberContext implements ExpressionEvaluationContext {
 
@@ -38,7 +39,7 @@ public class FakeExpressionEvaluationContext extends FakeDecimalNumberContext im
     }
 
     @Override
-    public ExpressionNode reference(final ExpressionReference reference) {
+    public Optional<ExpressionNode> reference(final ExpressionReference reference) {
         Objects.requireNonNull(reference, "reference");
         throw new UnsupportedOperationException();
     }

--- a/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/BasicExpressionEvaluationContextTest.java
@@ -29,6 +29,7 @@ import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLabelName;
 import java.math.MathContext;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -89,7 +90,7 @@ public final class BasicExpressionEvaluationContextTest extends  ExpressionEvalu
 
     @Test
     public void testReferences() {
-        assertEquals(this.expressionNode(), this.createContext().reference(this.expressionReference()));
+        assertEquals(Optional.of(this.expressionNode()), this.createContext().reference(this.expressionReference()));
     }
 
     @Test
@@ -134,11 +135,11 @@ public final class BasicExpressionEvaluationContextTest extends  ExpressionEvalu
         return "function-value-234";
     }
 
-    private Function<ExpressionReference, ExpressionNode> references() {
+    private Function<ExpressionReference, Optional<ExpressionNode>> references() {
         return (r -> {
             Objects.requireNonNull(r, "references");
             assertEquals("reference", this.expressionReference(), r);
-            return this.expressionNode();
+            return Optional.of(this.expressionNode());
         });
     }
 

--- a/src/test/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/expression/CycleDetectingExpressionEvaluationContextTest.java
@@ -32,6 +32,7 @@ import walkingkooka.util.variable.Variables;
 import java.math.BigInteger;
 import java.math.MathContext;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -75,12 +76,12 @@ public final class CycleDetectingExpressionEvaluationContextTest extends Express
         final CycleDetectingExpressionEvaluationContext context = this.createContext(new FakeExpressionEvaluationContext() {
 
             @Override
-            public ExpressionNode reference(final ExpressionReference reference) {
+            public Optional<ExpressionNode> reference(final ExpressionReference reference) {
                 assertSame("cell", cell, reference);
-                return text;
+                return Optional.of(text);
             }
         });
-        assertSame(text, context.reference(cell));
+        assertSame(text, context.reference(cell).get());
     }
 
     @Test
@@ -90,9 +91,9 @@ public final class CycleDetectingExpressionEvaluationContextTest extends Express
         final CycleDetectingExpressionEvaluationContext context = this.createContext(new FakeExpressionEvaluationContext() {
 
             @Override
-            public ExpressionNode reference(final ExpressionReference reference) {
+            public Optional<ExpressionNode> reference(final ExpressionReference reference) {
                 assertSame("label", label, reference);
-                return text();
+                return Optional.of(text());
             }
         });
         final ExpressionNode expression = ExpressionNode.reference(label);
@@ -116,7 +117,11 @@ public final class CycleDetectingExpressionEvaluationContextTest extends Express
         final CycleDetectingExpressionEvaluationContext context = this.createContext(new FakeExpressionEvaluationContext() {
 
             @Override
-            public ExpressionNode reference(final ExpressionReference reference) {
+            public Optional<ExpressionNode> reference(final ExpressionReference reference) {
+                return Optional.of(this.reference0(reference));
+            }
+
+            private ExpressionNode reference0(final ExpressionReference reference) {
                 if (label2 == reference) {
                     return label2Expression;
                 }
@@ -150,9 +155,9 @@ public final class CycleDetectingExpressionEvaluationContextTest extends Express
         final CycleDetectingExpressionEvaluationContext context = this.createContext(new FakeExpressionEvaluationContext() {
 
             @Override
-            public ExpressionNode reference(final ExpressionReference reference) {
+            public Optional<ExpressionNode> reference(final ExpressionReference reference) {
                 if (label == reference) {
-                    return labelExpression;
+                    return Optional.of(labelExpression);
                 }
                 return this.unknownReference(reference);
             }
@@ -177,7 +182,11 @@ public final class CycleDetectingExpressionEvaluationContextTest extends Express
         final CycleDetectingExpressionEvaluationContext context = this.createContext(new FakeExpressionEvaluationContext() {
 
             @Override
-            public ExpressionNode reference(final ExpressionReference reference) {
+            public Optional<ExpressionNode> reference(final ExpressionReference reference) {
+                return Optional.of(this.reference0(reference));
+            }
+
+            private ExpressionNode reference0(final ExpressionReference reference) {
                 if (label2 == reference) {
                     return label1Expression;
                 }
@@ -208,7 +217,11 @@ public final class CycleDetectingExpressionEvaluationContextTest extends Express
         final CycleDetectingExpressionEvaluationContext context = this.createContext(new FakeExpressionEvaluationContext() {
 
             @Override
-            public ExpressionNode reference(final ExpressionReference reference) {
+            public Optional<ExpressionNode> reference(final ExpressionReference reference) {
+                return Optional.of(this.reference0(reference));
+            }
+
+            private ExpressionNode reference0(final ExpressionReference reference) {
                 if (label2 == reference || label3 == reference) {
                     return label1Expression;
                 }
@@ -239,7 +252,11 @@ public final class CycleDetectingExpressionEvaluationContextTest extends Express
         final CycleDetectingExpressionEvaluationContext context = this.createContext(new FakeExpressionEvaluationContext() {
 
             @Override
-            public ExpressionNode reference(final ExpressionReference reference) {
+            public Optional<ExpressionNode> reference(final ExpressionReference reference) {
+                return Optional.of(this.reference0(reference));
+            }
+
+            private ExpressionNode reference0(final ExpressionReference reference) {
                 if (label2 == reference) {
                     return label1Expression;
                 }

--- a/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationReferenceExceptionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionEvaluationReferenceExceptionTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.expression;
+
+import walkingkooka.test.PublicThrowableTestCase;
+
+public final class ExpressionEvaluationReferenceExceptionTest extends PublicThrowableTestCase<ExpressionEvaluationReferenceException> {
+    @Override
+    protected Class<ExpressionEvaluationReferenceException> type() {
+        return ExpressionEvaluationReferenceException.class;
+    }
+}

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNodeEvaluationTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNodeEvaluationTest.java
@@ -175,7 +175,7 @@ public class ExpressionNodeEvaluationTest extends TestCase {
             }
 
             @Override
-            public ExpressionNode reference(final ExpressionReference reference) {
+            public Optional<ExpressionNode> reference(final ExpressionReference reference) {
                 return context.reference(reference);
             }
 

--- a/src/test/java/walkingkooka/tree/expression/ExpressionReferenceNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionReferenceNodeTest.java
@@ -26,6 +26,7 @@ import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReference;
 import walkingkooka.tree.visit.Visiting;
 
 import java.math.MathContext;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -140,9 +141,9 @@ public final class ExpressionReferenceNodeTest extends ExpressionLeafNodeTestCas
         return new FakeExpressionEvaluationContext() {
 
             @Override
-            public ExpressionNode reference(final ExpressionReference reference) {
+            public Optional<ExpressionNode> reference(final ExpressionReference reference) {
                 assertEquals("reference", value, reference);
-                return ExpressionNode.text(referenceText);
+                return Optional.of(ExpressionNode.text(referenceText));
             }
 
             @Override


### PR DESCRIPTION
- new exception ExpressionEvaluationReferenceException.
- added ExpressionEvaluationContext.referenceOrFail throws ExpressionEvaluationReferenceException