### PR TITLE
NodeSelectorContext supports potential and selected and convert/2

### DIFF
--- a/src/main/java/walkingkooka/tree/select/ExpressionNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/ExpressionNodeSelector.java
@@ -61,7 +61,7 @@ final class ExpressionNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
 
     @Override
     final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        if (this.predicate.test(ExpressionNodeSelectorPredicateExpressionEvaluationContext.with(node))) {
+        if (this.predicate.test(ExpressionNodeSelectorPredicateExpressionEvaluationContext.with(node, context))) {
             context.selected(node);
         }
     }

--- a/src/test/java/walkingkooka/tree/select/ExpressionNodeSelectorPredicateExpressionEvaluationContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/ExpressionNodeSelectorPredicateExpressionEvaluationContextTest.java
@@ -25,7 +25,7 @@ public final class ExpressionNodeSelectorPredicateExpressionEvaluationContextTes
 
     @Override
     protected ExpressionNodeSelectorPredicateExpressionEvaluationContext createContext() {
-        return ExpressionNodeSelectorPredicateExpressionEvaluationContext.with(null);
+        return ExpressionNodeSelectorPredicateExpressionEvaluationContext.with(null, null);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/select/ExpressionNodeSelectorPredicateTest.java
+++ b/src/test/java/walkingkooka/tree/select/ExpressionNodeSelectorPredicateTest.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 
-public final class ExpressionNodePredicateSelectorPredicateTest extends PredicateTestCase<ExpressionNodeSelectorPredicate, ExpressionEvaluationContext> {
+public final class ExpressionNodeSelectorPredicateTest extends PredicateTestCase<ExpressionNodeSelectorPredicate, ExpressionEvaluationContext> {
 
     private final static String ATTRIBUTE_NAME = "text";
 


### PR DESCRIPTION
- NodeSelectorContext now aggregates matches(selected) nodes.
- NodeSelector.accept(Node, Consumer) replaced by accept(Node, NodeSelectorContext)
- Consumer replaced by NodeSelectorContext.potential.
- Removed NodeSelectorContext.asPredicate (impl as NodeSelectorNodeAttributeValuePredicate).
- Internal code cleanup.
- Created two selectors which accept Predicates, Predicate<Node>, Predicate<ExpressionEvaluationContext>