### PR TITLE
SearchNode.setName: Ability to replace default name for that type of …

### DIFF
--- a/src/main/java/walkingkooka/tree/search/SearchBigDecimalNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchBigDecimalNode.java
@@ -30,21 +30,26 @@ public final class SearchBigDecimalNode extends SearchLeafNode<BigDecimal>{
     static SearchBigDecimalNode with(final String text, final BigDecimal value) {
         check(text, value);
 
-        return new SearchBigDecimalNode(NO_PARENT_INDEX, text, value);
+        return new SearchBigDecimalNode(NO_PARENT_INDEX, NAME, text, value);
     }
 
-    private SearchBigDecimalNode(final int index, final String text, final BigDecimal value) {
-        super(index, text, value);
+    private SearchBigDecimalNode(final int index, final SearchNodeName name, final String text, final BigDecimal value) {
+        super(index, name, text, value);
     }
-    
+
     @Override
-    public SearchNodeName name() {
+    SearchNodeName defaultName() {
         return NAME;
     }
 
     @Override
-    SearchBigDecimalNode wrap1(final int index, final String text, final BigDecimal value) {
-        return new SearchBigDecimalNode(index, text, value);
+    public SearchBigDecimalNode setName(final SearchNodeName name) {
+        return super.setName0(name).cast();
+    }
+
+    @Override
+    SearchBigDecimalNode replace0(final int index, final SearchNodeName name, final String text, final BigDecimal value) {
+        return new SearchBigDecimalNode(index, name, text, value);
     }
 
     @Override
@@ -107,7 +112,7 @@ public final class SearchBigDecimalNode extends SearchLeafNode<BigDecimal>{
     }
 
     @Override
-    final void toString0(final StringBuilder b) {
+    final void toString1(final StringBuilder b) {
         b.append(this.value());
     }
 }

--- a/src/main/java/walkingkooka/tree/search/SearchBigIntegerNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchBigIntegerNode.java
@@ -30,21 +30,26 @@ public final class SearchBigIntegerNode extends SearchLeafNode<BigInteger>{
     static SearchBigIntegerNode with(final String text, final BigInteger value) {
         check(text, value);
 
-        return new SearchBigIntegerNode(NO_PARENT_INDEX, text, value);
+        return new SearchBigIntegerNode(NO_PARENT_INDEX, NAME, text, value);
     }
 
-    private SearchBigIntegerNode(final int index, final String text, final BigInteger value) {
-        super(index, text, value);
+    private SearchBigIntegerNode(final int index, final SearchNodeName name, final String text, final BigInteger value) {
+        super(index, name, text, value);
     }
-    
+
     @Override
-    public SearchNodeName name() {
+    SearchNodeName defaultName() {
         return NAME;
     }
 
     @Override
-    SearchBigIntegerNode wrap1(final int index, final String text, final BigInteger value) {
-        return new SearchBigIntegerNode(index, text, value);
+    public SearchBigIntegerNode setName(final SearchNodeName name) {
+        return super.setName0(name).cast();
+    }
+
+    @Override
+    SearchBigIntegerNode replace0(final int index, final SearchNodeName name, final String text, final BigInteger value) {
+        return new SearchBigIntegerNode(index, name, text, value);
     }
 
     @Override
@@ -107,7 +112,7 @@ public final class SearchBigIntegerNode extends SearchLeafNode<BigInteger>{
     }
 
     @Override
-    final void toString0(final StringBuilder b) {
+    final void toString1(final StringBuilder b) {
         b.append(this.value());
     }
 }

--- a/src/main/java/walkingkooka/tree/search/SearchDoubleNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchDoubleNode.java
@@ -28,21 +28,26 @@ public final class SearchDoubleNode extends SearchLeafNode<Double>{
     static SearchDoubleNode with(final String text, final Double value) {
         check(text, value);
 
-        return new SearchDoubleNode(NO_PARENT_INDEX, text, value);
+        return new SearchDoubleNode(NO_PARENT_INDEX, NAME, text, value);
     }
 
-    private SearchDoubleNode(final int index, final String text, final Double value) {
-        super(index, text, value);
+    private SearchDoubleNode(final int index, final SearchNodeName name, final String text, final Double value) {
+        super(index, name, text, value);
     }
-    
+
     @Override
-    public SearchNodeName name() {
+    SearchNodeName defaultName() {
         return NAME;
     }
 
     @Override
-    SearchDoubleNode wrap1(final int index, final String text, final Double value) {
-        return new SearchDoubleNode(index, text, value);
+    public SearchDoubleNode setName(final SearchNodeName name) {
+        return super.setName0(name).cast();
+    }
+
+    @Override
+    SearchDoubleNode replace0(final int index, final SearchNodeName name, final String text, final Double value) {
+        return new SearchDoubleNode(index, name, text, value);
     }
 
     @Override
@@ -105,7 +110,7 @@ public final class SearchDoubleNode extends SearchLeafNode<Double>{
     }
 
     @Override
-    final void toString0(final StringBuilder b) {
+    final void toString1(final StringBuilder b) {
         b.append(this.value());
     }
 }

--- a/src/main/java/walkingkooka/tree/search/SearchIgnoredNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchIgnoredNode.java
@@ -41,19 +41,24 @@ public final class SearchIgnoredNode extends SearchParentNode2 {
         Objects.requireNonNull(child, "child");
         return child.isIgnored() ?
                 child.cast() :
-                new SearchIgnoredNode(NO_PARENT_INDEX, Lists.of(child));
+                new SearchIgnoredNode(NO_PARENT_INDEX, NAME, Lists.of(child));
     }
 
     /**
      * Private ctor to limit sub classing.
      */
-    private SearchIgnoredNode(final int index, final List<SearchNode> children) {
-        super(index, children);
+    private SearchIgnoredNode(final int index, final SearchNodeName name, final List<SearchNode> children) {
+        super(index, name, children);
     }
 
     @Override
-    public SearchNodeName name() {
+    SearchNodeName defaultName() {
         return NAME;
+    }
+
+    @Override
+    public SearchIgnoredNode setName(final SearchNodeName name) {
+        return super.setName0(name).cast();
     }
 
     public SearchNode child() {
@@ -90,8 +95,8 @@ public final class SearchIgnoredNode extends SearchParentNode2 {
     }
 
     @Override
-    SearchParentNode wrap0(final int index, final List<SearchNode> children) {
-        return new SearchIgnoredNode(index, children);
+    SearchParentNode replace0(final int index, final SearchNodeName name, final List<SearchNode> children) {
+        return new SearchIgnoredNode(index, name, children);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/search/SearchLeafNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchLeafNode.java
@@ -38,8 +38,8 @@ abstract class SearchLeafNode<V> extends SearchNode implements Value<V> {
         Objects.requireNonNull(value, "value");
     }
 
-    SearchLeafNode(final int index, final String text, final V value) {
-        super(index);
+    SearchLeafNode(final int index, final SearchNodeName name, final String text, final V value) {
+        super(index, name);
         this.text = text;
         this.value = value;
     }
@@ -70,20 +70,17 @@ abstract class SearchLeafNode<V> extends SearchNode implements Value<V> {
     final SearchLeafNode<V> replaceValue(final V value) {
         final int index = this.index();
 
-        return this.wrap1(index, this.text, value)
+        return this.replace0(index, this.name, this.text, value)
                 .replaceChild(this.parent(), index)
                 .cast();
     }
 
-    final SearchLeafNode wrap0(final int index) {
-        return this.wrap1(index, this.text, this.value);
+    @Override
+    final SearchNode replace(final int index, final SearchNodeName name) {
+        return this.replace0(index, name, this.text, this.value);
     }
 
-    abstract SearchLeafNode wrap1(final int index, final String text, final V value);
-
-    @Override final SearchNode wrap(final int index) {
-        return this.wrap0(index);
-    }
+    abstract SearchLeafNode replace0(final int index, final SearchNodeName name, final String text, final V value);
 
     @Override
     SearchNode replaceAll(final SearchNode replace) {
@@ -189,7 +186,7 @@ abstract class SearchLeafNode<V> extends SearchNode implements Value<V> {
 
     @Override
     public final int hashCode() {
-        return this.value.hashCode();
+        return Objects.hash(this.name, this.value.hashCode());
     }
 
     @Override
@@ -198,12 +195,19 @@ abstract class SearchLeafNode<V> extends SearchNode implements Value<V> {
     }
 
     @Override
-    boolean equalsIgnoringParentAndChildren(final SearchNode other) {
-        return other instanceof SearchLeafNode && this.equals1(Cast.to(other));
+    boolean equalsIgnoringParentAndChildren0(final SearchNode other) {
+        return other instanceof SearchLeafNode && this.equalsIgnoringParentAndChildren1(Cast.to(other));
     }
 
-    private boolean equals1(final SearchLeafNode<?> other) {
+    private boolean equalsIgnoringParentAndChildren1(final SearchLeafNode<?> other) {
         return this.text.equals(other.text) &&
                this.value.equals(other.value);
     }
+
+    @Override
+    final String toStringNameSuffix() {
+        return "=";
+    }
+
+    abstract void toString1(final StringBuilder b);
 }

--- a/src/main/java/walkingkooka/tree/search/SearchLocalDateNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchLocalDateNode.java
@@ -31,21 +31,26 @@ public final class SearchLocalDateNode extends SearchLeafNode<LocalDate>{
     static SearchLocalDateNode with(final String text, final LocalDate value) {
         check(text, value);
 
-        return new SearchLocalDateNode(NO_PARENT_INDEX, text, value);
+        return new SearchLocalDateNode(NO_PARENT_INDEX, NAME, text, value);
     }
 
-    private SearchLocalDateNode(final int index, final String text, final LocalDate value) {
-        super(index, text, value);
+    private SearchLocalDateNode(final int index, final SearchNodeName name, final String text, final LocalDate value) {
+        super(index, name, text, value);
     }
-    
+
     @Override
-    public SearchNodeName name() {
+    SearchNodeName defaultName() {
         return NAME;
     }
 
     @Override
-    SearchLocalDateNode wrap1(final int index, final String text, final LocalDate value) {
-        return new SearchLocalDateNode(index, text, value);
+    public SearchLocalDateNode setName(final SearchNodeName name) {
+        return super.setName0(name).cast();
+    }
+
+    @Override
+    SearchLocalDateNode replace0(final int index, final SearchNodeName name, final String text, final LocalDate value) {
+        return new SearchLocalDateNode(index, name, text, value);
     }
 
     @Override
@@ -108,7 +113,7 @@ public final class SearchLocalDateNode extends SearchLeafNode<LocalDate>{
     }
 
     @Override
-    final void toString0(final StringBuilder b) {
+    final void toString1(final StringBuilder b) {
         b.append(DateTimeFormatter.ISO_LOCAL_DATE.format(this.value()));
     }
 }

--- a/src/main/java/walkingkooka/tree/search/SearchLocalDateTimeNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchLocalDateTimeNode.java
@@ -31,21 +31,26 @@ public final class SearchLocalDateTimeNode extends SearchLeafNode<LocalDateTime>
     static SearchLocalDateTimeNode with(final String text, final LocalDateTime value) {
         check(text, value);
 
-        return new SearchLocalDateTimeNode(NO_PARENT_INDEX, text, value);
+        return new SearchLocalDateTimeNode(NO_PARENT_INDEX, NAME, text, value);
     }
 
-    private SearchLocalDateTimeNode(final int index, final String text, final LocalDateTime value) {
-        super(index, text, value);
+    private SearchLocalDateTimeNode(final int index, final SearchNodeName name, final String text, final LocalDateTime value) {
+        super(index, name, text, value);
     }
-    
+
     @Override
-    public SearchNodeName name() {
+    SearchNodeName defaultName() {
         return NAME;
     }
 
     @Override
-    SearchLocalDateTimeNode wrap1(final int index, final String text, final LocalDateTime value) {
-        return new SearchLocalDateTimeNode(index, text, value);
+    public SearchLocalDateTimeNode setName(final SearchNodeName name) {
+        return super.setName0(name).cast();
+    }
+
+    @Override
+    SearchLocalDateTimeNode replace0(final int index, final SearchNodeName name, final String text, final LocalDateTime value) {
+        return new SearchLocalDateTimeNode(index, name, text, value);
     }
 
     @Override
@@ -108,7 +113,7 @@ public final class SearchLocalDateTimeNode extends SearchLeafNode<LocalDateTime>
     }
 
     @Override
-    final void toString0(final StringBuilder b) {
+    final void toString1(final StringBuilder b) {
         b.append(DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(this.value()));
     }
 }

--- a/src/main/java/walkingkooka/tree/search/SearchLocalTimeNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchLocalTimeNode.java
@@ -31,21 +31,26 @@ public final class SearchLocalTimeNode extends SearchLeafNode<LocalTime>{
     static SearchLocalTimeNode with(final String text, final LocalTime value) {
         check(text, value);
 
-        return new SearchLocalTimeNode(NO_PARENT_INDEX, text, value);
+        return new SearchLocalTimeNode(NO_PARENT_INDEX, NAME, text, value);
     }
 
-    private SearchLocalTimeNode(final int index, final String text, final LocalTime value) {
-        super(index, text, value);
+    private SearchLocalTimeNode(final int index, final SearchNodeName name, final String text, final LocalTime value) {
+        super(index, name, text, value);
     }
-    
+
     @Override
-    public SearchNodeName name() {
+    SearchNodeName defaultName() {
         return NAME;
     }
 
     @Override
-    SearchLocalTimeNode wrap1(final int index, final String text, final LocalTime value) {
-        return new SearchLocalTimeNode(index, text, value);
+    public SearchLocalTimeNode setName(final SearchNodeName name) {
+        return super.setName0(name).cast();
+    }
+
+    @Override
+    SearchLocalTimeNode replace0(final int index, final SearchNodeName name, final String text, final LocalTime value) {
+        return new SearchLocalTimeNode(index, name, text, value);
     }
 
     @Override
@@ -108,7 +113,7 @@ public final class SearchLocalTimeNode extends SearchLeafNode<LocalTime>{
     }
 
     @Override
-    final void toString0(final StringBuilder b) {
+    final void toString1(final StringBuilder b) {
         b.append(DateTimeFormatter.ISO_LOCAL_TIME.format(this.value()));
     }
 }

--- a/src/main/java/walkingkooka/tree/search/SearchLongNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchLongNode.java
@@ -28,21 +28,26 @@ public final class SearchLongNode extends SearchLeafNode<Long>{
     static SearchLongNode with(final String text, final Long value) {
         check(text, value);
 
-        return new SearchLongNode(NO_PARENT_INDEX, text, value);
+        return new SearchLongNode(NO_PARENT_INDEX, NAME, text, value);
     }
 
-    private SearchLongNode(final int index, final String text, final Long value) {
-        super(index, text, value);
-    }
-
-    @Override
-    SearchLongNode wrap1(final int index, final String text, final Long value) {
-        return new SearchLongNode(index, text, value);
+    private SearchLongNode(final int index, final SearchNodeName name, final String text, final Long value) {
+        super(index, name, text, value);
     }
 
     @Override
-    public SearchNodeName name() {
+    SearchNodeName defaultName() {
         return NAME;
+    }
+
+    @Override
+    public SearchLongNode setName(final SearchNodeName name) {
+        return super.setName0(name).cast();
+    }
+
+    @Override
+    SearchLongNode replace0(final int index, final SearchNodeName name, final String text, final Long value) {
+        return new SearchLongNode(index, name, text, value);
     }
 
     @Override
@@ -105,7 +110,7 @@ public final class SearchLongNode extends SearchLeafNode<Long>{
     }
 
     @Override
-    final void toString0(final StringBuilder b) {
+    final void toString1(final StringBuilder b) {
         b.append(this.value());
     }
 }

--- a/src/main/java/walkingkooka/tree/search/SearchMetaNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchMetaNode.java
@@ -40,7 +40,7 @@ public final class SearchMetaNode extends SearchParentNode {
     static SearchMetaNode with(final SearchNode child, final Map<SearchNodeAttributeName, String> attributes) {
         Objects.requireNonNull(child, "child");
 
-        return new SearchMetaNode(NO_PARENT_INDEX, Lists.of(child), copy(attributes));
+        return new SearchMetaNode(NO_PARENT_INDEX, NAME, Lists.of(child), copy(attributes));
     }
 
     private static Map<SearchNodeAttributeName, String> copy(final Map<SearchNodeAttributeName, String> attributes) {
@@ -57,15 +57,21 @@ public final class SearchMetaNode extends SearchParentNode {
     }
 
     private SearchMetaNode(final int index,
+                           final SearchNodeName name,
                            final List<SearchNode> children,
                            final Map<SearchNodeAttributeName, String> attributes) {
-        super(index, children);
+        super(index, name, children);
         this.attributes = Maps.readOnly(attributes);
     }
 
     @Override
-    public SearchNodeName name() {
+    SearchNodeName defaultName() {
         return NAME;
+    }
+
+    @Override
+    public SearchMetaNode setName(final SearchNodeName name) {
+        return super.setName0(name).cast();
     }
 
     public SearchNode child() {
@@ -94,8 +100,8 @@ public final class SearchMetaNode extends SearchParentNode {
     }
 
     @Override
-    SearchParentNode wrap0(final int index, final List<SearchNode> children) {
-        return new SearchMetaNode(index, children, this.attributes);
+    SearchParentNode replace0(final int index, final SearchNodeName name, final List<SearchNode> children) {
+        return new SearchMetaNode(index, name, children, this.attributes);
     }
 
     @Override
@@ -124,7 +130,7 @@ public final class SearchMetaNode extends SearchParentNode {
 
         return this.attributes.equals(copy) ?
                this :
-               new SearchMetaNode(this.index, this.children, copy)
+               new SearchMetaNode(this.index, this.name, this.children, copy)
                        .replaceChild(this.parent(), this.index)
                        .cast();
     }
@@ -215,11 +221,11 @@ public final class SearchMetaNode extends SearchParentNode {
     }
 
     @Override
-    final boolean equalsIgnoringParentAndChildren(final SearchNode other) {
-        return this.canBeEqual(other) && this.equalsIgnoringParentAndChildren0(other.cast());
+    final boolean equalsIgnoringParentAndChildren0(final SearchNode other) {
+        return this.canBeEqual(other) && this.equalsIgnoringParentAndChildren1(other.cast());
     }
 
-    private boolean equalsIgnoringParentAndChildren0(final SearchMetaNode other) {
+    private boolean equalsIgnoringParentAndChildren1(final SearchMetaNode other) {
         return this.attributes.equals(other.attributes);
     }
 

--- a/src/main/java/walkingkooka/tree/search/SearchParentNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchParentNode.java
@@ -32,8 +32,8 @@ abstract class SearchParentNode extends SearchNode {
     /**
      * Package private to limit sub classing.
      */
-    SearchParentNode(final int index, final List<SearchNode> children) {
-        super(index);
+    SearchParentNode(final int index, final SearchNodeName name, final List<SearchNode> children) {
+        super(index, name);
 
         final Optional<SearchNode> p = Optional.of(this);
 
@@ -112,7 +112,7 @@ abstract class SearchParentNode extends SearchNode {
         this.replaceChildrenCheck(children);
 
         final int index = this.index();
-        return this.wrap0(index, children)
+        return this.replace0(index, this.name, children)
                 .replaceChild(this.parent(), index)
                 .cast();
     }
@@ -120,11 +120,11 @@ abstract class SearchParentNode extends SearchNode {
     abstract void replaceChildrenCheck(final List<SearchNode> children);
 
     @Override
-    final SearchNode wrap(final int index) {
-        return this.wrap0(index, this.children());
+    final SearchNode replace(final int index, final SearchNodeName name) {
+        return this.replace0(index, name, this.children());
     }
 
-    abstract SearchParentNode wrap0(final int index, final List<SearchNode> children);
+    abstract SearchParentNode replace0(final int index, final SearchNodeName name, final List<SearchNode> children);
 
     @Override
     public final boolean isBigDecimal() {
@@ -194,8 +194,17 @@ abstract class SearchParentNode extends SearchNode {
         return equals;
     }
 
+    /**
+     * If a non default name is present, just add the name followed by the formatted value
+     * which typically includes something like surrounding braces, brackets etc.
+     */
     @Override
-    final void toString0(final StringBuilder b) {
+    final String toStringNameSuffix() {
+        return "";
+    }
+
+    @Override
+    final void toString1(final StringBuilder b) {
         b.append(this.toStringPrefix());
 
         String separator = "";

--- a/src/main/java/walkingkooka/tree/search/SearchParentNode2.java
+++ b/src/main/java/walkingkooka/tree/search/SearchParentNode2.java
@@ -28,8 +28,8 @@ import java.util.Map;
  */
 abstract class SearchParentNode2 extends SearchParentNode {
 
-    SearchParentNode2(final int index, final List<SearchNode> children) {
-        super(index, children);
+    SearchParentNode2(final int index, final SearchNodeName name, final List<SearchNode> children) {
+        super(index, name, children);
     }
 
     // attributes........................................................................................
@@ -55,7 +55,7 @@ abstract class SearchParentNode2 extends SearchParentNode {
     }
 
     @Override
-    final boolean equalsIgnoringParentAndChildren(final SearchNode other) {
+    final boolean equalsIgnoringParentAndChildren0(final SearchNode other) {
         return this.canBeEqual(other);
     }
 

--- a/src/main/java/walkingkooka/tree/search/SearchSelectNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchSelectNode.java
@@ -41,19 +41,24 @@ public final class SearchSelectNode extends SearchParentNode2 {
         Objects.requireNonNull(child, "child");
         return child.isSelect() ?
                child.cast() :
-               new SearchSelectNode(NO_PARENT_INDEX, Lists.of(child));
+               new SearchSelectNode(NO_PARENT_INDEX, NAME, Lists.of(child));
     }
 
     /**
      * Private ctor to limit sub classing.
      */
-    private SearchSelectNode(final int index, final List<SearchNode> children) {
-        super(index, children);
+    private SearchSelectNode(final int index, final SearchNodeName name, final List<SearchNode> children) {
+        super(index, name, children);
     }
 
     @Override
-    public SearchNodeName name() {
+    SearchNodeName defaultName() {
         return NAME;
+    }
+
+    @Override
+    public SearchSelectNode setName(final SearchNodeName name) {
+        return super.setName0(name).cast();
     }
 
     public SearchNode child() {
@@ -90,8 +95,8 @@ public final class SearchSelectNode extends SearchParentNode2 {
     }
 
     @Override
-    SearchParentNode wrap0(final int index, final List<SearchNode> children) {
-        return new SearchSelectNode(index, children);
+    SearchParentNode replace0(final int index, final SearchNodeName name, final List<SearchNode> children) {
+        return new SearchSelectNode(index, name, children);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/search/SearchSequenceNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchSequenceNode.java
@@ -35,16 +35,21 @@ public final class SearchSequenceNode extends SearchParentNode2 {
     static SearchSequenceNode with(final List<SearchNode> children) {
         Objects.requireNonNull(children, "children");
 
-        return new SearchSequenceNode(NO_PARENT_INDEX, children);
+        return new SearchSequenceNode(NO_PARENT_INDEX, NAME, children);
     }
 
-    private SearchSequenceNode(final int index, final List<SearchNode> children) {
-        super(index, children);
+    private SearchSequenceNode(final int index, final SearchNodeName name, final List<SearchNode> children) {
+        super(index, name, children);
     }
 
     @Override
-    public SearchNodeName name() {
+    SearchNodeName defaultName() {
         return NAME;
+    }
+
+    @Override
+    public SearchSequenceNode setName(final SearchNodeName name) {
+        return super.setName0(name).cast();
     }
 
     @Override
@@ -65,8 +70,8 @@ public final class SearchSequenceNode extends SearchParentNode2 {
     }
 
     @Override
-    SearchParentNode wrap0(final int index, final List<SearchNode> children) {
-        return new SearchSequenceNode(index, children);
+    SearchParentNode replace0(final int index, final SearchNodeName name, final List<SearchNode> children) {
+        return new SearchSequenceNode(index, name, children);
     }
 
     @Override
@@ -192,7 +197,7 @@ public final class SearchSequenceNode extends SearchParentNode2 {
         // only wrap multiple extracted nodes in a SearchSequenceNode.
         return extracted.size() == 1 ?
                 extracted.get(0) :
-                new SearchSequenceNode(NO_PARENT_INDEX, extracted);
+                new SearchSequenceNode(NO_PARENT_INDEX, this.name, extracted);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/search/SearchTextNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchTextNode.java
@@ -30,21 +30,26 @@ public final class SearchTextNode extends SearchLeafNode<String>{
     static SearchTextNode with(final String text, final String value) {
         check(text, value);
 
-        return new SearchTextNode(NO_PARENT_INDEX, text, value);
+        return new SearchTextNode(NO_PARENT_INDEX, NAME, text, value);
     }
 
-    private SearchTextNode(final int index, final String text, final String value) {
-        super(index, text, value);
+    private SearchTextNode(final int index, final SearchNodeName name, final String text, final String value) {
+        super(index, name, text, value);
     }
-    
+
     @Override
-    public SearchNodeName name() {
+    SearchNodeName defaultName() {
         return NAME;
     }
 
     @Override
-    SearchTextNode wrap1(final int index, final String text, final String value) {
-        return new SearchTextNode(index, text, value);
+    public SearchTextNode setName(final SearchNodeName name) {
+        return super.setName0(name).cast();
+    }
+
+    @Override
+    SearchTextNode replace0(final int index, final SearchNodeName name, final String text, final String value) {
+        return new SearchTextNode(index, name, text, value);
     }
 
     @Override
@@ -107,7 +112,7 @@ public final class SearchTextNode extends SearchLeafNode<String>{
     }
 
     @Override
-    final void toString0(final StringBuilder b) {
+    final void toString1(final StringBuilder b) {
         b.append(CharSequences.quoteAndEscape(this.value()));
     }
 }

--- a/src/test/java/walkingkooka/tree/search/SearchBigDecimalNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchBigDecimalNodeTest.java
@@ -64,6 +64,13 @@ public final class SearchBigDecimalNodeTest extends SearchLeafNodeTestCase<Searc
         assertEquals("123", this.createSearchNode("123", BigDecimal.valueOf(123)).toString());
     }
 
+    @Test
+    public void testToStringWithName() {
+        assertEquals("Name123=123",
+                this.createSearchNode("123", BigDecimal.valueOf(123)). setName(SearchNodeName.with("Name123")).toString());
+    }
+
+
     @Override
     SearchBigDecimalNode createSearchNode(final String text, final BigDecimal value) {
         return SearchBigDecimalNode.with(text, value);

--- a/src/test/java/walkingkooka/tree/search/SearchBigIntegerNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchBigIntegerNodeTest.java
@@ -68,6 +68,12 @@ public final class SearchBigIntegerNodeTest extends SearchLeafNodeTestCase<Searc
         assertEquals("234", this.createSearchNode(BigInteger.valueOf(234)).toString());
     }
 
+    @Test
+    public void testToStringWithName() {
+        assertEquals("Name123=12345",
+                this.createSearchNode().setName(SearchNodeName.with("Name123")).toString());
+    }
+
     @Override
     SearchBigIntegerNode createSearchNode(final String text, final BigInteger value) {
         return SearchBigIntegerNode.with(text, value);

--- a/src/test/java/walkingkooka/tree/search/SearchDoubleNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchDoubleNodeTest.java
@@ -67,6 +67,11 @@ public final class SearchDoubleNodeTest extends SearchLeafNodeTestCase<SearchDou
         assertEquals("234.5", this.createSearchNode(234.5).toString());
     }
 
+    @Test
+    public void testToStringWithName() {
+        assertEquals("Name123=1234.5", this.createSearchNode().setName(SearchNodeName.with("Name123")).toString());
+    }
+
     private SearchDoubleNode createSearchNode(final double value) {
         return this.createSearchNode(Double.valueOf(value));
     }

--- a/src/test/java/walkingkooka/tree/search/SearchIgnoredNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchIgnoredNodeTest.java
@@ -190,6 +190,11 @@ public final class SearchIgnoredNodeTest extends SearchParentNodeTestCase<Search
         assertEquals("<! \"child\" !>", this.createSearchNode().toString());
     }
 
+    @Test
+    public void testToStringWithName() {
+        assertEquals("Name123<! \"child\" !>", this.createSearchNode().setName(SearchNodeName.with("Name123")).toString());
+    }
+
     @Override
     SearchIgnoredNode createSearchNode() {
         return SearchIgnoredNode.with(this.child());

--- a/src/test/java/walkingkooka/tree/search/SearchLeafNodeEqualityTestCase.java
+++ b/src/test/java/walkingkooka/tree/search/SearchLeafNodeEqualityTestCase.java
@@ -27,6 +27,12 @@ public abstract class SearchLeafNodeEqualityTestCase<N extends SearchLeafNode, V
         this.checkNotEquals(this.createSearchNode(this.differentValue()));
     }
 
+    @Test
+    public final void testDifferentValueBoth() {
+        final V differentValue = this.differentValue();
+        this.checkEquals(this.createSearchNode(differentValue), this.createSearchNode(differentValue));
+    }
+
     public final N createObject() {
         return this.createSearchNode(this.value());
     }

--- a/src/test/java/walkingkooka/tree/search/SearchLocalDateNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchLocalDateNodeTest.java
@@ -73,6 +73,14 @@ public final class SearchLocalDateNodeTest extends SearchLeafNodeTestCase<Search
         assertEquals(DIFFERENT_DATE_STRING, this.createSearchNode(LocalDate.parse(DIFFERENT_DATE_STRING)).toString());
     }
 
+    @Test
+    public void testToStringWithName() {
+        assertEquals("Name123="+ DIFFERENT_DATE_STRING,
+                this.createSearchNode(LocalDate.parse(DIFFERENT_DATE_STRING))
+                        .setName(SearchNodeName.with("Name123"))
+                        .toString());
+    }
+
     private SearchLocalDateNode createSearchNode(final String value) {
         return this.createSearchNode(LocalDate.parse(value));
     }

--- a/src/test/java/walkingkooka/tree/search/SearchLocalDateTimeNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchLocalDateTimeNodeTest.java
@@ -72,6 +72,14 @@ public final class SearchLocalDateTimeNodeTest extends SearchLeafNodeTestCase<Se
         assertEquals(DIFFERENT_DATETIME_STRING, this.createSearchNode(DIFFERENT_DATETIME_STRING).toString());
     }
 
+    @Test
+    public void testToStringWithName() {
+        assertEquals("Name123=" +DIFFERENT_DATETIME_STRING,
+                this.createSearchNode(DIFFERENT_DATETIME_STRING)
+                        .setName(SearchNodeName.with("Name123"))
+                        .toString());
+    }
+
     private SearchLocalDateTimeNode createSearchNode(final String value) {
         return this.createSearchNode(LocalDateTime.parse(value));
     }

--- a/src/test/java/walkingkooka/tree/search/SearchLocalTimeNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchLocalTimeNodeTest.java
@@ -72,6 +72,14 @@ public final class SearchLocalTimeNodeTest extends SearchLeafNodeTestCase<Search
         assertEquals(DIFFERENT_TIME_STRING, this.createSearchNode(LocalTime.parse(DIFFERENT_TIME_STRING)).toString());
     }
 
+    @Test
+    public void testToStringWithName() {
+        assertEquals("Name123=" + DIFFERENT_TIME_STRING,
+                this.createSearchNode(LocalTime.parse(DIFFERENT_TIME_STRING))
+                        .setName(SearchNodeName.with("Name123"))
+                        .toString());
+    }
+
     @Override
     SearchLocalTimeNode createSearchNode(final String text, final LocalTime value) {
         return SearchLocalTimeNode.with(text, value);

--- a/src/test/java/walkingkooka/tree/search/SearchLongNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchLongNodeTest.java
@@ -67,6 +67,14 @@ public final class SearchLongNodeTest extends SearchLeafNodeTestCase<SearchLongN
         assertEquals("234", this.createSearchNode(234L).toString());
     }
 
+    @Test
+    public void testToStringWithName() {
+        assertEquals("Name123=234",
+                this.createSearchNode(234L)
+                        .setName(SearchNodeName.with("Name123"))
+                        .toString());
+    }
+
     private SearchLongNode createSearchNode(final long value) {
         return this.createSearchNode(Long.valueOf(value));
     }

--- a/src/test/java/walkingkooka/tree/search/SearchMetaNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchMetaNodeTest.java
@@ -262,6 +262,12 @@ public final class SearchMetaNodeTest extends SearchParentNodeTestCase<SearchMet
         assertEquals("( \"child\" {attribute-1=attribute-value-1})", this.createSearchNode().toString());
     }
 
+    @Test
+    public void testToStringWithName() {
+        assertEquals("Name123( \"child\" {attribute-1=attribute-value-1})",
+                this.createSearchNode().setName(SearchNodeName.with("Name123")).toString());
+    }
+
     @Override
     SearchMetaNode createSearchNode() {
         return SearchMetaNode.with(this.child(), this.attributes());

--- a/src/test/java/walkingkooka/tree/search/SearchNodeEqualityTestCase.java
+++ b/src/test/java/walkingkooka/tree/search/SearchNodeEqualityTestCase.java
@@ -18,7 +18,19 @@
 
 package walkingkooka.tree.search;
 
+import org.junit.Test;
 import walkingkooka.test.HashCodeEqualsDefinedEqualityTestCase;
 
 public abstract class SearchNodeEqualityTestCase<N extends SearchNode> extends HashCodeEqualsDefinedEqualityTestCase<N> {
+
+    @Test
+    public final void testDifferentName() {
+        this.checkNotEquals(this.createObject().setName(SearchNodeName.with("different")));
+    }
+
+    @Test
+    public final void testDifferentNameBothNotDefault() {
+        final SearchNodeName name = SearchNodeName.with("different");
+        this.checkEquals(this.createObject().setName(name), this.createObject().setName(name));
+    }
 }

--- a/src/test/java/walkingkooka/tree/search/SearchNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/search/SearchNodeTestCase.java
@@ -44,6 +44,33 @@ public abstract class SearchNodeTestCase<N extends SearchNode> extends NodeTestC
         this.publicStaticFactoryCheck(SearchNode.class, "Search", Node.class);
     }
 
+    @Test(expected = NullPointerException.class)
+    public final void testSetNameNullFails() {
+        this.createSearchNode().setName(null);
+    }
+
+    @Test
+    public final void testSetNameSame() {
+        final N node = this.createSearchNode();
+        assertSame(node, node.setName(node.name()));
+    }
+
+    @Test
+    public final void testSetNameDifferent() {
+        final N node = this.createSearchNode();
+        final SearchNodeName name = SearchNodeName.with("different");
+        final N different = node.setName(name).cast();
+        assertNotSame(node, different);
+        assertEquals("name", name, different.name());
+    }
+
+    @Test
+    public final void testSetNameReturnType() throws Exception {
+        final Class<N> type = this.searchNodeType();
+        final Method method = type.getMethod("setName", SearchNodeName.class);
+        assertEquals(method.toGenericString(), type, method.getReturnType());
+    }
+
     @Test
     @Ignore
     public final void testSetSameAttributes() {

--- a/src/test/java/walkingkooka/tree/search/SearchSelectNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchSelectNodeTest.java
@@ -197,6 +197,12 @@ public final class SearchSelectNodeTest extends SearchParentNodeTestCase<SearchS
         assertEquals("< \"child\" >", this.createSearchNode().toString());
     }
 
+    @Test
+    public void testToStringWithName() {
+        assertEquals("Name123< \"child\" >",
+                this.createSearchNode().setName(SearchNodeName.with("Name123")).toString());
+    }
+
     @Override
     SearchSelectNode createSearchNode() {
         return SearchSelectNode.with(this.child());

--- a/src/test/java/walkingkooka/tree/search/SearchSequenceNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchSequenceNodeTest.java
@@ -397,6 +397,11 @@ public final class SearchSequenceNodeTest extends SearchParentNodeTestCase<Searc
         assertEquals("[ \"abcd\", \"EFGH\" ]", this.createSearchNode().toString());
     }
 
+    @Test
+    public void testToStringWithName() {
+        assertEquals("Name123[ \"abcd\", \"EFGH\" ]", this.createSearchNode().setName(SearchNodeName.with("Name123")).toString());
+    }
+
     @Override
     SearchSequenceNode createSearchNode() {
         return SearchSequenceNode.with(this.children());

--- a/src/test/java/walkingkooka/tree/search/SearchTextNodeTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchTextNodeTest.java
@@ -83,6 +83,14 @@ public final class SearchTextNodeTest extends SearchLeafNodeTestCase<SearchTextN
         assertEquals("\"abc\\t123\"", this.createSearchNode("abc\t123").toString());
     }
 
+    @Test
+    public void testToStringWithName() {
+        assertEquals("Name123=\"abc123\"",
+                this.createSearchNode("abc123")
+                        .setName(SearchNodeName.with("Name123"))
+                        .toString());
+    }
+
     @Override
     SearchTextNode createSearchNode(final String text, final String value) {
         return SearchTextNode.with(text, value);


### PR DESCRIPTION
…node.

- TODO Update all toSearchNode implementations to set names on the SearchNodes they create.