### PR TITLE
MediaType checks parameters.

### DIFF
--- a/src/main/java/walkingkooka/net/header/HeaderValueConverters.java
+++ b/src/main/java/walkingkooka/net/header/HeaderValueConverters.java
@@ -101,6 +101,13 @@ public final class HeaderValueConverters implements PublicStaticHelper {
     }
 
     /**
+     * {@see MediaTypeStringHeaderValueConverter}
+     */
+    public static HeaderValueConverter<String> mediaTypeString() {
+        return MediaTypeStringHeaderValueConverter.INSTANCE;
+    }
+
+    /**
      * {@see OffsetDateTimeHeaderValueConverter}
      */
     public static HeaderValueConverter<OffsetDateTime> offsetDateTime() {

--- a/src/main/java/walkingkooka/net/header/MediaTypeStringHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/header/MediaTypeStringHeaderValueConverter.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.header;
+
+import walkingkooka.naming.Name;
+import walkingkooka.predicate.character.CharPredicate;
+import walkingkooka.predicate.character.CharPredicates;
+
+/**
+ * A {@link HeaderValueConverter} that if necessary adds quotes and escape/encodes such characters.
+ * It assumes any {@link String} to be parsed have had any double quotes removed, and adds them
+ * when necessary
+ */
+final class MediaTypeStringHeaderValueConverter extends HeaderValueConverter2<String> {
+
+    /**
+     * Singleton
+     */
+    final static MediaTypeStringHeaderValueConverter INSTANCE = new MediaTypeStringHeaderValueConverter();
+
+    /**
+     * Private ctor use singleton.
+     */
+    private MediaTypeStringHeaderValueConverter() {
+        super();
+    }
+
+    @Override
+    String parse0(final String value, final Name name) {
+        final StringBuilder raw = new StringBuilder();
+        boolean escaped = false;
+
+        for (char c : value.toCharArray()) {
+            if (escaped) {
+                raw.append(c);
+                escaped = false;
+            } else {
+                if (BACKSLASH == c) {
+                    escaped = true;
+                    continue;
+                }
+                // TODO possibly non ascii characters are still invalid.
+                raw.append(c);
+            }
+        }
+
+        if (escaped) {
+            throw new HeaderValueException(MediaType.invalidCharacter('\\', value.length() - 1, value));
+        }
+        return raw.toString();
+    }
+
+    @Override
+    void check0(final Object value) {
+        this.checkType(value, String.class);
+    }
+
+    /**
+     * <a href="https://tools.ietf.org/html/rfc1341"></a>
+     * <pre>
+     * tspecials :=  "(" / ")" / "<" / ">" / "@"  ; Must be in
+     *                        /  "," / ";" / ":" / "\" / <">  ; quoted-string,
+     *                        /  "/" / "[" / "]" / "?" / "."  ; to use within
+     *                        /  "="                        ; parameter values
+     * </pre>
+     * Backslashes and double quote characters are escaped.
+     */
+    @Override
+    String format0(final String value, final Name name) {
+        StringBuilder b = new StringBuilder();
+        boolean quoteRequired = false;
+
+        for (char c : value.toCharArray()) {
+            if (BACKSLASH == c || DOUBLE_QUOTE == c) {
+                b.append(BACKSLASH);
+                b.append(c);
+                quoteRequired = true;
+                continue;
+            }
+            if (!isTokenCharacter(c)) {
+                b.append(c);
+                quoteRequired = true;
+                continue;
+            }
+            b.append(c);
+        }
+
+        return quoteRequired ?
+                b.insert(0, DOUBLE_QUOTE).append(DOUBLE_QUOTE).toString() :
+                value;
+    }
+
+    private static boolean isTokenCharacter(final char c) {
+        return TOKEN.test(c);
+    }
+
+    private final static CharPredicate TOKEN = CharPredicates.rfc2045Token();
+
+    private final static char BACKSLASH = '\\';
+    private final static char DOUBLE_QUOTE = '"';
+
+    @Override
+    public boolean isString() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return MediaType.class.getSimpleName() + " " + String.class.getSimpleName();
+    }
+}

--- a/src/test/java/walkingkooka/net/header/MediaTypeListParserTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeListParserTest.java
@@ -31,12 +31,18 @@ public final class MediaTypeListParserTest extends MediaTypeParserTestCase<Media
 
     @Test
     public void testTrailingComma() {
-        this.parseAndCheckOne("type/subtype,", TYPE, SUBTYPE, MediaType.NO_PARAMETERS);
+        this.parseAndCheckOne("type/subtype,",
+                TYPE,
+                SUBTYPE,
+                MediaType.NO_PARAMETERS);
     }
 
     @Test
     public void testTrailingComma2() {
-        this.parseAndCheckOne("type/subtype;parameter123=value456,", TYPE, SUBTYPE, parameters("parameter123", "value456"));
+        this.parseAndCheckOne("type/subtype;parameter123=value456,",
+                TYPE,
+                SUBTYPE,
+                parameters("parameter123", "value456"));
     }
 
     @Test
@@ -83,16 +89,16 @@ public final class MediaTypeListParserTest extends MediaTypeParserTestCase<Media
     @Test
     public void testSortedByQFactor() {
         this.parseAndCheck2("type1/subtype1; q=0.25, type2/subtype2; q=1.0, type3/subtype3; q=0.5",
-                MediaType.with("type2", "subtype2").setParameters(this.parameters("q", "1.0")),
-                MediaType.with("type3", "subtype3").setParameters(this.parameters("q", "0.5")),
-                MediaType.with("type1", "subtype1").setParameters(this.parameters("q", "0.25")));
+                MediaType.with("type2", "subtype2").setParameters(this.parameters("q", 1.0f)),
+                MediaType.with("type3", "subtype3").setParameters(this.parameters("q", 0.5f)),
+                MediaType.with("type1", "subtype1").setParameters(this.parameters("q", 0.25f)));
     }
 
     @Override
     final void parseAndCheck(final String text,
                                        final String type,
                                        final String subtype,
-                                       final Map<MediaTypeParameterName, String> parameters) {
+                                       final Map<MediaTypeParameterName<?>, Object> parameters) {
         parseAndCheckOne(text, type, subtype, parameters);
         parseAndCheckRepeated(text, type, subtype, parameters);
         parseAndCheckSeveral(text, type, subtype, parameters);
@@ -101,7 +107,7 @@ public final class MediaTypeListParserTest extends MediaTypeParserTestCase<Media
     private void parseAndCheckOne(final String text,
                                   final String type,
                                   final String subtype,
-                                  final Map<MediaTypeParameterName, String> parameters) {
+                                  final Map<MediaTypeParameterName<?>, Object> parameters) {
         final List<MediaType> result = MediaTypeListParser.parseList(text);
         assertEquals("parse " + CharSequences.quote(text) + " got " + result, 1, result.size());
         this.check(result.get(0), type, subtype, parameters);
@@ -110,7 +116,7 @@ public final class MediaTypeListParserTest extends MediaTypeParserTestCase<Media
     private void parseAndCheckRepeated(final String text,
                                        final String type,
                                        final String subtype,
-                                       final Map<MediaTypeParameterName, String> parameters) {
+                                       final Map<MediaTypeParameterName<?>, Object> parameters) {
         final String parsed = text + MediaType.MEDIATYPE_SEPARATOR + text;
         final List<MediaType> result = MediaTypeListParser.parseList(parsed);
         assertEquals("parse " + CharSequences.quote(parsed) + " got " + result, 2, result.size());
@@ -121,7 +127,7 @@ public final class MediaTypeListParserTest extends MediaTypeParserTestCase<Media
     private void parseAndCheckSeveral(final String text,
                                       final String type,
                                       final String subtype,
-                                      final Map<MediaTypeParameterName, String> parameters) {
+                                      final Map<MediaTypeParameterName<?>, Object> parameters) {
         final String parsed = "TYPE1/SUBTYPE1," + text + ",TYPE2/SUBTYPE2;x=y," + text;
         final List<MediaType> result = MediaTypeListParser.parseList(parsed);
 

--- a/src/test/java/walkingkooka/net/header/MediaTypeOneParserTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeOneParserTest.java
@@ -36,9 +36,9 @@ public final class MediaTypeOneParserTest extends MediaTypeParserTestCase<MediaT
 
     @Override
     final void parseAndCheck(final String text,
-                                       final String type,
-                                       final String subtype,
-                                       final Map<MediaTypeParameterName, String> parameters) {
+                             final String type,
+                             final String subtype,
+                             final Map<MediaTypeParameterName<?>, Object> parameters) {
         this.check(MediaType.parse(text), type, subtype, parameters);
     }
 

--- a/src/test/java/walkingkooka/net/header/MediaTypeParameterNameComparableTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeParameterNameComparableTest.java
@@ -20,9 +20,10 @@ package walkingkooka.net.header;
 
 
 import org.junit.Test;
+import walkingkooka.Cast;
 import walkingkooka.compare.ComparableTestCase;
 
-final public class MediaTypeParameterNameComparableTest extends ComparableTestCase<MediaTypeParameterName> {
+final public class MediaTypeParameterNameComparableTest extends ComparableTestCase<MediaTypeParameterName<?>> {
 
     @Test
     public void testAfter() {
@@ -41,7 +42,7 @@ final public class MediaTypeParameterNameComparableTest extends ComparableTestCa
 
 
     @Override
-    protected MediaTypeParameterName createComparable() {
-        return MediaTypeParameterName.with("parameter");
+    protected MediaTypeParameterName<Object> createComparable() {
+        return Cast.to(MediaTypeParameterName.with("parameter"));
     }
 }

--- a/src/test/java/walkingkooka/net/header/MediaTypeParameterNameTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeParameterNameTest.java
@@ -19,26 +19,26 @@
 package walkingkooka.net.header;
 
 import org.junit.Test;
-import walkingkooka.naming.NameTestCase;
+import walkingkooka.Cast;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 
-final public class MediaTypeParameterNameTest extends NameTestCase<MediaTypeParameterName> {
+final public class MediaTypeParameterNameTest extends HeaderNameTestCase<MediaTypeParameterName<Object>, Object> {
 
     @Test(expected = IllegalArgumentException.class)
-    public void testIncludesWhitespaceFails() {
+    public void testWithIncludesWhitespaceFails() {
         MediaTypeParameterName.with("paramet er");
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testIncludesEqualSignFails() {
+    public void testWithIncludesEqualSignFails() {
         MediaTypeParameterName.with("parameter=value");
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testIncludesSemiColonFails() {
+    public void testWithIncludesSemiColonFails() {
         MediaTypeParameterName.with("parameter=value;header2");
     }
 
@@ -67,12 +67,17 @@ final public class MediaTypeParameterNameTest extends NameTestCase<MediaTypePara
     }
 
     @Override
-    protected MediaTypeParameterName createName(final String name) {
-        return MediaTypeParameterName.with(name);
+    protected MediaTypeParameterName<Object> createName(final String name) {
+        return Cast.to(MediaTypeParameterName.with(name));
     }
 
     @Override
-    protected Class<MediaTypeParameterName> type() {
-        return MediaTypeParameterName.class;
+    protected String nameText() {
+        return "abc123";
+    }
+
+    @Override
+    protected Class<MediaTypeParameterName<Object>> type() {
+        return Cast.to(MediaTypeParameterName.class);
     }
 }

--- a/src/test/java/walkingkooka/net/header/MediaTypeParserTestCase.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeParserTestCase.java
@@ -286,12 +286,12 @@ public abstract class MediaTypeParserTestCase<P extends MediaTypeParser> extends
 
     @Test
     public final void testTypeSubTypeQuotedParameterValueBackslashEscaped() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"val\\\\ue\"", TYPE, SUBTYPE, parameters("parameter", "val\\\\ue"));
+        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"val\\\\ue\"", TYPE, SUBTYPE, parameters("parameter", "val\\ue"));
     }
 
     @Test
     public final void testTypeSubTypeQuotedParameterValueEscapedDoubleQuote() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"val\\\"ue\"", TYPE, SUBTYPE, parameters("parameter", "val\\\"ue"));
+        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"val\\\"ue\"", TYPE, SUBTYPE, parameters("parameter", "val\"ue"));
     }
 
     @Test
@@ -324,12 +324,15 @@ public abstract class MediaTypeParserTestCase<P extends MediaTypeParser> extends
         this.parseAndCheck(TYPE + "/" + SUBTYPE + ";p=v; \t \tp2=v2", TYPE, SUBTYPE, parameters("p", "v", "p2", "v2"));
     }
 
-    final Map<MediaTypeParameterName, String> parameters(final String name, final String value) {
+    final Map<MediaTypeParameterName<?>, Object> parameters(final String name, final Object value) {
         return Maps.one(MediaTypeParameterName.with(name), value);
     }
 
-    final Map<MediaTypeParameterName, String> parameters(final String name, final String value, final String name2, final String value2) {
-        final Map<MediaTypeParameterName, String> parameters = Maps.ordered();
+    final Map<MediaTypeParameterName<?>, Object> parameters(final String name,
+                                                            final Object value,
+                                                            final String name2,
+                                                            final Object value2) {
+        final Map<MediaTypeParameterName<?>, Object> parameters = Maps.ordered();
         parameters.put(MediaTypeParameterName.with(name), value);
         parameters.put(MediaTypeParameterName.with(name2), value2);
 
@@ -343,7 +346,7 @@ public abstract class MediaTypeParserTestCase<P extends MediaTypeParser> extends
     abstract void parseAndCheck(final String text,
                                 final String type,
                                 final String subtype,
-                                final Map<MediaTypeParameterName, String> parameters);
+                                final Map<MediaTypeParameterName<?>, Object> parameters);
 
     final void check(final MediaType mediaType, final String type, final String subtype) {
         check(mediaType, type, subtype, MediaType.NO_PARAMETERS);
@@ -352,7 +355,7 @@ public abstract class MediaTypeParserTestCase<P extends MediaTypeParser> extends
     final void check(final MediaType mediaType,
                      final String type,
                      final String subtype,
-                     final Map<MediaTypeParameterName, String> parameters) {
+                     final Map<MediaTypeParameterName<?>, Object> parameters) {
         assertEquals("type=" + mediaType, type, mediaType.type());
         assertEquals("subType=" + mediaType, subtype, mediaType.subType());
         assertEquals("parameters=" + mediaType, parameters, mediaType.parameters());

--- a/src/test/java/walkingkooka/net/header/MediaTypeStringHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeStringHeaderValueConverterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.header;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import walkingkooka.net.http.HttpHeaderName;
+
+public final class MediaTypeStringHeaderValueConverterTest extends
+        HeaderValueConverterTestCase<MediaTypeStringHeaderValueConverter, String> {
+
+    private final static String TEXT = "abc123";
+
+    @Override
+    protected String requiredPrefix() {
+        return MediaType.class.getSimpleName() + String.class.getSimpleName();
+    }
+
+    @Test
+    @Ignore
+    public void testInvalidHeaderValueFails() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    public void testValue() {
+        this.parseAndFormatAndCheck(TEXT, TEXT);
+    }
+
+    @Test
+    public void testQuotesAdded() {
+        this.formatAndCheck("abc def", "\"abc def\"");
+    }
+
+    @Test
+    public void testIncludesBackslash() {
+        this.parseAndCheck("abc\\\\def", "abc\\def");
+    }
+
+    @Test
+    public void testIncludesBackslash2() {
+        this.formatAndCheck("abc\\def", "\"abc\\\\def\"");
+    }
+
+    @Test
+    public void testIncludesDoubleQuote() {
+        this.parseAndCheck("abc\\\"def", "abc\"def");
+    }
+
+    @Test
+    public void testIncludesDoubleQuote2() {
+        this.formatAndCheck("abc\"def", "\"abc\\\"def\"");
+    }
+
+    @Override
+    protected MediaTypeStringHeaderValueConverter converter() {
+        return MediaTypeStringHeaderValueConverter.INSTANCE;
+    }
+
+    @Override
+    protected HttpHeaderName<String> name() {
+        return HttpHeaderName.CACHE_CONTROL;
+    }
+
+    @Override
+    protected String invalidHeaderValue() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected String value() {
+        return TEXT;
+    }
+
+    @Override
+    protected String converterToString() {
+        return "MediaType String";
+    }
+
+    @Override
+    protected Class<MediaTypeStringHeaderValueConverter> type() {
+        return MediaTypeStringHeaderValueConverter.class;
+    }
+}

--- a/src/test/java/walkingkooka/net/header/MediaTypeTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeTest.java
@@ -182,7 +182,7 @@ final public class MediaTypeTest extends HeaderValueTestCase<MediaType> {
     @Test
     public void testSetParametersDifferent() {
         final MediaType mediaType = this.mediaType();
-        final Map<MediaTypeParameterName, String> parameters = MediaType.NO_PARAMETERS;
+        final Map<MediaTypeParameterName<?>, Object> parameters = MediaType.NO_PARAMETERS;
         final MediaType different = mediaType.setParameters(parameters);
         check(different, TYPE, SUBTYPE, parameters);
     }
@@ -190,7 +190,7 @@ final public class MediaTypeTest extends HeaderValueTestCase<MediaType> {
     @Test
     public void testSetParametersDifferent2() {
         final MediaType mediaType = this.mediaType();
-        final Map<MediaTypeParameterName, String> parameters = Maps.one(MediaTypeParameterName.with("different"), "value789");
+        final Map<MediaTypeParameterName<?>, Object> parameters = Maps.one(MediaTypeParameterName.with("different"), "value789");
         final MediaType different = mediaType.setParameters(parameters);
         check(different, TYPE, SUBTYPE, parameters);
     }
@@ -202,7 +202,7 @@ final public class MediaTypeTest extends HeaderValueTestCase<MediaType> {
     private void check(final MediaType mediaType,
                        final String type,
                        final String subtype,
-                       final Map<MediaTypeParameterName, String> parameters) {
+                       final Map<MediaTypeParameterName<?>, Object> parameters) {
         assertEquals("type=" + mediaType, type, mediaType.type());
         assertEquals("subType=" + mediaType, subtype, mediaType.subType());
         assertEquals("parameters=" + mediaType, parameters, mediaType.parameters());
@@ -212,17 +212,14 @@ final public class MediaTypeTest extends HeaderValueTestCase<MediaType> {
 
     @Test
     public void testQParameterPresent() {
-        this.qFactorWeightAndCheck(this.mediaType().setParameters(parameters(MediaTypeParameterName.Q_FACTOR.value(), "0.5")), 0.5f);
+        this.qFactorWeightAndCheck(this.mediaType()
+                .setParameters(parameters(MediaTypeParameterName.Q_FACTOR.value(), 0.5f)),
+                0.5f);
     }
 
-    @Test
+    @Test(expected = HeaderValueException.class)
     public void testQParameterPresentInvalidFails() {
-        try {
-            this.mediaType().setParameters(parameters(MediaTypeParameterName.Q_FACTOR.value(), "XYZ")).qFactorWeight();
-            fail("Getter should have failed due to invalid q weight");
-        } catch (final IllegalStateException expected) {
-            assertEquals("Invalid q weight parameter XYZ in type/subtype; q=XYZ", expected.getMessage());
-        }
+        this.mediaType().setParameters(parameters(MediaTypeParameterName.Q_FACTOR.value(), "XYZ")).qFactorWeight();
     }
 
     @Test
@@ -421,11 +418,11 @@ final public class MediaTypeTest extends HeaderValueTestCase<MediaType> {
         return MediaType.with(TYPE, SUBTYPE, parameters(), "type/subtype;parameter123=value456");
     }
 
-    private Map<MediaTypeParameterName, String> parameters() {
+    private Map<MediaTypeParameterName<?>, Object> parameters() {
         return this.parameters("parameter123", "value456");
     }
 
-    private Map<MediaTypeParameterName, String> parameters(final String name, final String value) {
+    private Map<MediaTypeParameterName<?>, Object> parameters(final String name, final Object value) {
         return Maps.one(MediaTypeParameterName.with(name), value);
     }
 


### PR DESCRIPTION
- added MediaTypeParameterName type parameter.
- factory and setParameters check map name and values.
- MediaType.parameters Map<MediaTypeParameterName<?>, Object> was Map<MediaTypeParameterName, String>
- MediaTypeStringHeaderValueConverter auto escapes and adds quotes in parse.