### PR TITLE
HeaderParameterName, HeaderValueWithParameters interfaces introduced.

### DIFF
--- a/src/main/java/walkingkooka/net/header/ContentDisposition.java
+++ b/src/main/java/walkingkooka/net/header/ContentDisposition.java
@@ -37,7 +37,8 @@ import java.util.Objects;
  * Represents a content disposition header and its component values.<br>
  * <a href="https://en.wikipedia.org/wiki/MIME#Content-Disposition"></a>
  */
-public final class ContentDisposition implements HeaderValue, UsesToStringBuilder {
+public final class ContentDisposition implements HeaderValueWithParameters<ContentDispositionParameterName<?>>,
+        UsesToStringBuilder {
 
     /**
      * A constants with no parameters.
@@ -492,10 +493,12 @@ public final class ContentDisposition implements HeaderValue, UsesToStringBuilde
     /**
      * A map view of all parameters to their text or string value.
      */
+    @Override
     public Map<ContentDispositionParameterName<?>, Object> parameters() {
         return this.parameters;
     }
 
+    @Override
     public ContentDisposition setParameters(final Map<ContentDispositionParameterName<?>, Object> parameters) {
         final Map<ContentDispositionParameterName<?>, Object> copy = checkParameters(parameters);
         return this.parameters.equals(copy) ?

--- a/src/main/java/walkingkooka/net/header/ContentDispositionParameterName.java
+++ b/src/main/java/walkingkooka/net/header/ContentDispositionParameterName.java
@@ -68,7 +68,7 @@ import java.util.Optional;
  *                       ; numeric timezones (+HHMM or -HHMM) MUST be used
  * </pre>
  */
-final public class ContentDispositionParameterName<T> implements HeaderName<T>,
+final public class ContentDispositionParameterName<T> implements HeaderParameterName<T>,
         Comparable<ContentDispositionParameterName<?>> {
 
     /**

--- a/src/main/java/walkingkooka/net/header/HeaderNameTestCase.java
+++ b/src/main/java/walkingkooka/net/header/HeaderNameTestCase.java
@@ -24,7 +24,7 @@ import walkingkooka.text.CharSequences;
 
 import static org.junit.Assert.assertEquals;
 
-public abstract class HeaderNameTestCase<N extends HeaderName<V>, V> extends NameTestCase<N> {
+public abstract class HeaderNameTestCase<N extends HeaderName<?>> extends NameTestCase<N> {
 
     // parameterValue...........................................................................................
 

--- a/src/main/java/walkingkooka/net/header/HeaderParameterName.java
+++ b/src/main/java/walkingkooka/net/header/HeaderParameterName.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.header;
+
+import walkingkooka.Cast;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Defines a few methods to retrieve header parameters.
+ */
+public interface HeaderParameterName<V> extends HeaderName<V>{
+
+    /**
+     * Gets a value wrapped in an {@link Optional} in a type safe manner.
+     */
+    default Optional<V> parameterValue(final HeaderValueWithParameters hasParameters) {
+        Objects.requireNonNull(hasParameters, "hasParameters");
+        return Optional.ofNullable(Cast.to(hasParameters.parameters().get(this)));
+    }
+
+    /**
+     * Retrieves the value or throws a {@link HeaderValueException} if absent.
+     */
+    default V parameterValueOrFail(final HeaderValueWithParameters hasParameters) {
+        final Optional<V> value = this.parameterValue(hasParameters);
+        if (!value.isPresent()) {
+            throw new HeaderValueException("Required value is absent for " + this);
+        }
+        return value.get();
+    }
+}

--- a/src/main/java/walkingkooka/net/header/HeaderParameterNameTestCase.java
+++ b/src/main/java/walkingkooka/net/header/HeaderParameterNameTestCase.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.header;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class HeaderParameterNameTestCase<N extends HeaderParameterName<?>> extends HeaderNameTestCase<N> {
+
+    @Test(expected = NullPointerException.class)
+    public final void testParameterValueNullFails() {
+        this.createName().parameterValue(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public final void testParameterValueOrFailNullFails() {
+        this.createName().parameterValueOrFail(null);
+    }
+
+    protected void parameterValueAndCheckAbsent(final N name,
+                                                final HeaderValueWithParameters<N> hasParameters) {
+        this.parameterValueAndCheck(name, hasParameters, Optional.empty());
+    }
+
+    protected <T> void parameterValueAndCheckPresent(final N name,
+                                                     final HeaderValueWithParameters<N> hasParameters,
+                                                     final T value) {
+        this.parameterValueAndCheck(name, hasParameters, Optional.of(value));
+    }
+
+    protected <T> void parameterValueAndCheck(final N name,
+                                              final HeaderValueWithParameters<N> hasParameters,
+                                              final Optional<T> value) {
+        assertEquals("wrong parameter value " + name + " in " + hasParameters,
+                value,
+                name.parameterValue(hasParameters));
+    }
+}

--- a/src/main/java/walkingkooka/net/header/HeaderValueToken.java
+++ b/src/main/java/walkingkooka/net/header/HeaderValueToken.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
  * Holds a simple header value, and any accompanying parameters. Parameter values will be of the type
  * compatible with each parameter name.
  */
-public final class HeaderValueToken implements HeaderValue,
+public final class HeaderValueToken implements HeaderValueWithParameters<HeaderValueTokenParameterName<?>>,
         Value<String>,
         HasQFactorWeight,
         UsesToStringBuilder {
@@ -416,10 +416,12 @@ public final class HeaderValueToken implements HeaderValue,
     /**
      * A map view of all parameters to their text or string value.
      */
+    @Override
     public Map<HeaderValueTokenParameterName<?>, Object> parameters() {
         return this.parameters;
     }
 
+    @Override
     public HeaderValueToken setParameters(final Map<HeaderValueTokenParameterName<?>, Object> parameters) {
         final Map<HeaderValueTokenParameterName<?>, Object> copy = checkParameters(parameters);
         return this.parameters.equals(copy) ?

--- a/src/main/java/walkingkooka/net/header/HeaderValueTokenParameterName.java
+++ b/src/main/java/walkingkooka/net/header/HeaderValueTokenParameterName.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 /**
  * The {@link Name} of header parameter value.
  */
-final public class HeaderValueTokenParameterName<T> implements HeaderName<T>,
+final public class HeaderValueTokenParameterName<T> implements HeaderParameterName<T>,
         Comparable<HeaderValueTokenParameterName<?>> {
 
     /**

--- a/src/main/java/walkingkooka/net/header/HeaderValueWithParameters.java
+++ b/src/main/java/walkingkooka/net/header/HeaderValueWithParameters.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.header;
+
+import java.util.Map;
+
+/**
+ * Defines a method to retrieve the parameters from a header.
+ */
+public interface HeaderValueWithParameters<N extends HeaderParameterName<?>> extends HeaderValue{
+
+    /**
+     * A read only map view of all parameters.
+     */
+    Map<N, Object> parameters();
+
+    /**
+     * Would be setter that returns a {@link HeaderValueWithParameters} creating a new instance if the parameters
+     * are different.
+     */
+    HeaderValueWithParameters<N> setParameters(final Map<N, Object> parameters);
+}

--- a/src/main/java/walkingkooka/net/header/HeaderValueWithParametersTestCase.java
+++ b/src/main/java/walkingkooka/net/header/HeaderValueWithParametersTestCase.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.header;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+
+public abstract class HeaderValueWithParametersTestCase<V extends HeaderValueWithParameters<N>,
+        N extends HeaderParameterName<?>> extends HeaderValueTestCase<V> {
+
+    // setParameters ...........................................................................................
+
+    @Test(expected = NullPointerException.class)
+    public final void testSetParametersNullFails() {
+        this.createHeaderValueWithParameters().setParameters(null);
+    }
+
+    @Test
+    public final void testSetParametersSame() {
+        final V headerValueWithParameters = this.createHeaderValueWithParameters();
+        assertSame(headerValueWithParameters, headerValueWithParameters.setParameters(headerValueWithParameters.parameters()));
+    }
+
+    abstract protected V createHeaderValueWithParameters();
+}

--- a/src/main/java/walkingkooka/net/header/MediaType.java
+++ b/src/main/java/walkingkooka/net/header/MediaType.java
@@ -52,8 +52,8 @@ import java.util.stream.Collectors;
  * message/External-body is not case-sensitive.)
  * </pre>
  */
-final public class MediaType implements HeaderValue,
-        Value<String>,
+final public class MediaType implements Value<String>,
+        HeaderValueWithParameters<MediaTypeParameterName<?>>,
         HasQFactorWeight,
         Serializable {
 
@@ -413,10 +413,12 @@ final public class MediaType implements HeaderValue,
     /**
      * Retrieves the parameters.
      */
+    @Override
     public Map<MediaTypeParameterName<?>, Object> parameters() {
         return this.parameters;
     }
 
+    @Override
     public MediaType setParameters(final Map<MediaTypeParameterName<?>, Object> parameters) {
         final Map<MediaTypeParameterName<?>, Object> copy = checkParameters(parameters);
         return this.parameters.equals(copy) ?

--- a/src/main/java/walkingkooka/net/header/MediaTypeParameterName.java
+++ b/src/main/java/walkingkooka/net/header/MediaTypeParameterName.java
@@ -27,14 +27,13 @@ import walkingkooka.text.CaseSensitivity;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 
 /**
  * The {@link Name} of an optional parameter accompanying a {@link MediaType}. Note the name may not contain the whitespace, equals sign, semi colons
  * or commas.
  */
-final public class MediaTypeParameterName<T> implements HeaderName<T>,
+final public class MediaTypeParameterName<T> implements HeaderParameterName<T>,
         Comparable<MediaTypeParameterName<?>>,
         Serializable {
 
@@ -97,15 +96,6 @@ final public class MediaTypeParameterName<T> implements HeaderName<T>,
     }
 
     private final String value;
-
-    /**
-     * A type safe getter that fetches a parameter value wrapped in an {@link Optional}.
-     */
-    public Optional<T> parameterValue(final MediaType mediaType) {
-        Objects.requireNonNull(mediaType, "mediaType");
-
-        return Optional.ofNullable(Cast.to(mediaType.parameters().get(this)));
-    }
 
     /**
      * Accepts text and converts it into its value.

--- a/src/test/java/walkingkooka/net/header/ContentDispositionParameterNameTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentDispositionParameterNameTest.java
@@ -28,8 +28,7 @@ import java.time.ZoneOffset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
-final public class ContentDispositionParameterNameTest extends HeaderNameTestCase<ContentDispositionParameterName<Object>,
-        Object> {
+final public class ContentDispositionParameterNameTest extends HeaderParameterNameTestCase<ContentDispositionParameterName<?>> {
 
     @Test(expected = IllegalArgumentException.class)
     public void testControlCharacterFails() {
@@ -59,6 +58,28 @@ final public class ContentDispositionParameterNameTest extends HeaderNameTestCas
     @Test
     public void testConstantNameReturnsConstant() {
         assertSame(ContentDispositionParameterName.CREATION_DATE, ContentDispositionParameterName.with(ContentDispositionParameterName.CREATION_DATE.value()));
+    }
+
+    // parameter value......................................................................................
+
+    @Test
+    public void testParameterValueAbsent() {
+        this.parameterValueAndCheckAbsent(ContentDispositionParameterName.CREATION_DATE,
+                this.contentDisposition());
+    }
+
+    @Test
+    public void testParameterValuePresent() {
+        final ContentDispositionParameterName<ContentDispositionFilename> parameter = ContentDispositionParameterName.FILENAME;
+        final ContentDispositionFilename filename = ContentDispositionFilename.with("readme.txt");
+
+        this.parameterValueAndCheckPresent(parameter,
+                this.contentDisposition(),
+                filename);
+    }
+
+    private ContentDisposition contentDisposition() {
+        return ContentDisposition.parse("attachment; filename=readme.txt");
     }
 
     // toValue...........................................................................................
@@ -96,7 +117,7 @@ final public class ContentDispositionParameterNameTest extends HeaderNameTestCas
     }
 
     @Override
-    protected Class<ContentDispositionParameterName<Object>> type() {
+    protected Class<ContentDispositionParameterName<?>> type() {
         return Cast.to(ContentDispositionParameterName.class);
     }
 }

--- a/src/test/java/walkingkooka/net/header/ContentDispositionTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentDispositionTest.java
@@ -30,7 +30,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
-public final class ContentDispositionTest extends HeaderValueTestCase<ContentDisposition> {
+public final class ContentDispositionTest extends HeaderValueWithParametersTestCase<ContentDisposition,
+        ContentDispositionParameterName<?>> {
 
     private final static ContentDispositionType TYPE = ContentDispositionType.ATTACHMENT;
     private final static String PARAMETER_VALUE = "v1";
@@ -54,7 +55,7 @@ public final class ContentDispositionTest extends HeaderValueTestCase<ContentDis
 
     @Test
     public void testWith() {
-        final ContentDisposition token = this.contentDisposition();
+        final ContentDisposition token = this.createHeaderValueWithParameters();
         this.check(token);
     }
 
@@ -62,42 +63,31 @@ public final class ContentDispositionTest extends HeaderValueTestCase<ContentDis
 
     @Test(expected = NullPointerException.class)
     public void testSetTypeNullFails() {
-        this.contentDisposition().setType(null);
+        this.createHeaderValueWithParameters().setType(null);
     }
 
     @Test
     public void testSetTypeSame() {
-        final ContentDisposition token = this.contentDisposition();
-        assertSame(token, token.setType(TYPE));
+        final ContentDisposition disposition = this.createHeaderValueWithParameters();
+        assertSame(disposition, disposition.setType(TYPE));
     }
 
     @Test
     public void testSetTypeDifferent() {
-        final ContentDisposition token = this.contentDisposition();
+        final ContentDisposition disposition = this.createHeaderValueWithParameters();
         final ContentDispositionType type = ContentDispositionType.INLINE;
-        this.check(token.setType(type), type, this.parameters());
-        this.check(token);
+        this.check(disposition.setType(type), type, this.parameters());
+        this.check(disposition);
     }
 
     // setParameters ...........................................................................................
 
-    @Test(expected = NullPointerException.class)
-    public void testSetParametersNullFails() {
-        this.contentDisposition().setParameters(null);
-    }
-
-    @Test
-    public void testSetParametersSame() {
-        final ContentDisposition token = this.contentDisposition();
-        assertSame(token, token.setParameters(this.parameters()));
-    }
-
     @Test
     public void testSetParametersDifferent() {
-        final ContentDisposition token = this.contentDisposition();
+        final ContentDisposition disposition = this.createHeaderValueWithParameters();
         final Map<ContentDispositionParameterName<?>, Object> parameters = this.parameters("different", "2");
-        this.check(token.setParameters(parameters), TYPE, parameters);
-        this.check(token);
+        this.check(disposition.setParameters(parameters), TYPE, parameters);
+        this.check(disposition);
     }
 
     // parse ...................................................................................................
@@ -557,7 +547,7 @@ public final class ContentDispositionTest extends HeaderValueTestCase<ContentDis
 
     @Test
     public void testToStringWithParameters() {
-        this.toStringAndCheck(this.contentDisposition(),
+        this.toStringAndCheck(this.createHeaderValueWithParameters(),
                 "attachment; p1=v1");
     }
 
@@ -574,7 +564,8 @@ public final class ContentDispositionTest extends HeaderValueTestCase<ContentDis
 
     // helpers ...........................................................................................
 
-    private ContentDisposition contentDisposition() {
+    @Override
+    protected ContentDisposition createHeaderValueWithParameters() {
         return ContentDisposition.with(TYPE, this.parameters());
     }
 

--- a/src/test/java/walkingkooka/net/header/HeaderValueTokenParameterNameTest.java
+++ b/src/test/java/walkingkooka/net/header/HeaderValueTokenParameterNameTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 
-final public class HeaderValueTokenParameterNameTest extends HeaderNameTestCase<HeaderValueTokenParameterName<Object>, Object> {
+final public class HeaderValueTokenParameterNameTest extends HeaderParameterNameTestCase<HeaderValueTokenParameterName<?>> {
 
     @Test(expected = IllegalArgumentException.class)
     public void testWithControlCharacterFails() {
@@ -65,17 +65,17 @@ final public class HeaderValueTokenParameterNameTest extends HeaderNameTestCase<
         assertSame(HeaderValueTokenParameterName.Q, HeaderValueTokenParameterName.with(differentCase));
     }
 
-    // parameterValue...........................................................................................
+    // toValue...........................................................................................
 
     @Test
-    public void testParameterValueFloat() {
+    public void testToValueFloat() {
         this.toValueAndCheck(HeaderValueTokenParameterName.Q,
                 "0.75",
                 0.75f);
     }
 
     @Test
-    public void testParameterValueString() {
+    public void testToValueString() {
         this.toValueAndCheck(Cast.to(HeaderValueTokenParameterName.with("xyz")),
                 "abc",
                 "abc");
@@ -100,7 +100,7 @@ final public class HeaderValueTokenParameterNameTest extends HeaderNameTestCase<
     }
 
     @Override
-    protected Class<HeaderValueTokenParameterName<Object>> type() {
+    protected Class<HeaderValueTokenParameterName<?>> type() {
         return Cast.to(HeaderValueTokenParameterName.class);
     }
 }

--- a/src/test/java/walkingkooka/net/header/HeaderValueTokenTest.java
+++ b/src/test/java/walkingkooka/net/header/HeaderValueTokenTest.java
@@ -30,7 +30,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
-public final class HeaderValueTokenTest extends HeaderValueTestCase<HeaderValueToken> {
+public final class HeaderValueTokenTest extends HeaderValueWithParametersTestCase<HeaderValueToken,
+        HeaderValueTokenParameterName<?>> {
 
     private final static String VALUE = "abc";
     private final static String PARAMETER_VALUE = "v1";
@@ -102,20 +103,9 @@ public final class HeaderValueTokenTest extends HeaderValueTestCase<HeaderValueT
 
     // setParameters ...........................................................................................
 
-    @Test(expected = NullPointerException.class)
-    public void testSetParametersNullFails() {
-        this.token().setParameters(null);
-    }
-
     @Test(expected = HeaderValueException.class)
     public void testSetParametersInvalidParameterValueFails() {
         this.token().setParameters(this.parameters("Q", "INVALID!"));
-    }
-
-    @Test
-    public void testSetParametersSame() {
-        final HeaderValueToken token = this.token();
-        assertSame(token, token.setParameters(this.parameters()));
     }
 
     @Test
@@ -599,6 +589,11 @@ public final class HeaderValueTokenTest extends HeaderValueTestCase<HeaderValueT
     }
 
     // helpers ...........................................................................................
+
+    @Override
+    protected HeaderValueToken createHeaderValueWithParameters() {
+        return this.token();
+    }
 
     private HeaderValueToken token() {
         return HeaderValueToken.with(VALUE, this.parameters());

--- a/src/test/java/walkingkooka/net/header/MediaTypeParameterNameTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeParameterNameTest.java
@@ -22,13 +22,11 @@ import org.junit.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.map.Maps;
 
-import java.util.Optional;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 
-final public class MediaTypeParameterNameTest extends HeaderNameTestCase<MediaTypeParameterName<Object>, Object> {
+final public class MediaTypeParameterNameTest extends HeaderParameterNameTestCase<MediaTypeParameterName<?>> {
 
     @Test(expected = IllegalArgumentException.class)
     public void testWithIncludesWhitespaceFails() {
@@ -65,16 +63,10 @@ final public class MediaTypeParameterNameTest extends HeaderNameTestCase<MediaTy
 
     // parameter value......................................................................................
 
-    @Test(expected = NullPointerException.class)
-    public void testParameterValueNullMediaTypeFails() {
-        MediaTypeParameterName.Q_FACTOR.parameterValue(null);
-    }
-
     @Test
     public void testParameterValueAbsent() {
-        this.parameterValueAndCheck(MediaTypeParameterName.Q_FACTOR,
-                this.mediaType(),
-                Optional.empty());
+        this.parameterValueAndCheckAbsent(MediaTypeParameterName.Q_FACTOR,
+                this.mediaType());
     }
 
     @Test
@@ -82,22 +74,16 @@ final public class MediaTypeParameterNameTest extends HeaderNameTestCase<MediaTy
         final MediaTypeParameterName<Float> parameter = MediaTypeParameterName.Q_FACTOR;
         final Float value = 0.75f;
 
-        this.parameterValueAndCheck(parameter,
+        this.parameterValueAndCheckPresent(parameter,
                 this.mediaType().setParameters(Maps.one(parameter, value)),
-                Optional.of(value));
+                value);
     }
 
     private MediaType mediaType() {
         return MediaType.with("type", "subType");
     }
 
-    private <T> void parameterValueAndCheck(final MediaTypeParameterName<T> name,
-                                            final MediaType mediaType,
-                                            final Optional<T> value) {
-        assertEquals("wrong parameter value " + name + " in " + mediaType,
-                value,
-                name.parameterValue(mediaType));
-    }
+    // toString...........................................................................
 
     @Test
     public void testToString() {
@@ -116,7 +102,7 @@ final public class MediaTypeParameterNameTest extends HeaderNameTestCase<MediaTy
     }
 
     @Override
-    protected Class<MediaTypeParameterName<Object>> type() {
+    protected Class<MediaTypeParameterName<?>> type() {
         return Cast.to(MediaTypeParameterName.class);
     }
 }

--- a/src/test/java/walkingkooka/net/header/MediaTypeTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
-final public class MediaTypeTest extends HeaderValueTestCase<MediaType> {
+final public class MediaTypeTest extends HeaderValueWithParametersTestCase<MediaType, MediaTypeParameterName<?>> {
 
     // constants
 
@@ -198,17 +198,6 @@ final public class MediaTypeTest extends HeaderValueTestCase<MediaType> {
     }
 
     // setParameters ..........................................................................................
-
-    @Test(expected = NullPointerException.class)
-    public void testSetParametersNullFails() {
-        this.mediaType().setParameters(null);
-    }
-
-    @Test
-    public void testSetParametersSame() {
-        final MediaType mediaType = this.mediaType();
-        assertSame(mediaType, mediaType.setParameters(parameters()));
-    }
 
     @Test
     public void testSetParametersSameDifferentCase() {
@@ -459,6 +448,11 @@ final public class MediaTypeTest extends HeaderValueTestCase<MediaType> {
     }
 
     // helpers........................................................................................................
+
+    @Override
+    protected MediaType createHeaderValueWithParameters() {
+        return this.mediaType();
+    }
 
     private MediaType mediaType() {
         return MediaType.with(TYPE, SUBTYPE, parameters(), "type/subtype;parameter123=value456");

--- a/src/test/java/walkingkooka/net/http/HttpHeaderNameTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpHeaderNameTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
-final public class HttpHeaderNameTest extends HeaderNameTestCase<HttpHeaderName<Object>, Object> {
+final public class HttpHeaderNameTest extends HeaderNameTestCase<HttpHeaderName<?>> {
 
     @Test(expected = IllegalArgumentException.class)
     public void testControlCharacterFails() {
@@ -253,7 +253,7 @@ final public class HttpHeaderNameTest extends HeaderNameTestCase<HttpHeaderName<
     }
 
     @Override
-    protected Class<HttpHeaderName<Object>> type() {
+    protected Class<HttpHeaderName<?>> type() {
         return Cast.to(HttpHeaderName.class);
     }
 }


### PR DESCRIPTION
- HeaderParameterName extends HeaderName.
- HeaderValueWithParameters extends HeaderValue.
- ContentDisposition, HeaderValueToken and MediaType now implement HeaderValueWithParameters.
- ContentDispositionParameterName, HeaderValueTokenParameterName and MediaTypeParameterNames
 now implement HeaderParameterName.
- Introduced HeaderParameterNameTestCase.