### PR TITLE
ExpressionNode.valueOrFail accept all primitive number types.

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/ExpressionNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNode.java
@@ -53,19 +53,33 @@ public abstract class ExpressionNode implements Node<ExpressionNode, ExpressionN
                         bigInteger(Cast.to(value)) :
                         value instanceof Boolean ?
                                 booleanNode(Cast.to(value)) :
-                                value instanceof Double ?
-                                        doubleNode(Cast.to(value)) :
-                                        value instanceof LocalDate ?
-                                                localDate(Cast.to(value)) :
-                                                value instanceof LocalDateTime ?
-                                                        localDateTime(Cast.to(value)) :
-                                                        value instanceof LocalTime ?
-                                                                localTime(Cast.to(value)) :
-                                                                value instanceof Long ?
-                                                                        longNode(Cast.to(value)) :
+                                value instanceof Byte | value instanceof Short | value instanceof Integer | value instanceof Long ?
+                                        valueOrFailLongNode(Cast.to(value)) :
+                                        value instanceof Float || value instanceof Double ?
+                                                valueOrFailDoubleNode(Cast.to(value)) :
+                                                value instanceof LocalDate ?
+                                                        localDate(Cast.to(value)) :
+                                                        value instanceof LocalDateTime ?
+                                                                localDateTime(Cast.to(value)) :
+                                                                value instanceof LocalTime ?
+                                                                        localTime(Cast.to(value)) :
                                                                         value instanceof String ?
                                                                                 text(Cast.to(value)) :
                                                                                 valueOrFailFail(value);
+    }
+
+    /**
+     * Expects float or double and creates a {@link ExpressionDoubleNode}
+     */
+    private static ExpressionNode valueOrFailDoubleNode(final Number value) {
+        return doubleNode(value.doubleValue());
+    }
+
+    /**
+     * Expects any of the primitive numeric types except for float or double.
+     */
+    private static ExpressionNode valueOrFailLongNode(final Number value) {
+        return longNode(value.longValue());
     }
 
     /**

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNodeTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNodeTest.java
@@ -62,13 +62,33 @@ public final class ExpressionNodeTest extends PublicClassTestCase<ExpressionNode
     }
 
     @Test
+    public void testValueOrFailFloat() {
+        this.valueOrFailAndCheck(123.5f, ExpressionDoubleNode.class, 123.5);
+    }
+
+    @Test
     public void testValueOrFailDouble() {
-        this.valueOrFailAndCheck(Double.valueOf(123.5), ExpressionDoubleNode.class);
+        this.valueOrFailAndCheck(123.5, ExpressionDoubleNode.class);
+    }
+
+    @Test
+    public void testValueOrFailByte() {
+        this.valueOrFailAndCheck((byte) 123, ExpressionLongNode.class, 123L);
+    }
+
+    @Test
+    public void testValueOrFailShort() {
+        this.valueOrFailAndCheck((short) 123, ExpressionLongNode.class, 123L);
+    }
+
+    @Test
+    public void testValueOrFailInteger() {
+        this.valueOrFailAndCheck(123, ExpressionLongNode.class, 123L);
     }
 
     @Test
     public void testValueOrFailLong() {
-        this.valueOrFailAndCheck(Long.valueOf(123), ExpressionLongNode.class);
+        this.valueOrFailAndCheck(123L, ExpressionLongNode.class);
     }
 
     @Test
@@ -93,9 +113,13 @@ public final class ExpressionNodeTest extends PublicClassTestCase<ExpressionNode
     }
 
     private void valueOrFailAndCheck(final Object value, final Class<? extends ExpressionValueNode> type) {
+        valueOrFailAndCheck(value, type, value);
+    }
+
+    private void valueOrFailAndCheck(final Object value, final Class<? extends ExpressionValueNode> type, final Object expected) {
         final ExpressionNode node = ExpressionNode.valueOrFail(value);
         assertEquals("node type of " + value, type, node.getClass());
-        assertEquals("value", value, type.cast(node).value());
+        assertEquals("value", expected, type.cast(node).value());
     }
 
     @Override


### PR DESCRIPTION
- byte, short, int mapped to ExpressionLongNode.
- float mapped to ExpressionDoubleNode.