### PR TITLE
MediaTypeParser naming improvements.

### DIFF
--- a/src/main/java/walkingkooka/net/header/MediaType.java
+++ b/src/main/java/walkingkooka/net/header/MediaType.java
@@ -221,7 +221,7 @@ final public class MediaType implements HeaderValue,
      * Creates a {@link MediaType} breaking up the {@link String text} into type and sub types, ignoring any optional
      * parameters if they are present.
      */
-    public static MediaType parseOne(final String text) {
+    public static MediaType parse(final String text) {
         checkText(text);
 
         return MediaTypeParser.one(text);
@@ -230,10 +230,10 @@ final public class MediaType implements HeaderValue,
 
     /**
      * Creates a list of {@link MediaType}. If the text contains a single header type the results of this will be
-     * identical to {@link #parseOne(String)} except the result will be in a list, which will also be
+     * identical to {@link #parse(String)} except the result will be in a list, which will also be
      * sorted by the q factor of each header type.
      */
-    public static List<MediaType> parseMany(final String text) {
+    public static List<MediaType> parseList(final String text) {
         checkText(text);
 
         return MediaTypeParser.many(text);
@@ -329,7 +329,7 @@ final public class MediaType implements HeaderValue,
 
     /**
      * Formats or converts a list of media types back to a String. Basically
-     * an inverse of {@link #parseMany(String)}.
+     * an inverse of {@link #parseList(String)}.
      */
     public static String format(final List<MediaType> mediaTypes) {
         Objects.requireNonNull(mediaTypes, "mediaTypes");

--- a/src/main/java/walkingkooka/net/header/MediaTypeHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/header/MediaTypeHeaderValueConverter.java
@@ -39,7 +39,7 @@ final class MediaTypeHeaderValueConverter extends HeaderValueConverter2<MediaTyp
 
     @Override
     MediaType parse0(final String value, final Name name) {
-        return MediaType.parseOne(value);
+        return MediaType.parse(value);
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/MediaTypeListHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/header/MediaTypeListHeaderValueConverter.java
@@ -41,7 +41,7 @@ final class MediaTypeListHeaderValueConverter extends HeaderValueConverter2<List
 
     @Override
     List<MediaType> parse0(final String value, final Name name) {
-        return MediaType.parseMany(value);
+        return MediaType.parseList(value);
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/MediaTypeListParser.java
+++ b/src/main/java/walkingkooka/net/header/MediaTypeListParser.java
@@ -27,11 +27,11 @@ import java.util.List;
  * A {@link MediaTypeParser} that parses a header value containing one or more {@link MediaType} separated by commas
  * as appears in some header values.
  */
-final class ManyMediaTypeParser extends MediaTypeParser {
+final class MediaTypeListParser extends MediaTypeParser {
 
-    static List<MediaType> parseMany(final String text) {
+    static List<MediaType> parseList(final String text) {
         final List<MediaType> result = Lists.array();
-        final ManyMediaTypeParser parser = new ManyMediaTypeParser(text);
+        final MediaTypeListParser parser = new MediaTypeListParser(text);
         final int length = text.length();
 
         int mode = MODE_TYPE;
@@ -44,7 +44,7 @@ final class ManyMediaTypeParser extends MediaTypeParser {
         return result;
     }
 
-    private ManyMediaTypeParser(final String text) {
+    private MediaTypeListParser(final String text) {
         super(text);
     }
 

--- a/src/main/java/walkingkooka/net/header/MediaTypeOneParser.java
+++ b/src/main/java/walkingkooka/net/header/MediaTypeOneParser.java
@@ -18,13 +18,13 @@
 
 package walkingkooka.net.header;
 
-final class OneMediaTypeParser extends MediaTypeParser {
+final class MediaTypeOneParser extends MediaTypeParser {
 
-    static MediaType parseOneOrFail(final String text) {
-        return new OneMediaTypeParser(text).parse(MODE_TYPE);
+    static MediaType parseOrFail(final String text) {
+        return new MediaTypeOneParser(text).parse(MODE_TYPE);
     }
 
-    private OneMediaTypeParser(final String text) {
+    private MediaTypeOneParser(final String text) {
         super(text);
     }
 

--- a/src/main/java/walkingkooka/net/header/MediaTypeParser.java
+++ b/src/main/java/walkingkooka/net/header/MediaTypeParser.java
@@ -34,11 +34,11 @@ import java.util.Map;
 abstract class MediaTypeParser {
 
     static MediaType one(final String text) {
-        return OneMediaTypeParser.parseOneOrFail(text);
+        return MediaTypeOneParser.parseOrFail(text);
     }
 
     static List<MediaType> many(final String text) {
-        return ManyMediaTypeParser.parseMany(text);
+        return MediaTypeListParser.parseList(text);
     }
 
     /**

--- a/src/test/java/walkingkooka/net/QFactorWeightComparatorTest.java
+++ b/src/test/java/walkingkooka/net/QFactorWeightComparatorTest.java
@@ -32,24 +32,24 @@ public final class QFactorWeightComparatorTest extends ComparatorTestCase<QFacto
 
     @Test
     public void testLeftHigherQFactor() {
-        this.compareAndCheckLess(MediaType.parseOne("a/b;q=1.0"), MediaType.parseOne("c/d;q=0.5"));
+        this.compareAndCheckLess(MediaType.parse("a/b;q=1.0"), MediaType.parse("c/d;q=0.5"));
     }
 
     @Test
     public void testLeftDefaultedHigherQFactor() {
-        this.compareAndCheckLess(MediaType.parseOne("a/b"), MediaType.parseOne("c/d;q=0.5"));
+        this.compareAndCheckLess(MediaType.parse("a/b"), MediaType.parse("c/d;q=0.5"));
     }
 
     @Test
     public void testSecondDefaultedAndHigherQFactor() {
-        this.compareAndCheckMore(MediaType.parseOne("a/b;q=0.5"), MediaType.parseOne("c/d"));
+        this.compareAndCheckMore(MediaType.parse("a/b;q=0.5"), MediaType.parse("c/d"));
     }
 
     @Test
     public void testListSortedDescending() {
-        final MediaType one = MediaType.parseOne("a/b;q=1.0");
-        final MediaType half = MediaType.parseOne("c/d;q=0.5");
-        final MediaType quarter = MediaType.parseOne("e/f;q=0.25");
+        final MediaType one = MediaType.parse("a/b;q=1.0");
+        final MediaType half = MediaType.parse("c/d;q=0.5");
+        final MediaType quarter = MediaType.parse("e/f;q=0.25");
 
         final List<MediaType> list = Lists.array();
         list.add(quarter);
@@ -63,9 +63,9 @@ public final class QFactorWeightComparatorTest extends ComparatorTestCase<QFacto
 
     @Test
     public void testListSortedDescending2() {
-        final MediaType one = MediaType.parseOne("a/b");
-        final MediaType half = MediaType.parseOne("c/d;q=0.5");
-        final MediaType quarter = MediaType.parseOne("e/f;q=0.25");
+        final MediaType one = MediaType.parse("a/b");
+        final MediaType half = MediaType.parse("c/d;q=0.5");
+        final MediaType quarter = MediaType.parse("e/f;q=0.25");
 
         final List<MediaType> list = Lists.array();
         list.add(quarter);

--- a/src/test/java/walkingkooka/net/header/MediaTypeEqualityTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeEqualityTest.java
@@ -25,43 +25,43 @@ final public class MediaTypeEqualityTest extends HashCodeEqualsDefinedEqualityTe
 
     @Test
     public void testDifferentMimeType() {
-        this.checkNotEquals(MediaType.parseOne("major/different"));
+        this.checkNotEquals(MediaType.parse("major/different"));
     }
 
     @Test
     public void testDifferentParameter() {
-        this.checkNotEquals(MediaType.parseOne("major/minor;parameter=value"));
+        this.checkNotEquals(MediaType.parse("major/minor;parameter=value"));
     }
 
     @Test
     public void testDifferentParameter2() {
-        checkNotEquals(MediaType.parseOne("major/minor;parameter=value"),
-                MediaType.parseOne("major/minor;different=value"));
+        checkNotEquals(MediaType.parse("major/minor;parameter=value"),
+                MediaType.parse("major/minor;different=value"));
     }
 
     @Test
     public void testDifferentParamterOrderStillEqual() {
-        checkEqualsAndHashCode(MediaType.parseOne("a/b;x=1;y=2"),
-                MediaType.parseOne("a/b;y=2;x=1"));
+        checkEqualsAndHashCode(MediaType.parse("a/b;x=1;y=2"),
+                MediaType.parse("a/b;y=2;x=1"));
     }
 
     @Test
     public void testParsedAndBuild() {
-        checkEquals(this.createObject(), MediaType.parseOne("major/minor"));
+        checkEquals(this.createObject(), MediaType.parse("major/minor"));
     }
 
     @Test
     public void testParameterOrderIrrelevant() {
-        checkEquals(MediaType.parseOne("type/subtype;a=1;b=2;c=3"), MediaType.parseOne("type/subtype;c=3;b=2;a=1"));
+        checkEquals(MediaType.parse("type/subtype;a=1;b=2;c=3"), MediaType.parse("type/subtype;c=3;b=2;a=1"));
     }
 
     @Test
     public void testDifferentWhitespaceSameParametersStillEqual() {
-        checkEqualsAndHashCode(MediaType.parseOne("a/b;   x=1"), MediaType.parseOne("a/b;x=1"));
+        checkEqualsAndHashCode(MediaType.parse("a/b;   x=1"), MediaType.parse("a/b;x=1"));
     }
 
     @Override
     protected MediaType createObject() {
-        return MediaType.parseOne("major/minor");
+        return MediaType.parse("major/minor");
     }
 }

--- a/src/test/java/walkingkooka/net/header/MediaTypeListParserTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeListParserTest.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-public final class ManyMediaTypeParserTest extends MediaTypeParserTestCase<ManyMediaTypeParser> {
+public final class MediaTypeListParserTest extends MediaTypeParserTestCase<MediaTypeListParser> {
 
     @Test
     public void testTrailingComma() {
@@ -102,7 +102,7 @@ public final class ManyMediaTypeParserTest extends MediaTypeParserTestCase<ManyM
                                   final String type,
                                   final String subtype,
                                   final Map<MediaTypeParameterName, String> parameters) {
-        final List<MediaType> result = ManyMediaTypeParser.parseMany(text);
+        final List<MediaType> result = MediaTypeListParser.parseList(text);
         assertEquals("parse " + CharSequences.quote(text) + " got " + result, 1, result.size());
         this.check(result.get(0), type, subtype, parameters);
     }
@@ -112,7 +112,7 @@ public final class ManyMediaTypeParserTest extends MediaTypeParserTestCase<ManyM
                                        final String subtype,
                                        final Map<MediaTypeParameterName, String> parameters) {
         final String parsed = text + MediaType.MEDIATYPE_SEPARATOR + text;
-        final List<MediaType> result = ManyMediaTypeParser.parseMany(parsed);
+        final List<MediaType> result = MediaTypeListParser.parseList(parsed);
         assertEquals("parse " + CharSequences.quote(parsed) + " got " + result, 2, result.size());
         this.check(result.get(0), type, subtype, parameters);
         this.check(result.get(1), type, subtype, parameters);
@@ -123,7 +123,7 @@ public final class ManyMediaTypeParserTest extends MediaTypeParserTestCase<ManyM
                                       final String subtype,
                                       final Map<MediaTypeParameterName, String> parameters) {
         final String parsed = "TYPE1/SUBTYPE1," + text + ",TYPE2/SUBTYPE2;x=y," + text;
-        final List<MediaType> result = ManyMediaTypeParser.parseMany(parsed);
+        final List<MediaType> result = MediaTypeListParser.parseList(parsed);
 
         assertEquals("parse " + CharSequences.quote(parsed) + " got " + result, 4, result.size());
 
@@ -137,11 +137,11 @@ public final class ManyMediaTypeParserTest extends MediaTypeParserTestCase<ManyM
     private void parseAndCheck2(final String text, final MediaType...mediaTypes) {
         assertEquals("Incorrect result parsing " + CharSequences.quote(text),
                 Lists.of(mediaTypes),
-                ManyMediaTypeParser.parseMany(text));
+                MediaTypeListParser.parseList(text));
     }
 
     @Override
-    protected Class<ManyMediaTypeParser> type() {
-        return ManyMediaTypeParser.class;
+    protected Class<MediaTypeListParser> type() {
+        return MediaTypeListParser.class;
     }
 }

--- a/src/test/java/walkingkooka/net/header/MediaTypeOneParserTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeOneParserTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
-public final class OneMediaTypeParserTest extends MediaTypeParserTestCase<OneMediaTypeParser> {
+public final class MediaTypeOneParserTest extends MediaTypeParserTestCase<MediaTypeOneParser> {
 
     @Test
     public void testTrailingCommaFails() {
@@ -39,11 +39,11 @@ public final class OneMediaTypeParserTest extends MediaTypeParserTestCase<OneMed
                                        final String type,
                                        final String subtype,
                                        final Map<MediaTypeParameterName, String> parameters) {
-        this.check(MediaType.parseOne(text), type, subtype, parameters);
+        this.check(MediaType.parse(text), type, subtype, parameters);
     }
 
     @Override
-    protected Class<OneMediaTypeParser> type() {
-        return OneMediaTypeParser.class;
+    protected Class<MediaTypeOneParser> type() {
+        return MediaTypeOneParser.class;
     }
 }

--- a/src/test/java/walkingkooka/net/header/MediaTypeParserTestCase.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeParserTestCase.java
@@ -172,7 +172,7 @@ public abstract class MediaTypeParserTestCase<P extends MediaTypeParser> extends
 
     final void parseFails(final String text, final String message) {
         try {
-            MediaType.parseOne(text);
+            MediaType.parse(text);
             fail();
         } catch (final IllegalArgumentException expected) {
             assertEquals("Incorrect failure message", message, expected.getMessage());
@@ -337,7 +337,7 @@ public abstract class MediaTypeParserTestCase<P extends MediaTypeParser> extends
     }
 
     private void parseAndCheck(final String text, final String type, final String subtype) {
-        this.check(MediaType.parseOne(text), type, subtype);
+        this.check(MediaType.parse(text), type, subtype);
     }
 
     abstract void parseAndCheck(final String text,

--- a/src/test/java/walkingkooka/net/header/MediaTypeSerializationTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeSerializationTest.java
@@ -36,7 +36,7 @@ final public class MediaTypeSerializationTest extends SerializationTestCase<Medi
     @Test
     public void testTwoParameters() throws Exception {
         final String raw = "a/b;x=1;y=2";
-        final MediaType mimeType = this.cloneUsingSerialization(MediaType.parseOne(raw));
+        final MediaType mimeType = this.cloneUsingSerialization(MediaType.parse(raw));
         assertEquals("primary", "a", mimeType.type());
         assertEquals("sub", "b", mimeType.subType());
         assertEquals("value", "a/b", mimeType.value());
@@ -49,7 +49,7 @@ final public class MediaTypeSerializationTest extends SerializationTestCase<Medi
 
     @Override
     protected MediaType create() {
-        return MediaType.parseOne("custom/bin;parameter123=value456");
+        return MediaType.parse("custom/bin;parameter123=value456");
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/MediaTypeTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeTest.java
@@ -241,36 +241,36 @@ final public class MediaTypeTest extends HeaderValueTestCase<MediaType> {
     // parse .........................................................................
 
     @Test(expected = NullPointerException.class)
-    public void testParseOneNullFails() {
-        MediaType.parseOne(null);
+    public void testParseNullFails() {
+        MediaType.parse(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testParseOneEmptyFails() {
-        MediaType.parseOne("");
+    public void testParseEmptyFails() {
+        MediaType.parse("");
     }
 
     @Test
-    public void testParseOne() {
-        assertEquals(MediaType.with("type1", "subtype1"), MediaType.parseOne("type1/subtype1"));
+    public void testParse() {
+        assertEquals(MediaType.with("type1", "subtype1"), MediaType.parse("type1/subtype1"));
     }
 
     @Test(expected = NullPointerException.class)
-    public void testParseOneOrManyNullFails() {
-        MediaType.parseMany(null);
+    public void testParseListyNullFails() {
+        MediaType.parseList(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testParseOneOrManyEmptyFails() {
-        MediaType.parseMany("");
+    public void testParseListEmptyFails() {
+        MediaType.parseList("");
     }
 
     @Test
-    public void testParseOneOrMany() {
+    public void testParseList() {
         assertEquals(Lists.of(
                 MediaType.with("type1", "subtype1"),
                 MediaType.with("type2", "subtype2")),
-                MediaType.parseMany("type1/subtype1,type2/subtype2"));
+                MediaType.parseList("type1/subtype1,type2/subtype2"));
     }
 
     // isCompatible .........................................................................
@@ -340,19 +340,19 @@ final public class MediaTypeTest extends HeaderValueTestCase<MediaType> {
     @Test
     public void testToStringParse() {
         final String text = "type/subtype";
-        assertEquals(text, MediaType.parseOne(text).toString());
+        assertEquals(text, MediaType.parse(text).toString());
     }
 
     @Test
     public void testToStringParseWithParameters() {
         final String text = "type/subtype;a=b;c=d";
-        assertEquals(text, MediaType.parseOne(text).toString());
+        assertEquals(text, MediaType.parse(text).toString());
     }
 
     @Test
     public void testToStringParseWithParametersWithQuotes() {
         final String text = "type/subtype;a=b;c=\"d\"";
-        assertEquals(text, MediaType.parseOne(text).toString());
+        assertEquals(text, MediaType.parse(text).toString());
     }
 
     @Test


### PR DESCRIPTION
- Also renamed public MediaType.parse methods to parse and parseList.
- no code changes, only renames.