### PR TITLE
Introduced HasHeaders.

### DIFF
--- a/src/main/java/walkingkooka/net/http/HasHeaders.java
+++ b/src/main/java/walkingkooka/net/http/HasHeaders.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import java.util.Map;
+
+/**
+ * Defines a contract for a container that includes headers, such as a http request.
+ */
+public interface HasHeaders {
+
+    /**
+     * Returns a {@link Map} view of all headers.
+     */
+    Map<HttpHeaderName<?>, Object> headers();
+}

--- a/src/main/java/walkingkooka/net/http/HttpHeaderName.java
+++ b/src/main/java/walkingkooka/net/http/HttpHeaderName.java
@@ -33,7 +33,6 @@ import walkingkooka.net.header.HeaderValueConverters;
 import walkingkooka.net.header.HeaderValueToken;
 import walkingkooka.net.header.MediaType;
 import walkingkooka.net.http.cookie.ClientCookie;
-import walkingkooka.net.http.server.HttpRequest;
 import walkingkooka.net.http.server.HttpResponse;
 import walkingkooka.predicate.character.CharPredicate;
 import walkingkooka.predicate.character.CharPredicates;
@@ -753,16 +752,12 @@ final public class HttpHeaderName<T> implements HeaderName<T>,
     }
 
     /**
-     * A type safe getter that converts any present header values to the header name type.
+     * A type safe getter that retrieves this header from the headers.
      */
-    public Optional<T> headerValue(final HttpRequest request) {
-        Objects.requireNonNull(request, "request");
+    public Optional<T> headerValue(final HasHeaders headers) {
+        Objects.requireNonNull(headers, "headers");
 
-        this.scope.requestHeader(this);
-        final String value = request.headers().get(this);
-        return null != value ?
-                Optional.of(this.toValue0(value)) :
-                Optional.empty();
+        return Optional.ofNullable(Cast.to(headers.headers().get(this)));
     }
 
     /**
@@ -771,10 +766,7 @@ final public class HttpHeaderName<T> implements HeaderName<T>,
     @Override
     public T toValue(final String value) {
         Objects.requireNonNull(value, "value");
-        return this.toValue0(value);
-    }
 
-    private T toValue0(final String value) {
         return this.valueConverter.parse(value, this);
     }
 

--- a/src/main/java/walkingkooka/net/http/server/FakeHttpRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/FakeHttpRequest.java
@@ -52,7 +52,7 @@ public class FakeHttpRequest implements HttpRequest, Fake {
     }
 
     @Override
-    public Map<HttpHeaderName<?>, String> headers() {
+    public Map<HttpHeaderName<?>, Object> headers() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/net/http/server/FakeHttpResponse.java
+++ b/src/main/java/walkingkooka/net/http/server/FakeHttpResponse.java
@@ -22,10 +22,17 @@ import walkingkooka.net.http.HttpHeaderName;
 import walkingkooka.net.http.HttpStatus;
 import walkingkooka.test.Fake;
 
+import java.util.Map;
+
 public class FakeHttpResponse implements HttpResponse, Fake {
 
     @Override
     public void setStatus(final HttpStatus status) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<HttpHeaderName<?>, Object> headers() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/net/http/server/HttpRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpRequest.java
@@ -21,6 +21,7 @@ package walkingkooka.net.http.server;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.net.RelativeUrl;
+import walkingkooka.net.http.HasHeaders;
 import walkingkooka.net.http.HttpHeaderName;
 import walkingkooka.net.http.HttpMethod;
 import walkingkooka.net.http.HttpProtocolVersion;
@@ -33,7 +34,7 @@ import java.util.Map;
 /**
  * Defines a HTTP request.
  */
-public interface HttpRequest {
+public interface HttpRequest extends HasHeaders {
 
     /**
      * An empty {@link Map} with no headers.
@@ -69,11 +70,6 @@ public interface HttpRequest {
      * Returns the {@link HttpMethod method} used to make the request.
      */
     HttpMethod method();
-
-    /**
-     * Returns a {@link Map} view of all request headers.
-     */
-    Map<HttpHeaderName<?>, String> headers();
 
     /**
      * Returns all cookies that appear in the request.

--- a/src/main/java/walkingkooka/net/http/server/HttpResponse.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpResponse.java
@@ -18,13 +18,14 @@
 
 package walkingkooka.net.http.server;
 
+import walkingkooka.net.http.HasHeaders;
 import walkingkooka.net.http.HttpHeaderName;
 import walkingkooka.net.http.HttpStatus;
 
 /**
  * Defines a HTTP response.
  */
-public interface HttpResponse {
+public interface HttpResponse extends HasHeaders {
 
     /**
      * Sets the response status

--- a/src/test/java/walkingkooka/net/http/HttpHeaderNameTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpHeaderNameTest.java
@@ -25,9 +25,7 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.net.header.HeaderNameTestCase;
 import walkingkooka.net.header.MediaType;
-import walkingkooka.net.http.server.FakeHttpRequest;
 import walkingkooka.net.http.server.FakeHttpResponse;
-import walkingkooka.net.http.server.HttpRequests;
 import walkingkooka.net.http.server.HttpResponses;
 import walkingkooka.text.CharSequences;
 
@@ -107,53 +105,41 @@ final public class HttpHeaderNameTest extends HeaderNameTestCase<HttpHeaderName<
     // headerValue.........................................................................
 
     @Test(expected = NullPointerException.class)
-    public void testHeaderValueNullRequestFails() {
+    public void testHeaderValueNullFails() {
         HttpHeaderName.ALLOW.headerValue(null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testHeaderValueScopeResponseFails() {
-        HttpHeaderName.SERVER.headerValue(HttpRequests.fake());
+    @Test
+    public void testHeaderValueScopeAccept() {
+        this.headerValueAndCheck(HttpHeaderName.ACCEPT,
+                MediaType.parseList("text/html, application/xhtml+xml"));
     }
 
     @Test
-    public void testHeaderValueScopeRequestAcceptRequest() {
-        this.headerValueRequestAndCheck(HttpHeaderName.ACCEPT,
-                "text/html, application/xhtml+xml",
-                Optional.of(Lists.of(
-                        MediaType.with("text", "html"),
-                        MediaType.with("application", "xhtml+xml"))));
+    public void testHeaderValueScopeContentLength() {
+        this.headerValueAndCheck(HttpHeaderName.CONTENT_LENGTH,
+                123L);
     }
 
     @Test
-    public void testHeaderValueScopeRequestContentLengthRequest() {
-        this.headerValueRequestAndCheck(HttpHeaderName.CONTENT_LENGTH,
-                "123",
-                Optional.of(123L));
+    public void testHeaderValueScopeResponseContentLengthAbsent() {
+        this.headerValueAndCheck(HttpHeaderName.CONTENT_LENGTH,
+                null);
     }
 
     @Test
-    public void testHeaderValueScopeRequestResponseContentLengthAbsentRequest() {
-        this.headerValueRequestAndCheck(HttpHeaderName.CONTENT_LENGTH,
-                null,
-                Optional.empty());
+    public void testHeaderValueScopeUnknown() {
+        this.headerValueAndCheck(HttpHeaderName.with("xyz").stringHeaderValues(),
+                "xyz");
     }
 
-    @Test
-    public void testHeaderValueScopeRequestUnknown() {
-        this.headerValueRequestAndCheck(HttpHeaderName.with("xyz").stringHeaderValues(),
-                "xyz",
-                Optional.of("xyz"));
-    }
-
-    private <T> void headerValueRequestAndCheck(final HttpHeaderName<T> headerName,
-                                                final String headerValue,
-                                                final Optional<T> value) {
+    private <T> void headerValueAndCheck(final HttpHeaderName<T> headerName,
+                                                final T headerValue) {
         assertEquals(headerName + "=" + headerValue,
-                value,
-                headerName.headerValue(new FakeHttpRequest() {
+                Optional.ofNullable(headerValue),
+                headerName.headerValue(new HasHeaders() {
                     @Override
-                    public Map<HttpHeaderName<?>, String> headers() {
+                    public Map<HttpHeaderName<?>, Object> headers() {
                         return Maps.one(headerName, headerValue);
                     }
                 }));
@@ -190,7 +176,7 @@ final public class HttpHeaderNameTest extends HeaderNameTestCase<HttpHeaderName<
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testAddHeaderScopeRequestFails() {
+    public void testAddHeaderScopeFails() {
         HttpHeaderName.USER_AGENT.addHeaderValue("xyz", HttpResponses.fake());
     }
 
@@ -200,7 +186,7 @@ final public class HttpHeaderNameTest extends HeaderNameTestCase<HttpHeaderName<
     }
 
     @Test
-    public void testAddHeaderValueScopeRequestResponse() {
+    public void testAddHeaderValueScopeRequest() {
         this.addHeaderValueAndCheck(HttpHeaderName.CONTENT_LENGTH, 123L);
     }
 


### PR DESCRIPTION
- HasHeaders.headers() returns Map<HttpHeaderName<?>, Object>
- HttpHeaderName.headerValue requires HasHeaders was HttpRequest,
and removed HttpHeaderScope check.
- HttpRequest and HttpResponse implements HasHeaders.