### PR TITLE
tree.expression.* tests failing with NullPointerException with code c…

### DIFF
--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctions.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionFunctions.java
@@ -26,115 +26,122 @@ import walkingkooka.type.PublicStaticHelper;
 public final class ExpressionFunctions implements PublicStaticHelper {
 
     /**
-     * {@see ExpressionFunction}
+     * {@see ExpressionBooleanFunction}
      */
-    public static ExpressionFunction<Boolean> booleanExpressionFunction() {
-        return ExpressionTemplateFunction.BOOLEAN;
+    public static ExpressionFunction<Boolean> booleanFunction() {
+        return ExpressionBooleanFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionConcatFunction}
      */
     public static ExpressionFunction<String> concat() {
-        return ExpressionTemplateFunction.CONCAT;
+        return ExpressionConcatFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionContainsFunction}
      */
     public static ExpressionFunction<Boolean> contains() {
-        return ExpressionTemplateFunction.CONTAINS;
+        return ExpressionContainsFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionEndsWithFunction}
      */
     public static ExpressionFunction<Boolean> endsWith() {
-        return ExpressionTemplateFunction.ENDS_WITH;
+        return ExpressionEndsWithFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionFalseFunction}
      */
-    public static ExpressionFunction<Boolean> falseExpressionFunction() {
-        return ExpressionTemplateFunction.FALSE;
+    public static ExpressionFunction<Boolean> falseFunction() {
+        return ExpressionFalseFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionNormalizeSpaceFunction}
      */
     public static ExpressionFunction<String> normalizeSpace() {
-        return ExpressionTemplateFunction.NORMALIZE_SPACE;
+        return ExpressionNormalizeSpaceFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionNodeNameFunction}
      */
     public static ExpressionFunction<String> nodeName() {
-        return ExpressionTemplateFunction.NODE_NAME;
+        return ExpressionNodeNameFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionNodePositionFunction}
      */
     public static ExpressionFunction<Number> nodePosition() {
-        return ExpressionTemplateFunction.NODE_POSITION;
+        return ExpressionNodePositionFunction.INSTANCE;
+    }
+
+    /**
+     * {@see ExpressionNotFunction}
+     */
+    public static final ExpressionFunction<Boolean> not(final ExpressionFunction<? extends Object> function) {
+        return ExpressionNotFunction.with(function);
     }
 
     /**
      * {@see ExpressionNumberFunction}
      */
     public static ExpressionFunction<Number> number() {
-        return ExpressionTemplateFunction.NUMBER;
+        return ExpressionNumberFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionStartsWithFunction}
      */
     public static ExpressionFunction<Boolean> startsWith() {
-        return ExpressionTemplateFunction.STARTS_WITH;
+        return ExpressionStartsWithFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionStringLengthFunction}
      */
     public static ExpressionFunction<Number> stringLength() {
-        return ExpressionTemplateFunction.STRING_LENGTH;
+        return ExpressionStringLengthFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionSubstringFunction}
      */
     public static ExpressionFunction<String> substring(final int indexBias) {
-        return ExpressionTemplateFunction.substring(indexBias);
+        return ExpressionSubstringFunction.with(indexBias);
     }
 
     /**
      * {@see ExpressionSubstringAfterFunction}
      */
     public static ExpressionFunction<String> substringAfter() {
-        return ExpressionTemplateFunction.SUBSTRING_AFTER;
+        return ExpressionSubstringAfterFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionSubstringBeforeFunction}
      */
     public static ExpressionFunction<String> substringBefore() {
-        return ExpressionTemplateFunction.SUBSTRING_BEFORE;
+        return ExpressionSubstringBeforeFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionTextFunction}
      */
     public static ExpressionFunction<String> text() {
-        return ExpressionTemplateFunction.TEXT;
+        return ExpressionTextFunction.INSTANCE;
     }
 
     /**
      * {@see ExpressionTrueFunction}
      */
-    public static ExpressionFunction<Boolean> trueExpressionFunction() {
-        return ExpressionTemplateFunction.TRUE;
+    public static ExpressionFunction<Boolean> trueFunction() {
+        return ExpressionTrueFunction.INSTANCE;
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionNotFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionNotFunction.java
@@ -31,7 +31,7 @@ final class ExpressionNotFunction extends ExpressionTemplateFunction<Boolean> {
     /**
      * Factory
      */
-    static final ExpressionNotFunction with(final ExpressionTemplateFunction<Boolean> function) {
+    static final ExpressionNotFunction with(final ExpressionFunction<? extends Object> function) {
         Objects.requireNonNull(function, "function");
         return new ExpressionNotFunction(function);
     }
@@ -39,7 +39,7 @@ final class ExpressionNotFunction extends ExpressionTemplateFunction<Boolean> {
     /**
      * Private ctor
      */
-    private ExpressionNotFunction(final ExpressionTemplateFunction<Boolean> function) {
+    private ExpressionNotFunction(final ExpressionFunction<? extends Object> function) {
         super();
         this.function = function;
     }
@@ -52,7 +52,7 @@ final class ExpressionNotFunction extends ExpressionTemplateFunction<Boolean> {
         return Boolean.valueOf(!context.convert(this.function.apply(parameters, context), Boolean.class));
     }
 
-    private final ExpressionTemplateFunction<Boolean> function;
+    private final ExpressionFunction<? extends Object> function;
 
 
     @Override

--- a/src/main/java/walkingkooka/tree/expression/function/ExpressionTemplateFunction.java
+++ b/src/main/java/walkingkooka/tree/expression/function/ExpressionTemplateFunction.java
@@ -29,40 +29,6 @@ import java.util.List;
  */
 abstract class ExpressionTemplateFunction<T> implements ExpressionFunction<T> {
 
-    final static ExpressionBooleanFunction BOOLEAN = ExpressionBooleanFunction.INSTANCE;
-
-    final static ExpressionConcatFunction CONCAT = ExpressionConcatFunction.INSTANCE;
-
-    final static ExpressionContainsFunction CONTAINS = ExpressionContainsFunction.INSTANCE;
-
-    final static ExpressionEndsWithFunction ENDS_WITH = ExpressionEndsWithFunction.INSTANCE;
-
-    final static ExpressionFalseFunction FALSE = ExpressionFalseFunction.INSTANCE;
-
-    final static ExpressionNodeNameFunction NODE_NAME = ExpressionNodeNameFunction.INSTANCE;
-
-    final static ExpressionNormalizeSpaceFunction NORMALIZE_SPACE = ExpressionNormalizeSpaceFunction.INSTANCE;
-
-    final static ExpressionNumberFunction NUMBER = ExpressionNumberFunction.INSTANCE;
-
-    final static ExpressionNodePositionFunction NODE_POSITION = ExpressionNodePositionFunction.INSTANCE;
-
-    final static ExpressionStartsWithFunction STARTS_WITH = ExpressionStartsWithFunction.INSTANCE;
-
-    final static ExpressionStringLengthFunction STRING_LENGTH = ExpressionStringLengthFunction.INSTANCE;
-
-    final static ExpressionSubstringFunction substring(final int indexBase) {
-        return ExpressionSubstringFunction.with(indexBase);
-    }
-
-    final static ExpressionSubstringAfterFunction SUBSTRING_AFTER = ExpressionSubstringAfterFunction.INSTANCE;
-
-    final static ExpressionSubstringBeforeFunction SUBSTRING_BEFORE = ExpressionSubstringBeforeFunction.INSTANCE;
-
-    final static ExpressionTextFunction TEXT = ExpressionTextFunction.INSTANCE;
-
-    final static ExpressionTrueFunction TRUE = ExpressionTrueFunction.INSTANCE;
-
     /**
      * Package private to limit sub classing.
      */

--- a/src/main/java/walkingkooka/tree/select/BasicNodeSelectorContextFunction.java
+++ b/src/main/java/walkingkooka/tree/select/BasicNodeSelectorContextFunction.java
@@ -46,11 +46,11 @@ final class BasicNodeSelectorContextFunction implements Function<ExpressionNodeN
         // must be init before register calls to avoid NPE.
         this.nameToFunction = Maps.sorted();
 
-        this.register(ExpressionFunctions.booleanExpressionFunction());
+        this.register(ExpressionFunctions.booleanFunction());
         this.register(ExpressionFunctions.concat());
         this.register(ExpressionFunctions.contains());
         this.register(ExpressionFunctions.endsWith());
-        this.register(ExpressionFunctions.falseExpressionFunction());
+        this.register(ExpressionFunctions.falseFunction());
         this.register(ExpressionFunctions.nodeName());
         this.register(ExpressionFunctions.nodePosition());
         this.register(ExpressionFunctions.normalizeSpace());
@@ -61,7 +61,7 @@ final class BasicNodeSelectorContextFunction implements Function<ExpressionNodeN
         this.register(ExpressionFunctions.substringAfter());
         this.register(ExpressionFunctions.substringBefore());
         this.register(ExpressionFunctions.text());
-        this.register(ExpressionFunctions.trueExpressionFunction());
+        this.register(ExpressionFunctions.trueFunction());
     }
 
     private void register(final ExpressionFunction<?> function) {

--- a/src/test/java/walkingkooka/tree/expression/function/ExpressionNotFunctionTest.java
+++ b/src/test/java/walkingkooka/tree/expression/function/ExpressionNotFunctionTest.java
@@ -41,12 +41,12 @@ public final class ExpressionNotFunctionTest extends ExpressionFunctionTestCase<
 
     @Test
     public void testToString() {
-        assertEquals("not(" + ExpressionTemplateFunction.CONTAINS + ")", this.createBiFunction().toString());
+        assertEquals("not(" + ExpressionFunctions.contains() + ")", this.createBiFunction().toString());
     }
 
     @Override
     protected ExpressionNotFunction createBiFunction() {
-        return ExpressionNotFunction.with(ExpressionTemplateFunction.CONTAINS);
+        return ExpressionNotFunction.with(ExpressionFunctions.contains());
     }
 
     @Override


### PR DESCRIPTION
…overage

- ExpressionFunctions: public factory for ExpressionNotFunction.
- Removed static factory/constants for all ExpressionTemplateFunction singleons
- ExpressionFunctions: improved static factory method names.
- pull request #510 from mP1/feature/BasicNodeSelectorContextFunction-ctor-race-fix attempt #2.