### PR TITLE
HeaderParameterName case insensitive constant lookup fix

### DIFF
--- a/src/main/java/walkingkooka/net/header/HeaderParameterName.java
+++ b/src/main/java/walkingkooka/net/header/HeaderParameterName.java
@@ -44,7 +44,7 @@ final public class HeaderParameterName<T> implements Name, HashCodeEqualsDefined
     /**
      * A read only cache of already prepared {@link HeaderParameterName names}. These constants are incomplete.
      */
-    final static Map<String, HeaderParameterName> CONSTANTS = Maps.sorted();
+    final static Map<String, HeaderParameterName> CONSTANTS = Maps.sorted(String.CASE_INSENSITIVE_ORDER);
 
     /**
      * Creates and adds a new {@link HeaderParameterName} to the cache being built that handles float header values.

--- a/src/test/java/walkingkooka/net/header/HeaderParameterNameTest.java
+++ b/src/test/java/walkingkooka/net/header/HeaderParameterNameTest.java
@@ -28,6 +28,7 @@ import walkingkooka.text.CharSequences;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 
 final public class HeaderParameterNameTest extends NameTestCase<HeaderParameterName<?>> {
@@ -60,6 +61,13 @@ final public class HeaderParameterNameTest extends NameTestCase<HeaderParameterN
     @Test
     public void testConstantNameReturnsConstant() {
         assertSame(HeaderParameterName.Q, HeaderParameterName.with(HeaderParameterName.Q.value()));
+    }
+
+    @Test
+    public void testConstantNameCaseInsensitiveReturnsConstant() {
+        final String differentCase = HeaderParameterName.Q.value().toLowerCase();
+        assertNotEquals(differentCase, HeaderParameterName.Q.value());
+        assertSame(HeaderParameterName.Q, HeaderParameterName.with(differentCase));
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
- constant map lookup now case insensitive to match name equality checks.