### PR TITLE
HttpETagParser uses HttpCharPredicates.whitespace.

### DIFF
--- a/src/main/java/walkingkooka/net/http/HttpETagParser.java
+++ b/src/main/java/walkingkooka/net/http/HttpETagParser.java
@@ -75,7 +75,7 @@ abstract class HttpETagParser {
                     }
                     failInvalidCharacter();
                 case MODE_WHITESPACE:
-                    if (' ' == c) {
+                    if (WHITESPACE.test(c)) {
                         break;
                     }
                     // fall thru intentional...
@@ -166,6 +166,11 @@ abstract class HttpETagParser {
     private final static int MODE_QUOTE_BEGIN = MODE_WEAK + 1;
     private final static int MODE_VALUE = MODE_QUOTE_BEGIN + 1;
     private final static int MODE_FINISHED = MODE_VALUE + 1;
+
+    /**
+     * Matches any whitespace characters.
+     */
+    private final static CharPredicate WHITESPACE = HttpCharPredicates.whitespace();
 
     /**
      * A {@link CharPredicate} used to validate etag tokens.

--- a/src/test/java/walkingkooka/net/http/HttpETagManyParserTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpETagManyParserTest.java
@@ -35,41 +35,74 @@ public final class HttpETagManyParserTest extends HttpETagParserTestCase<HttpETa
     }
 
     @Test
-    public final void testSeparatorWhitespaceFails() {
+    public final void testSeparatorSpaceFails() {
         final String text = "\"ABC\", ";
         this.parseFails(text, HttpETagParser.missingETagValue(text));
     }
 
     @Test
-    public final void testWeakSeparatorWhitespaceFails() {
+    public final void testSeparatorTabFails() {
+        final String text = "\"ABC\",\t";
+        this.parseFails(text, HttpETagParser.missingETagValue(text));
+    }
+
+    @Test
+    public final void testWeakSeparatorSpaceFails() {
         final String text = "W/\"ABC\", ";
         this.parseFails(text, HttpETagParser.missingETagValue(text));
     }
 
     @Test
-    public void testSeveral() {
+    public final void testWeakSeparatorTabFails() {
+        final String text = "W/\"ABC\",\t";
+        this.parseFails(text, HttpETagParser.missingETagValue(text));
+    }
+
+    @Test
+    public void testETagSeparatorETag() {
         this.parseAndCheck2("\"A\",\"B\"",
                 HttpETag.with("A", HttpETagValidator.STRONG),
                 HttpETag.with("B", HttpETagValidator.STRONG));
     }
 
     @Test
-    public void testSeveral2() {
+    public void testETagSeparatorSpaceETag() {
         this.parseAndCheck2("\"A\", \"B\"",
                 HttpETag.with("A", HttpETagValidator.STRONG),
                 HttpETag.with("B", HttpETagValidator.STRONG));
     }
 
     @Test
-    public void testSeveralWeak() {
-        this.parseAndCheck2("W/\"A\", W/\"B\"",
+    public void testETagSeparatorTabETag() {
+        this.parseAndCheck2("\"A\",\t\"B\"",
+                HttpETag.with("A", HttpETagValidator.STRONG),
+                HttpETag.with("B", HttpETagValidator.STRONG));
+    }
+
+    @Test
+    public void testETagSeparatorSpaceSpaceETag() {
+        this.parseAndCheck2("\"A\",  \"B\"",
+                HttpETag.with("A", HttpETagValidator.STRONG),
+                HttpETag.with("B", HttpETagValidator.STRONG));
+    }
+
+    @Test
+    public void testWeakETagSeparatorWeakETag() {
+        this.parseAndCheck2("W/\"A\",W/\"B\"",
                 HttpETag.with("A", HttpETagValidator.WEAK),
                 HttpETag.with("B", HttpETagValidator.WEAK));
     }
 
     @Test
-    public void testSeveralWeak2() {
+    public void testWeakETagSeparatorSpaceWeakETag() {
         this.parseAndCheck2("\"A\", W/\"B\"",
+                HttpETag.with("A", HttpETagValidator.STRONG),
+                HttpETag.with("B", HttpETagValidator.WEAK));
+    }
+
+    @Test
+    public void testWeakETagSeparatorTabWeakETag() {
+        this.parseAndCheck2("\"A\",\tW/\"B\"",
                 HttpETag.with("A", HttpETagValidator.STRONG),
                 HttpETag.with("B", HttpETagValidator.WEAK));
     }


### PR DESCRIPTION
- additional tests.