### PR TITLE
CacheControlDirective header value.

### DIFF
--- a/src/main/java/walkingkooka/net/header/HeaderValue.java
+++ b/src/main/java/walkingkooka/net/header/HeaderValue.java
@@ -37,6 +37,11 @@ public interface HeaderValue extends HashCodeEqualsDefined {
     CharacterConstant WILDCARD = CharacterConstant.with('*');
 
     /**
+     * The separator between parameter name and value.
+     */
+    CharacterConstant PARAMETER_NAME_VALUE_SEPARATOR = CharacterConstant.with('=');
+
+    /**
      * Converts this value to its text form.
      */
     String toHeaderText();

--- a/src/main/java/walkingkooka/net/header/HeaderValueWithParameters.java
+++ b/src/main/java/walkingkooka/net/header/HeaderValueWithParameters.java
@@ -28,11 +28,6 @@ import java.util.Map;
 public interface HeaderValueWithParameters<N extends HeaderParameterName<?>> extends HeaderValue{
 
     /**
-     * The separator between parameter name and value.
-     */
-    CharacterConstant PARAMETER_NAME_VALUE_SEPARATOR = CharacterConstant.with('=');
-
-    /**
      * The separator character that separates parameters belonging to a header value.
      */
     CharacterConstant PARAMETER_SEPARATOR = CharacterConstant.with(';');

--- a/src/main/java/walkingkooka/net/http/CacheControlDirective.java
+++ b/src/main/java/walkingkooka/net/http/CacheControlDirective.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import walkingkooka.Cast;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.net.header.HeaderValue;
+import walkingkooka.text.CharSequences;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * <pre>
+ * Cache request directivesSection
+ * Standard Cache-Control directives that can be used by the client in an HTTP request.
+ *
+ * Cache-Control: max-age=<seconds>
+ * Cache-Control: max-stale[=<seconds>]
+ * Cache-Control: min-fresh=<seconds>
+ * Cache-Control: no-cache
+ * Cache-Control: no-store
+ * Cache-Control: no-transform
+ * Cache-Control: only-if-cached
+ * Cache response directivesSection
+ * Standard Cache-Control directives that can be used by the server in an HTTP response.
+ *
+ * Cache-Control: must-revalidate
+ * Cache-Control: no-cache
+ * Cache-Control: no-store
+ * Cache-Control: no-transform
+ * Cache-Control: public
+ * Cache-Control: private
+ * Cache-Control: proxy-revalidate
+ * Cache-Control: max-age=<seconds>
+ * Cache-Control: s-maxage=<seconds>
+ * </pre>
+ */
+public final class CacheControlDirective<T> implements HeaderValue {
+
+    /**
+     * Parses a header value into its {@link List} of {@link CacheControlDirective} equivalent.
+     */
+    public static List<CacheControlDirective<?>> parse(final String text) {
+        return CacheControlDirectiveHttpHeaderParser.parseCacheControlDirectiveList(text);
+    }
+
+    /**
+     * Makes a header text from a list of directives.
+     */
+    public static String toHeaderTextList(final List<CacheControlDirective<?>> directives) {
+        Objects.requireNonNull(directives, "directives");
+
+        return directives.stream()
+                .map(d -> d.toHeaderText())
+                .collect(Collectors.joining(TO_STRING_SEPARATOR));
+    }
+
+    private final static String TO_STRING_SEPARATOR = SEPARATOR + " ";
+
+    // constants................................................................................................
+
+    /**
+     * Registers a directive name including some meta data about its parameters.
+     */
+    private static <T> CacheControlDirective<T> register(final CacheControlDirectiveName<T> name) {
+        final Optional<T> parameter = Optional.empty();
+        name.checkValue(parameter);
+
+        final CacheControlDirective<T> directive = new CacheControlDirective(name, parameter);
+        CONSTANTS.put(name, directive);
+        return directive;
+    }
+
+    /**
+     * Holds all constants directives without a value.
+     */
+    private final static Map<CacheControlDirectiveName<?>, CacheControlDirective> CONSTANTS =
+            Maps.sorted();
+
+    /**
+     * max-stale
+     */
+    public final static CacheControlDirective<Long> MAX_STALE = register(CacheControlDirectiveName.MAX_STALE);
+
+    /**
+     * must-revalidate
+     */
+    public final static CacheControlDirective<Void> MUST_REVALIDATE = register(CacheControlDirectiveName.MUST_REVALIDATE);
+
+    /**
+     * no-cache
+     */
+    public final static CacheControlDirective<Void> NO_CACHE = register(CacheControlDirectiveName.NO_CACHE);
+
+    /**
+     * no-store
+     */
+    public final static CacheControlDirective<Void> NO_STORE = register(CacheControlDirectiveName.NO_STORE);
+
+    /**
+     * no-transform
+     */
+    public final static CacheControlDirective<Void> NO_TRANSFORM = register(CacheControlDirectiveName.NO_TRANSFORM);
+
+    /**
+     * only-if-cached
+     */
+    public final static CacheControlDirective<Void> ONLY_IF_CACHED = register(CacheControlDirectiveName.ONLY_IF_CACHED);
+
+    /**
+     * private
+     */
+    public final static CacheControlDirective<Void> PRIVATE = register(CacheControlDirectiveName.PRIVATE);
+
+    /**
+     * proxy-revalidate
+     */
+    public final static CacheControlDirective<Void> PROXY_REVALIDATE = register(CacheControlDirectiveName.PROXY_REVALIDATE);
+
+    /**
+     * public
+     */
+    public final static CacheControlDirective<Void> PUBLIC = register(CacheControlDirectiveName.PUBLIC);
+
+    /**
+     * Factory that creates a new {@link CacheControlDirective} with the provided name and parameter.
+     */
+    public static <T> CacheControlDirective<T> with(final CacheControlDirectiveName<T> name,
+                                                    final Optional<T> parameter) {
+        Objects.requireNonNull(name, "name");
+        name.checkValue(parameter);
+
+        return parameter.isPresent() ?
+                new CacheControlDirective<T>(name, parameter) :
+                withoutParameter(name, parameter);
+    }
+
+    private static <T> CacheControlDirective<T> withoutParameter(final CacheControlDirectiveName<T> name,
+                                                                 final Optional<T> parameter) {
+        final CacheControlDirective<T> constant = CONSTANTS.get(name);
+        return null != constant ?
+                constant :
+                new CacheControlDirective<T>(name, parameter);
+    }
+
+    /**
+     * Private use constant or factory
+     */
+    CacheControlDirective(final CacheControlDirectiveName<T> name, final Optional<T> parameter) {
+        super();
+        this.name = name;
+        this.parameter = parameter;
+    }
+
+    public CacheControlDirectiveName<T> value() {
+        return this.name;
+    }
+
+    private final CacheControlDirectiveName<T> name;
+
+    /**
+     * Returns the parameter.
+     */
+    public final Optional<T> parameter() {
+        return this.parameter;
+    }
+
+    /**
+     * Would be setter that returns a {@link CacheControlDirective} with the given parameter value
+     * creating a new instance if necessary.
+     */
+    public final CacheControlDirective<T> setParameter(final Optional<T> parameter) {
+        this.name.checkValue(parameter);
+
+        return this.parameter().equals(parameter) ?
+                this :
+                this.replace(parameter);
+    }
+
+    private final Optional<T> parameter;
+
+    /**
+     * Factory that creates a new {@link CacheControlDirective}
+     */
+    private CacheControlDirective<T> replace(final Optional<T> parameter) {
+        return new CacheControlDirective(this.name, parameter);
+    }
+
+    /**
+     * Returns the scope of the directive
+     */
+    public HttpHeaderScope scope() {
+        return this.name.scope;
+    }
+
+    @Override
+    public String toHeaderText() {
+        final String name = this.name.toString();
+        final Optional<T> parameter = this.parameter;
+        return parameter.isPresent() ?
+                name + "=" + CharSequences.quoteIfChars(parameter.get()) :
+                name;
+    }
+
+    // Object.........................................................................................................
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(this.name, this.parameter);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+                other instanceof CacheControlDirective &&
+                        this.equals0(Cast.to(other));
+    }
+
+    private boolean equals0(final CacheControlDirective<?> other) {
+        return this.name.equals(other.name) &&
+                this.parameter().equals(other.parameter());
+    }
+
+    @Override
+    public final String toString() {
+        return this.toHeaderText();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/CacheControlDirectiveExtensionHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/http/CacheControlDirectiveExtensionHeaderValueConverter.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import walkingkooka.naming.Name;
+import walkingkooka.net.header.HeaderValueConverter;
+import walkingkooka.net.header.HeaderValueConverters;
+import walkingkooka.net.header.HeaderValueException;
+import walkingkooka.text.CharSequences;
+
+/**
+ * A converter that accepts both {@link Long} and {@link String} values. This converter is only intended
+ * for extension (non standard) directives which could hold either numbers or quoted text.
+ */
+final class CacheControlDirectiveExtensionHeaderValueConverter extends HttpHeaderValueConverter<Object> {
+
+    /**
+     * Singleton
+     */
+    final static CacheControlDirectiveExtensionHeaderValueConverter INSTANCE = new CacheControlDirectiveExtensionHeaderValueConverter();
+
+    /**
+     * Private ctor use singleton
+     */
+    private CacheControlDirectiveExtensionHeaderValueConverter() {
+        super();
+    }
+
+    /**
+     * Try parsing as a {@link Long} and then {@link String}
+     */
+    @Override
+    Object parse0(final String text, final Name name) throws HeaderValueException, RuntimeException {
+        Object value;
+        try {
+            value = LONG.parse(text, name);
+        } catch (final HeaderValueException cause) {
+            value = STRING.parse(text, name);
+        }
+        return value;
+    }
+
+    /**
+     * Try checking as a {@link Long} and then {@link String}
+     */
+    @Override
+    void check0(final Object value) {
+        try {
+            LONG.check(value);
+        } catch (final HeaderValueException cause) {
+            STRING.check(value);
+        }
+    }
+
+    @Override
+    String toText0(final Object value, final Name name) {
+        String text;
+
+        for (; ; ) {
+            if (value instanceof Long) {
+                text = LONG.toText(Long.class.cast(value), name);
+                break;
+            }
+            if (value instanceof String) {
+                text = STRING.toText(String.class.cast(value), name);
+                break;
+            }
+            throw new HeaderValueException(name + "  value is not a long or string " + CharSequences.quoteIfChars(value));
+        }
+
+        return text;
+    }
+
+    private final static HeaderValueConverter<String> STRING = HeaderValueConverters.rfc2045String();
+    private final static HeaderValueConverter<Long> LONG = HeaderValueConverters.longConverter();
+
+    @Override
+    public String toString() {
+        return CacheControlDirective.class.getSimpleName() + "Extension";
+    }
+}

--- a/src/main/java/walkingkooka/net/http/CacheControlDirectiveHttpHeaderParser.java
+++ b/src/main/java/walkingkooka/net/http/CacheControlDirectiveHttpHeaderParser.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import walkingkooka.Cast;
+import walkingkooka.NeverError;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.net.header.HeaderValue;
+import walkingkooka.predicate.character.CharPredicate;
+import walkingkooka.predicate.character.CharPredicates;
+import walkingkooka.text.CharSequences;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A parser that knows how to parse text holding one or more directives.
+ */
+final class CacheControlDirectiveHttpHeaderParser extends HttpHeaderParser {
+
+    static List<CacheControlDirective<?>> parseCacheControlDirectiveList(final String text) {
+        return new CacheControlDirectiveHttpHeaderParser(text)
+                .parse();
+    }
+
+    private CacheControlDirectiveHttpHeaderParser(String text) {
+        super(text);
+    }
+
+    /**
+     * Parses a header value which must have one or more cache control directives.
+     */
+    private List<CacheControlDirective<?>> parse() {
+        final int length = text.length();
+
+        int mode = MODE_DIRECTIVE_NAME;
+        int start = 0;
+        CacheControlDirectiveName<?> directiveName = null;
+        Optional<?> parameter = Optional.empty();
+
+        while (this.position < length) {
+            final char c = this.text.charAt(this.position);
+            switch (mode) {
+                case MODE_SEPARATOR_WHITESPACE:
+                    if (WHITESPACE.test(c)) {
+                        break;
+                    }
+                    start = this.position;
+                    parameter = Optional.empty();
+                    mode = MODE_DIRECTIVE_NAME;
+                    // fall thru intentional
+                case MODE_DIRECTIVE_NAME:
+                    if (TOKEN.test(c)) {
+                        break;
+                    }
+                    directiveName = this.directiveName(start);
+                    parameter = Optional.empty();
+                    if (SEPARATOR == c) {
+                        this.addParameter(Cast.to(directiveName), parameter);
+                        mode = MODE_SEPARATOR_WHITESPACE;
+                        break;
+                    }
+                    if (directiveName.mayIncludeParameter() && PARAMETER_NAME_VALUE_SEPARATOR == c) {
+                        mode = MODE_PARAMETER_VALUE_INITIAL;
+                        start = this.position + 1;
+                        break;
+                    }
+                    failInvalidCharacter();
+                case MODE_PARAMETER_VALUE_INITIAL:
+                    if (DOUBLE_QUOTE == c) {
+                        mode = MODE_PARAMETER_QUOTED_VALUE;
+                        start = this.position + 1;
+                        break;
+                    }
+                    mode = MODE_PARAMETER_NUMERIC_VALUE;
+                    start = this.position;
+                    // fall thru must be a parameter value
+                case MODE_PARAMETER_NUMERIC_VALUE:
+                    if (DIGIT.test(c)) {
+                        break;
+                    }
+                    if (SEPARATOR == c) {
+                        this.addParameter(directiveName, start, DISALLOW_EMPTY_PARAMETER);
+                        mode = MODE_SEPARATOR_WHITESPACE;
+                        break;
+                    }
+                    failInvalidCharacter();
+                case MODE_PARAMETER_QUOTED_VALUE:
+                    if (DOUBLE_QUOTE == c) {
+                        this.addParameter(directiveName, start, ALLOW_EMPTY_PARAMETER);
+                        mode = MODE_SEPARATOR;
+                        break;
+                    }
+                    if (TOKEN.test(c)) {
+                        break;
+                    }
+                    failInvalidCharacter();
+                case MODE_SEPARATOR:
+                    if (SEPARATOR == c) {
+                        mode = MODE_SEPARATOR_WHITESPACE;
+                        break;
+                    }
+                    failInvalidCharacter();
+                default:
+                    NeverError.unhandledCase(MODE_SEPARATOR_WHITESPACE,
+                            MODE_DIRECTIVE_NAME,
+                            MODE_PARAMETER_VALUE_INITIAL,
+                            MODE_PARAMETER_NUMERIC_VALUE,
+                            MODE_PARAMETER_QUOTED_VALUE,
+                            MODE_SEPARATOR,
+                            MODE_SEPARATOR_WHITESPACE);
+            }
+            this.position++;
+        }
+
+        switch (mode) {
+            case MODE_SEPARATOR_WHITESPACE:
+                break;
+            case MODE_DIRECTIVE_NAME:
+                this.addParameter(Cast.to(this.directiveName(start)), parameter);
+                break;
+            case MODE_PARAMETER_VALUE_INITIAL:
+                this.failMissingParameter();
+            case MODE_PARAMETER_NUMERIC_VALUE:
+                this.addParameter(directiveName, start, DISALLOW_EMPTY_PARAMETER);
+                break;
+            case MODE_PARAMETER_QUOTED_VALUE:
+                this.fail(missingClosingQuote(this.text));
+            case MODE_SEPARATOR:
+                break;
+            default:
+                NeverError.unhandledCase(MODE_SEPARATOR_WHITESPACE,
+                        MODE_DIRECTIVE_NAME,
+                        MODE_PARAMETER_VALUE_INITIAL,
+                        MODE_PARAMETER_NUMERIC_VALUE,
+                        MODE_PARAMETER_QUOTED_VALUE,
+                        MODE_SEPARATOR,
+                        MODE_SEPARATOR_WHITESPACE);
+        }
+
+        return Lists.readOnly(this.directives);
+    }
+
+    private final static int MODE_SEPARATOR_WHITESPACE = 1;
+    private final static int MODE_DIRECTIVE_NAME = MODE_SEPARATOR_WHITESPACE + 1;
+    private final static int MODE_PARAMETER_VALUE_INITIAL = MODE_DIRECTIVE_NAME + 1;
+    private final static int MODE_PARAMETER_NUMERIC_VALUE = MODE_PARAMETER_VALUE_INITIAL + 1;
+    private final static int MODE_PARAMETER_QUOTED_VALUE = MODE_PARAMETER_NUMERIC_VALUE + 1;
+    private final static int MODE_SEPARATOR = MODE_PARAMETER_QUOTED_VALUE + 1;
+
+    private final static CharPredicate TOKEN = CharPredicates.rfc2045Token();
+    private final static CharPredicate DIGIT = CharPredicates.digit();
+
+    private final static char SEPARATOR = HeaderValue.SEPARATOR.character();
+    private final static char PARAMETER_NAME_VALUE_SEPARATOR = HeaderValue.PARAMETER_NAME_VALUE_SEPARATOR.character();
+
+    /**
+     * Factory that creates a new {@link CacheControlDirectiveName}
+     */
+    private CacheControlDirectiveName<?> directiveName(final int start) {
+        final String text = this.text.substring(start, this.position);
+        if (text.isEmpty()) {
+            this.failInvalidCharacter();
+        }
+        return CacheControlDirectiveName.with(text);
+    }
+
+    private final static boolean ALLOW_EMPTY_PARAMETER = true;
+    private final static boolean DISALLOW_EMPTY_PARAMETER = false;
+
+    /**
+     * Factory that creates a {@link CacheControlDirective} after extracting and converting the text of the present value
+     */
+    private <T> void addParameter(final CacheControlDirectiveName<T> name,
+                                  final int start,
+                                  final boolean allowEmpty) {
+        final String parameter = this.text.substring(start, this.position);
+        if (parameter.isEmpty() && !allowEmpty) {
+            this.failMissingParameter();
+        }
+        this.addParameter(name, name.toValue(parameter));
+    }
+
+    /**
+     * Factory that creates a {@link CacheControlDirective} with the given parameter value
+     */
+    private <T> void addParameter(final CacheControlDirectiveName<T> name,
+                                  final Optional<T> parameter) {
+        if (name.requiresParameter() && Optional.empty().equals(parameter)) {
+            if (this.position < this.text.length()) {
+                this.failInvalidCharacter();
+            } else {
+                this.failMissingParameter();
+            }
+        }
+        if (!name.mayIncludeParameter() && !Optional.empty().equals(parameter)) {
+            if (this.position < this.text.length()) {
+                this.failInvalidCharacter();
+            } else {
+                this.failMissingParameter();
+            }
+        }
+        this.directives.add(name.setParameter(parameter));
+    }
+
+    private void failMissingParameter() {
+        fail(missingParameter(this.position, this.text));
+    }
+
+    static String missingParameter(final int start, final String text) {
+        return "Parameter missing at " + start + " in " + CharSequences.quoteAndEscape(text);
+    }
+
+    private final List<CacheControlDirective<?>> directives = Lists.array();
+}

--- a/src/main/java/walkingkooka/net/http/CacheControlDirectiveListHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/http/CacheControlDirectiveListHeaderValueConverter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import walkingkooka.naming.Name;
+
+import java.util.List;
+
+/**
+ * A {@link HttpHeaderValueConverter} that expects a list of {@link CacheControlDirective directives}.
+ */
+final class CacheControlDirectiveListHeaderValueConverter extends HttpHeaderValueConverter<List<CacheControlDirective<?>>> {
+
+    /**
+     * Singleton
+     */
+    final static CacheControlDirectiveListHeaderValueConverter INSTANCE = new CacheControlDirectiveListHeaderValueConverter();
+
+    /**
+     * Private ctor use singleton.
+     */
+    private CacheControlDirectiveListHeaderValueConverter() {
+        super();
+    }
+
+    @Override
+    List<CacheControlDirective<?>> parse0(final String value, final Name name) {
+        return CacheControlDirective.parse(value);
+    }
+
+    @Override
+    void check0(final Object value) {
+        this.checkListOfType(value, CacheControlDirective.class);
+    }
+
+    @Override
+    String toText0(final List<CacheControlDirective<?>> directives, final Name name) {
+        return CacheControlDirective.toHeaderTextList(directives);
+    }
+
+    @Override
+    public String toString() {
+        return toStringListOf(CacheControlDirective.class);
+    }
+}

--- a/src/main/java/walkingkooka/net/http/CacheControlDirectiveName.java
+++ b/src/main/java/walkingkooka/net/http/CacheControlDirectiveName.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import walkingkooka.Cast;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.net.header.HeaderName;
+import walkingkooka.net.header.HeaderValueConverter;
+import walkingkooka.net.header.HeaderValueConverters;
+import walkingkooka.predicate.character.CharPredicate;
+import walkingkooka.predicate.character.CharPredicates;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Holds a cache control directive name.
+ */
+public final class CacheControlDirectiveName<T> implements HeaderName<Optional<T>>, Comparable<CacheControlDirectiveName<?>> {
+
+    /**
+     * Registers one of the parameterless directive names.
+     */
+    private static CacheControlDirectiveName<Void> registerWithoutParameter(final String name,
+                                                                            final HttpHeaderScope scope) {
+        return register(name,
+                CacheControlDirectiveNameParameter.ABSENT,
+                null,
+                scope);
+    }
+
+    /**
+     * Registers a directive name with a required seconds parameter.
+     */
+    private static CacheControlDirectiveName<Long> registerWithRequiredSecondsParameter(final String name,
+                                                                                        final HttpHeaderScope scope) {
+        return register(name,
+                CacheControlDirectiveNameParameter.REQUIRED,
+                HeaderValueConverters.longConverter(),
+                scope);
+    }
+
+    /**
+     * Registers a directive name including some meta data about its parameters.
+     */
+    private static <T> CacheControlDirectiveName<T> register(final String name,
+                                                             final CacheControlDirectiveNameParameter required,
+                                                             final HeaderValueConverter<T> value,
+                                                             final HttpHeaderScope scope) {
+        final CacheControlDirectiveName<T> constant = new CacheControlDirectiveName<T>(name, required, value, scope);
+        CONSTANTS.put(name, constant);
+        return constant;
+    }
+
+    /**
+     * Holds all constants.
+     */
+    private final static Map<String, CacheControlDirectiveName> CONSTANTS = Maps.sorted(String.CASE_INSENSITIVE_ORDER);
+
+    /**
+     * max-age
+     */
+    public final static CacheControlDirectiveName<Long> MAX_AGE = registerWithRequiredSecondsParameter("max-age",
+            HttpHeaderScope.REQUEST_RESPONSE);
+
+    /**
+     * max-stale
+     */
+    public final static CacheControlDirectiveName<Long> MAX_STALE = register("max-stale",
+            CacheControlDirectiveNameParameter.OPTIONAL,
+            HeaderValueConverters.longConverter(),
+            HttpHeaderScope.REQUEST);
+
+    /**
+     * min-fresh
+     */
+    public final static CacheControlDirectiveName<Long> MIN_FRESH = registerWithRequiredSecondsParameter("min-fresh",
+            HttpHeaderScope.REQUEST);
+
+    /**
+     * must-revalidate
+     */
+    public final static CacheControlDirectiveName<Void> MUST_REVALIDATE = registerWithoutParameter("must-revalidate",
+            HttpHeaderScope.RESPONSE);
+
+    /**
+     * no-cache
+     */
+    public final static CacheControlDirectiveName<Void> NO_CACHE = registerWithoutParameter("no-cache",
+            HttpHeaderScope.REQUEST_RESPONSE);
+
+    /**
+     * no-store
+     */
+    public final static CacheControlDirectiveName<Void> NO_STORE = registerWithoutParameter("no-store",
+            HttpHeaderScope.REQUEST_RESPONSE);
+
+    /**
+     * no-transform
+     */
+    public final static CacheControlDirectiveName<Void> NO_TRANSFORM = registerWithoutParameter("no-transform",
+            HttpHeaderScope.REQUEST_RESPONSE);
+
+    /**
+     * only-if-cached
+     */
+    public final static CacheControlDirectiveName<Void> ONLY_IF_CACHED = registerWithoutParameter("only-if-cached",
+            HttpHeaderScope.REQUEST);
+
+    /**
+     * private
+     */
+    public final static CacheControlDirectiveName<Void> PRIVATE = registerWithoutParameter("private",
+            HttpHeaderScope.RESPONSE);
+
+    /**
+     * proxy-revalidate
+     */
+    public final static CacheControlDirectiveName<Void> PROXY_REVALIDATE = registerWithoutParameter("proxy-revalidate",
+            HttpHeaderScope.RESPONSE);
+
+    /**
+     * public
+     */
+    public final static CacheControlDirectiveName<Void> PUBLIC = registerWithoutParameter("public",
+            HttpHeaderScope.RESPONSE);
+
+    /**
+     * s-maxage
+     */
+    public final static CacheControlDirectiveName<Long> S_MAXAGE = registerWithRequiredSecondsParameter("s-maxage",
+            HttpHeaderScope.RESPONSE);
+
+    // token predicates ................................................................................................
+
+    static final CharPredicate INITIAL_CHAR_PREDICATE = CharPredicates.builder()
+            .range('A', 'Z')
+            .range('a', 'z')
+            .range('0', '9')
+            .build()
+            .setToString("Charset initial");
+    static final CharPredicate PART_CHAR_PREDICATE = CharPredicates.rfc2045Token();
+
+    // factory ..........................................................................................................
+
+    /**
+     * Returns a {@link CacheControlDirectiveName}
+     */
+    public static CacheControlDirectiveName<?> with(final String name) {
+        CharPredicates.failIfNullOrEmptyOrInitialAndPartFalse(name,
+                "value",
+                INITIAL_CHAR_PREDICATE,
+                PART_CHAR_PREDICATE);
+
+        final CacheControlDirectiveName directiveName = CONSTANTS.get(name);
+        return null != directiveName ?
+                directiveName :
+                new CacheControlDirectiveName<>(name,
+                        CacheControlDirectiveNameParameter.OPTIONAL,
+                        CacheControlDirectiveExtensionHeaderValueConverter.INSTANCE, // maybe
+                        HttpHeaderScope.UNKNOWN);
+    }
+
+    /**
+     * Private ctor use constant or factory.
+     */
+    private CacheControlDirectiveName(final String name,
+                                      final CacheControlDirectiveNameParameter parameter,
+                                      final HeaderValueConverter<T> converter,
+                                      final HttpHeaderScope scope) {
+        super();
+        this.name = name;
+        this.parameter = parameter;
+        this.converter = converter;
+        this.scope = scope;
+    }
+
+    /**
+     * Returns true if the this directive is an extension which also requires quoted values.
+     */
+    public boolean isExtension() {
+        return CONSTANTS.containsKey(this.name);
+    }
+
+    @Override
+    public String value() {
+        return this.name;
+    }
+
+    private final String name;
+
+    @Override
+    public Optional<T> checkValue(final Object parameter) {
+        Objects.requireNonNull(parameter, "parameter");
+        return this.parameter.check(parameter, this);
+    }
+
+    private final CacheControlDirectiveNameParameter parameter;
+
+    final HeaderValueConverter<T> converter;
+
+    final HttpHeaderScope scope;
+
+    @Override
+    public Optional<T> toValue(final String text) {
+        return Optional.of(this.converter.parse(text, this));
+    }
+
+    boolean mayIncludeParameter() {
+        return this.parameter != CacheControlDirectiveNameParameter.ABSENT;
+    }
+
+    boolean requiresParameter() {
+        return this.parameter == CacheControlDirectiveNameParameter.REQUIRED;
+    }
+
+    /**
+     * Factory that creates a {@link CacheControlDirective} with the parameter which may or may not be empty or present.
+     */
+    CacheControlDirective<T> setParameter(final Optional<T> parameter) {
+        return CacheControlDirective.with(this,
+                this.checkValue(parameter));
+    }
+
+    // Comparable...........................................................................................................
+
+    @Override
+    public final int compareTo(final CacheControlDirectiveName other) {
+        return this.value().compareToIgnoreCase(other.value());
+    }
+
+    // Object...........................................................................................................
+
+    @Override
+    public final int hashCode() {
+        return this.value().hashCode();
+    }
+
+    @Override
+    public final boolean equals(final Object other) {
+        return this == other ||
+                other instanceof CacheControlDirectiveName &&
+                        this.equals0(Cast.to(other));
+    }
+
+    private boolean equals0(final CacheControlDirectiveName other) {
+        return this.compareTo(other) == 0;
+    }
+
+    @Override
+    public String toString() {
+        return this.value();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/CacheControlDirectiveNameParameter.java
+++ b/src/main/java/walkingkooka/net/http/CacheControlDirectiveNameParameter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import walkingkooka.Cast;
+import walkingkooka.net.header.HeaderValueException;
+import walkingkooka.text.CharSequences;
+
+import java.util.Optional;
+
+/**
+ * Additional meta data for a particular cache control directive.
+ */
+enum CacheControlDirectiveNameParameter {
+
+    REQUIRED {
+        @Override
+        <T> Optional<T> check0(final Optional<T> value, final CacheControlDirectiveName<T> name) {
+            if (value.isPresent()) {
+                name.converter.check(value.get());
+            } else {
+                fail("Directive " + name + " missing required parameter.");
+            }
+            return value;
+        }
+    },
+    OPTIONAL {
+        @Override
+        <T> Optional<T> check0(final Optional<T> value, final CacheControlDirectiveName<T> name) {
+            if (value.isPresent()) {
+                name.converter.check(value.get());
+            }
+            return value;
+        }
+    },
+    ABSENT {
+        @Override
+        <T> Optional<T> check0(final Optional<T> value, final CacheControlDirectiveName<T> name) {
+            if (value.isPresent()) {
+                fail("Directive " + name + " does not accept parameter " + CharSequences.quoteIfChars(value));
+            }
+            return value;
+        }
+    };
+
+    final <T> Optional<T> check(final Object value, final CacheControlDirectiveName<T> name) {
+        if (false == value instanceof Optional) {
+            fail("Incorrect parameter type " + CharSequences.quoteIfChars(value) + " for " + name);
+        }
+        return this.check0(Cast.to(value), name);
+    }
+
+    abstract <T> Optional<T> check0(Optional<T> value, final CacheControlDirectiveName<T> name);
+
+    final <T> Optional<T> fail(final String message) {
+        throw new HeaderValueException(message);
+    }
+}

--- a/src/main/java/walkingkooka/net/http/HttpETag.java
+++ b/src/main/java/walkingkooka/net/http/HttpETag.java
@@ -55,14 +55,14 @@ public abstract class HttpETag implements HeaderValue,
      * Parsers a header value holding a single tag.
      */
     public static HttpETag parseOne(final String text) {
-        return HttpETagOneParser.parseOne(text);
+        return HttpETagOneHttpHeaderParser.parseOne(text);
     }
 
     /**
      * Parsers a header value which may hold one or more tags.
      */
     public static List<HttpETag> parseList(final String text) {
-        return HttpETagListParser.parseList(text);
+        return HttpETagListHttpHeaderParser.parseList(text);
     }
 
     /**
@@ -104,7 +104,7 @@ public abstract class HttpETag implements HeaderValue,
     }
 
     static void checkValue(final String value) {
-        CharPredicates.failIfNullOrFalse(value, "value", HttpETagParser.ETAG_VALUE);
+        CharPredicates.failIfNullOrFalse(value, "value", HttpETagHttpHeaderParser.ETAG_VALUE);
     }
 
     // weak...........................................................................................................

--- a/src/main/java/walkingkooka/net/http/HttpETagHttpHeaderParser.java
+++ b/src/main/java/walkingkooka/net/http/HttpETagHttpHeaderParser.java
@@ -19,7 +19,6 @@
 package walkingkooka.net.http;
 
 import walkingkooka.NeverError;
-import walkingkooka.net.header.HeaderValueException;
 import walkingkooka.predicate.character.CharPredicate;
 import walkingkooka.predicate.character.CharPredicates;
 import walkingkooka.text.CharSequences;
@@ -27,15 +26,13 @@ import walkingkooka.text.CharSequences;
 /**
  * Base parser for both tag parsers.
  */
-abstract class HttpETagParser {
+abstract class HttpETagHttpHeaderParser extends HttpHeaderParser{
 
     /**
      * Package private to limit sub classing.
      */
-    HttpETagParser(final String text) {
-        CharSequences.failIfNullOrEmpty(text, "Text");
-        this.text = text;
-        this.position = 0;
+    HttpETagHttpHeaderParser(final String text) {
+        super(text);
     }
 
     /**
@@ -139,15 +136,15 @@ abstract class HttpETagParser {
 
         switch (mode) {
             case MODE_WHITESPACE:
-                throw new HeaderValueException(missingETagValue(text));
+                this.fail(missingETagValue(text));
             case MODE_WEAK_OR_WILDCARD_OR_QUOTE_BEGIN:
-                throw new HeaderValueException(missingETagValue(text));
+                this.fail(missingETagValue(text));
             case MODE_WEAK:
-                throw new HeaderValueException(incompleteWeakIndicator(text));
+                this.fail(incompleteWeakIndicator(text));
             case MODE_QUOTE_BEGIN:
-                throw new HeaderValueException(missingETagValue(text));
+                this.fail(missingETagValue(text));
             case MODE_VALUE:
-                throw new HeaderValueException(missingClosingQuote(text));
+                this.fail(missingClosingQuote(text));
             case MODE_FINISHED:
                 break;
             default:
@@ -185,43 +182,10 @@ abstract class HttpETagParser {
                     .build();
 
     /**
-     * Matches any whitespace characters.<br>
-     * <a href="https://en.wikipedia.org/wiki/Augmented_Backus%E2%80%93Naur_form"></a>
-     * <pre>
-     * HS | SP
-     * </pre>
-     */
-    private final static CharPredicate WHITESPACE = CharPredicates.any("\u0009\u0020")
-            .setToString("SP|HTAB");
-
-    /**
-     * Reports an invalid character within the unparsed text.
-     */
-    final void failInvalidCharacter() {
-        throw new HeaderValueException(invalidCharacter(this.position, this.text));
-    }
-
-    /**
-     * Builds a message to report an invalid or unexpected character.
-     */
-    static String invalidCharacter(final int position, final String text) {
-        return "Invalid character " + CharSequences.quoteIfChars(text.charAt(position)) +
-                " at " + position +
-                " in " + CharSequences.quoteAndEscape(text);
-    }
-
-    /**
      * Reports a missing etag value.
      */
     static String missingETagValue(final String text) {
         return "Missing etag " + CharSequences.quote(text);
-    }
-
-    /**
-     * Reports a missing closing quote.
-     */
-    static String missingClosingQuote(final String text) {
-        return "Missing closing '\"' " + CharSequences.quote(text);
     }
 
     /**
@@ -235,12 +199,4 @@ abstract class HttpETagParser {
      * Called whenever a separator is encountered.
      */
     abstract void separator();
-
-    final String text;
-    int position;
-
-    @Override
-    public final String toString() {
-        return this.position + " " + CharSequences.quote(this.text);
-    }
 }

--- a/src/main/java/walkingkooka/net/http/HttpETagListHttpHeaderParser.java
+++ b/src/main/java/walkingkooka/net/http/HttpETagListHttpHeaderParser.java
@@ -25,11 +25,11 @@ import java.util.List;
 /**
  * A parser that handles comma separated etags.
  */
-final class HttpETagListParser extends HttpETagParser {
+final class HttpETagListHttpHeaderParser extends HttpETagHttpHeaderParser {
 
     static List<HttpETag> parseList(final String text) {
         final List<HttpETag> result = Lists.array();
-        final HttpETagListParser parser = new HttpETagListParser(text);
+        final HttpETagListHttpHeaderParser parser = new HttpETagListHttpHeaderParser(text);
         final int length = text.length();
 
         int mode = MODE_WEAK_OR_WILDCARD_OR_QUOTE_BEGIN;
@@ -41,7 +41,7 @@ final class HttpETagListParser extends HttpETagParser {
         return result;
     }
 
-    private HttpETagListParser(final String text) {
+    private HttpETagListHttpHeaderParser(final String text) {
         super(text);
     }
 

--- a/src/main/java/walkingkooka/net/http/HttpETagOneHttpHeaderParser.java
+++ b/src/main/java/walkingkooka/net/http/HttpETagOneHttpHeaderParser.java
@@ -21,11 +21,11 @@ package walkingkooka.net.http;
 /**
  * A parser that only parses text with a single etag.
  */
-final class HttpETagOneParser extends HttpETagParser {
+final class HttpETagOneHttpHeaderParser extends HttpETagHttpHeaderParser {
 
     static HttpETag parseOne(final String text) {
-        final HttpETagOneParser parser = new HttpETagOneParser(text);
-        final HttpETag tag = parser.parse(HttpETagOneParser.MODE_WEAK_OR_WILDCARD_OR_QUOTE_BEGIN);
+        final HttpETagOneHttpHeaderParser parser = new HttpETagOneHttpHeaderParser(text);
+        final HttpETag tag = parser.parse(HttpETagOneHttpHeaderParser.MODE_WEAK_OR_WILDCARD_OR_QUOTE_BEGIN);
 
         final int position = parser.position;
         if (position != text.length()) {
@@ -34,7 +34,7 @@ final class HttpETagOneParser extends HttpETagParser {
         return tag;
     }
 
-    private HttpETagOneParser(final String text) {
+    private HttpETagOneHttpHeaderParser(final String text) {
         super(text);
     }
 

--- a/src/main/java/walkingkooka/net/http/HttpHeaderName.java
+++ b/src/main/java/walkingkooka/net/http/HttpHeaderName.java
@@ -68,6 +68,18 @@ final public class HttpHeaderName<T> implements HeaderName<T>,
         return registerConstant(header, scope, HeaderValueConverters.absoluteUrl());
     }
 
+
+
+    /**
+     * Creates and adds a new {@link HttpHeaderName} to the cache being built that handles {@link List<CharsetHeaderValue>} header values.
+     */
+    private static HttpHeaderName<List<CacheControlDirective<?>>> registerCacheControlDirectiveListConstant(final String header,
+                                                                                                            final HttpHeaderScope scope) {
+        return registerConstant(header,
+                scope,
+                HttpHeaderValueConverter.cacheControlDirectiveList());
+    }
+
     /**
      * Creates and adds a new {@link HttpHeaderName} to the cache being built that handles {@link List<CharsetHeaderValue>} header values.
      */
@@ -290,8 +302,8 @@ final public class HttpHeaderName<T> implements HeaderName<T>,
      * Cache-Control: s-maxage=<seconds>
      * </pre>
      */
-    public final static HttpHeaderName<String> CACHE_CONTROL = registerStringConstant("Cache-Control",
-            HttpHeaderScope.REQUEST);
+    public final static HttpHeaderName<List<CacheControlDirective<?>>> CACHE_CONTROL = registerCacheControlDirectiveListConstant("Cache-Control",
+            HttpHeaderScope.REQUEST_RESPONSE);
 
     /**
      * A {@link HttpHeaderName} holding <code>Connection</code>

--- a/src/main/java/walkingkooka/net/http/HttpHeaderParser.java
+++ b/src/main/java/walkingkooka/net/http/HttpHeaderParser.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import walkingkooka.net.header.HeaderValueException;
+import walkingkooka.predicate.character.CharPredicate;
+import walkingkooka.predicate.character.CharPredicates;
+import walkingkooka.text.CharSequences;
+
+/**
+ * Base parser for any parser in this package.
+ */
+abstract class HttpHeaderParser {
+
+    /**
+     * Package private to limit sub classing.
+     */
+    HttpHeaderParser(final String text) {
+        CharSequences.failIfNullOrEmpty(text, "Text");
+        this.text = text;
+        this.position = 0;
+    }
+
+    final static char DOUBLE_QUOTE = '"';
+
+    /**
+     * Matches any whitespace characters.<br>
+     * <a href="https://en.wikipedia.org/wiki/Augmented_Backus%E2%80%93Naur_form"></a>
+     * <pre>
+     * HS | SP
+     * </pre>
+     */
+    final static CharPredicate WHITESPACE = CharPredicates.any("\u0009\u0020")
+            .setToString("SP|HTAB");
+
+    /**
+     * Reports an invalid character within the unparsed text.
+     */
+    final void failInvalidCharacter() {
+        this.fail(invalidCharacter(this.position, text));
+    }
+
+    /**
+     * Builds a message to report an invalid or unexpected character.
+     */
+    static String invalidCharacter(final int position, final String text) {
+        return "Invalid character " + CharSequences.quoteIfChars(text.charAt(position)) +
+                " at " + position +
+                " in " + CharSequences.quoteAndEscape(text);
+    }
+
+    /**
+     * Reports a missing closing quote.
+     */
+    static String missingClosingQuote(final String text) {
+        return "Missing closing '\"' " + CharSequences.quote(text);
+    }
+
+    /**
+     * Reports a failure.
+     */
+    static <T> T fail(final String message) {
+        throw new HeaderValueException(message);
+    }
+
+    final String text;
+    int position;
+
+    @Override
+    public final String toString() {
+        return this.position + " " + CharSequences.quote(this.text);
+    }
+}

--- a/src/main/java/walkingkooka/net/http/HttpHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/http/HttpHeaderValueConverter.java
@@ -24,16 +24,23 @@ import walkingkooka.net.header.HeaderValueConverter;
 import walkingkooka.net.header.HeaderValueConverters;
 import walkingkooka.net.header.HeaderValueException;
 import walkingkooka.net.http.cookie.ClientCookie;
-import walkingkooka.net.http.server.HttpRequest;
 import walkingkooka.text.CharSequences;
 
 import java.util.List;
 import java.util.Objects;
 
 /**
- * Base class and contract to assist {@link HttpHeaderName#toValue(HttpRequest)}
+ * Base class and contract to assist {@link HttpHeaderName#toValue(String)} and other header
+ * text to/from values.
  */
 abstract class HttpHeaderValueConverter<T> implements HeaderValueConverter<T> {
+
+    /**
+     * {@see CacheControlDirectiveListHeaderValueConverter}
+     */
+    static HttpHeaderValueConverter<List<CacheControlDirective<?>>> cacheControlDirectiveList() {
+        return CacheControlDirectiveListHeaderValueConverter.INSTANCE;
+    }
 
     /**
      * {@see ClientCookieListHttpHeaderValueConverter}

--- a/src/test/java/walkingkooka/net/header/MediaTypeAutoQuotingStringHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeAutoQuotingStringHeaderValueConverterTest.java
@@ -75,7 +75,7 @@ public final class MediaTypeAutoQuotingStringHeaderValueConverterTest extends
 
     @Override
     protected HttpHeaderName<String> name() {
-        return HttpHeaderName.CACHE_CONTROL;
+        return HttpHeaderName.SERVER;
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/StringHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/StringHeaderValueConverterTest.java
@@ -50,7 +50,7 @@ public final class StringHeaderValueConverterTest extends
 
     @Override
     protected HttpHeaderName<String> name() {
-        return HttpHeaderName.CACHE_CONTROL;
+        return HttpHeaderName.SERVER;
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/http/CacheControlDirectiveEqualityTest.java
+++ b/src/test/java/walkingkooka/net/http/CacheControlDirectiveEqualityTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import org.junit.Test;
+import walkingkooka.test.HashCodeEqualsDefinedEqualityTestCase;
+
+import java.util.Optional;
+
+public final class CacheControlDirectiveEqualityTest extends HashCodeEqualsDefinedEqualityTestCase<CacheControlDirective<Long>> {
+
+    private final static Optional<Long> PARAMETER = Optional.of(123L);
+
+    @Test
+    public void testDifferentParameter() {
+        this.checkNotEquals(this.directiveName().setParameter(Optional.of(456L)));
+    }
+
+    @Test
+    public void testDifferentName() {
+        this.checkNotEquals(CacheControlDirectiveName.S_MAXAGE.setParameter(PARAMETER));
+    }
+
+    @Override
+    protected CacheControlDirective<Long> createObject() {
+        return this.directiveName().setParameter(PARAMETER);
+    }
+
+    private CacheControlDirectiveName<Long> directiveName() {
+        return CacheControlDirectiveName.MAX_AGE;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/CacheControlDirectiveExtensionHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/http/CacheControlDirectiveExtensionHeaderValueConverterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import org.junit.Test;
+import walkingkooka.naming.Name;
+import walkingkooka.net.header.HeaderValueConverterTestCase;
+import walkingkooka.net.header.HeaderValueException;
+
+public final class CacheControlDirectiveExtensionHeaderValueConverterTest extends
+        HeaderValueConverterTestCase<CacheControlDirectiveExtensionHeaderValueConverter, Object> {
+
+    @Test
+    public void testCheckLong() {
+        CacheControlDirectiveExtensionHeaderValueConverter.INSTANCE.check(123L);
+    }
+
+    @Test
+    public void testCheckString() {
+        CacheControlDirectiveExtensionHeaderValueConverter.INSTANCE.check("abc123");
+    }
+
+    @Test
+    public void testParseNumber() {
+        this.parseAndCheck("123", 123L);
+    }
+
+    @Test
+    public void testParseText() {
+        this.parseAndCheck("abc", "abc");
+    }
+
+    @Test
+    public void testToTextNumber() {
+        this.toTextAndCheck(123L, "123");
+    }
+
+    @Test
+    public void testToTextText() {
+        this.toTextAndCheck("abc123", "abc123");
+    }
+
+    @Test(expected = HeaderValueException.class)
+    public void testToTextInvalidValueFail() {
+        CacheControlDirectiveExtensionHeaderValueConverter.INSTANCE
+                .toText(this,
+                        CacheControlDirectiveName.MAX_STALE);
+    }
+
+    @Override
+    protected String requiredPrefix() {
+        return "CacheControlDirectiveExtension";
+    }
+
+    @Override
+    protected String invalidHeaderValue() {
+        return ",";
+    }
+
+    @Override
+    protected String converterToString() {
+        return "CacheControlDirectiveExtension";
+    }
+
+    @Override
+    protected CacheControlDirectiveExtensionHeaderValueConverter converter() {
+        return CacheControlDirectiveExtensionHeaderValueConverter.INSTANCE;
+    }
+
+    @Override
+    protected Name name() {
+        return CacheControlDirectiveName.with("extension");
+    }
+
+    @Override
+    protected Object value() {
+        return "abc123";
+    }
+
+    @Override
+    protected Class<CacheControlDirectiveExtensionHeaderValueConverter> type() {
+        return CacheControlDirectiveExtensionHeaderValueConverter.class;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/CacheControlDirectiveHttpHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/http/CacheControlDirectiveHttpHeaderParserTest.java
@@ -1,0 +1,597 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+
+import java.util.List;
+import java.util.Optional;
+
+public final class CacheControlDirectiveHttpHeaderParserTest extends HttpHeaderParserTestCase<CacheControlDirectiveHttpHeaderParser,
+        List<CacheControlDirective<?>>> {
+
+    @Test
+    public void testSpaceFails() {
+        this.parseInvalidCharacterFails(" ");
+    }
+
+    @Test
+    public void testTabFails() {
+        this.parseInvalidCharacterFails("\t");
+    }
+
+    @Test
+    public void testInvalidCharacterFails() {
+        this.parseInvalidCharacterFails(",");
+    }
+
+    @Test
+    public void testDirective() {
+        this.parseAndCheck2("A", "A");
+    }
+
+    @Test
+    public void testDirectiveParameterSeparatorFails() {
+        this.parseMissingParameterFails("A=");
+    }
+
+    @Test
+    public void testDirectiveParameterSeparatorSpaceFails() {
+        this.parseInvalidCharacterFails("A= ");
+    }
+
+    @Test
+    public void testDirectiveParameterSeparatorTabFails() {
+        this.parseInvalidCharacterFails("A=\t");
+    }
+
+    @Test
+    public void testDirectiveSpaceFails() {
+        this.parseInvalidCharacterFails("A ");
+    }
+
+    @Test
+    public void testDirectiveTabFails() {
+        this.parseInvalidCharacterFails("A\t");
+    }
+
+    @Test
+    public void testDirectiveSeparator() {
+        this.parseAndCheck2("A,", "A");
+    }
+
+    @Test
+    public void testDirectiveSeparatorSpace() {
+        this.parseAndCheck2("A, ", "A");
+    }
+
+    @Test
+    public void testDirectiveSeparatorTab() {
+        this.parseAndCheck2("A,\t", "A");
+    }
+
+    @Test
+    public void testDirectiveParameterQuoteFails() {
+        this.parseMissingClosingQuoteFails("A=\"");
+    }
+
+    @Test
+    public void testDirectiveParameterQuoteInvalidCharFails() {
+        this.parseInvalidCharacterFails("A=\";");
+    }
+
+    @Test
+    public void testDirectiveParameterQuoteInvalidCharFails2() {
+        this.parseInvalidCharacterFails("A=\"B;");
+    }
+
+    @Test
+    public void testDirectiveParameterQuoteUnclosedFails() {
+        this.parseMissingClosingQuoteFails("A=\"BCD");
+    }
+
+    @Test
+    public void testDirectiveParameterNonNumericValueFails() {
+        this.parseInvalidCharacterFails("A=B");
+    }
+
+    @Test
+    public void testDirectiveParameterNonNumericValueFails2() {
+        this.parseInvalidCharacterFails("A=BCD", 'B');
+    }
+
+    @Test
+    public void testDirectiveParameterNumericValue() {
+        this.parseAndCheck2("A=1", "A", 1L);
+    }
+
+    @Test
+    public void testDirectiveParameterNumericValue2() {
+        this.parseAndCheck2("A=123", "A", 123L);
+    }
+
+    @Test
+    public void testDirectiveParameterQuoteValueQuote() {
+        this.parseAndCheck2("A=\"B\"", "A", "B");
+    }
+
+    @Test
+    public void testDirectiveParameterQuoteValueQuote2() {
+        this.parseAndCheck2("A=\"BCD\"", "A", "BCD");
+    }
+
+    @Test
+    public void testDirectiveParameterQuoteValueQuote3() {
+        this.parseAndCheck2("A=\"1\"", "A", 1L); // contents of quotes gets detected as a Long
+    }
+
+    // max-age.....................................................
+
+    @Test
+    public void testMaxAgeWithoutSecondsFails() {
+        this.parseMissingParameterFails("max-age");
+    }
+
+    @Test
+    public void testMaxAgeWithoutSecondsSeparatorFails() {
+        this.parseInvalidCharacterFails("max-age,");
+    }
+
+    @Test
+    public void testMaxAgeWithoutSecondsSpaceSeparatorFails() {
+        this.parseInvalidCharacterFails("max-age ");
+    }
+
+    @Test
+    public void testMaxAgeWithoutSecondsTabSeparatorFails() {
+        this.parseInvalidCharacterFails("max-age\t");
+    }
+
+    @Test
+    public void testMaxAgeInvalidCharacterFails() {
+        this.parseInvalidCharacterFails("max-age=!");
+    }
+
+    @Test
+    public void testMaxAgeInvalidCharacterFails2() {
+        this.parseInvalidCharacterFails("max-age=1!");
+    }
+
+    @Test
+    public void testMaxAgeWithSeconds() {
+        this.parseAndCheck2("max-age=1", "max-age", 1L);
+    }
+
+    @Test
+    public void testMaxAgeWithSeconds2() {
+        this.parseAndCheck2("max-age=23", "max-age", 23L);
+    }
+
+    // max-stale.....................................................
+
+    @Test
+    public void testMaxStaleWithoutSeconds() {
+        this.parseAndCheck2("max-stale", "max-stale");
+    }
+
+    @Test
+    public void testMaxStaleWithoutSecondsSeparator() {
+        this.parseAndCheck2("max-stale,", "max-stale");
+    }
+
+    @Test
+    public void testMaxStaleWithoutSecondsSpace() {
+        this.parseInvalidCharacterFails("max-stale ");
+    }
+
+    @Test
+    public void testMaxStaleWithoutSecondsTab() {
+        this.parseInvalidCharacterFails("max-stale\t");
+    }
+
+    @Test
+    public void testMaxStaleInvalidCharacterFails() {
+        this.parseInvalidCharacterFails("max-stale=!");
+    }
+
+    @Test
+    public void testMaxStaleInvalidCharacterFails2() {
+        this.parseInvalidCharacterFails("max-stale=1!");
+    }
+
+    @Test
+    public void testMaxStaleWithSeconds() {
+        this.parseAndCheck2("max-stale=1", "max-stale", 1L);
+    }
+
+    @Test
+    public void testMaxStaleWithSeconds2() {
+        this.parseAndCheck2("max-stale=23", "max-stale", 23L);
+    }
+
+    // must-revalidate.....................................................
+
+    @Test
+    public void testMustRevalidateWithoutSecondsSpaceFails() {
+        this.parseInvalidCharacterFails("must-revalidate ");
+    }
+
+    @Test
+    public void testMustRevalidateWithoutSecondsTabFails() {
+        this.parseInvalidCharacterFails("must-revalidate\t");
+    }
+
+    @Test
+    public void testMustRevalidateParameterSeparatorFails() {
+        this.parseInvalidCharacterFails("must-revalidate=");
+    }
+
+    @Test
+    public void testMustRevalidateSeparator() {
+        this.parseAndCheck2("must-revalidate,", "must-revalidate");
+    }
+
+    @Test
+    public void testMustRevalidate() {
+        this.parseAndCheck2("must-revalidate", "must-revalidate");
+    }
+
+    // no-cache.....................................................
+
+    @Test
+    public void testNoCacheWithoutSecondsSpaceFails() {
+        this.parseInvalidCharacterFails("no-cache ");
+    }
+
+    @Test
+    public void testNoCacheWithoutSecondsTabFails() {
+        this.parseInvalidCharacterFails("no-cache\t");
+    }
+
+    @Test
+    public void testNoCacheParameterSeparatorFails() {
+        this.parseInvalidCharacterFails("no-cache=");
+    }
+
+    @Test
+    public void testNoCache() {
+        this.parseAndCheck2("no-cache", "no-cache");
+    }
+
+    @Test
+    public void testNoCacheSeparator() {
+        this.parseAndCheck2("no-cache,", "no-cache");
+    }
+
+    // no-store.....................................................
+
+    @Test
+    public void testNoStoreWithoutSecondsSpaceFails() {
+        this.parseInvalidCharacterFails("no-store ");
+    }
+
+    @Test
+    public void testNoStoreWithoutSecondsTabFails() {
+        this.parseInvalidCharacterFails("no-store\t");
+    }
+
+    @Test
+    public void testNoStoreParameterSeparatorFails() {
+        this.parseInvalidCharacterFails("no-store=");
+    }
+
+    @Test
+    public void testNoStore() {
+        this.parseAndCheck2("no-store", "no-store");
+    }
+
+    @Test
+    public void testNoStoreSeparator() {
+        this.parseAndCheck2("no-store,", "no-store");
+    }
+
+    // no-transform.....................................................
+
+    @Test
+    public void testNoTransformWithoutSecondsSpaceFails() {
+        this.parseInvalidCharacterFails("no-transform ");
+    }
+
+    @Test
+    public void testNoTransformWithoutSecondsTabFails() {
+        this.parseInvalidCharacterFails("no-transform\t");
+    }
+
+    @Test
+    public void testNoTransformParameterSeparatorFails() {
+        this.parseInvalidCharacterFails("no-transform=");
+    }
+
+    @Test
+    public void testNoTransform() {
+        this.parseAndCheck2("no-transform", "no-transform");
+    }
+
+    @Test
+    public void testNoTransformSeparator() {
+        this.parseAndCheck2("no-transform,", "no-transform");
+    }
+
+    // public.....................................................
+
+    @Test
+    public void testPublicWithoutSecondsSpaceFails() {
+        this.parseInvalidCharacterFails("public ");
+    }
+
+    @Test
+    public void testPublicWithoutSecondsTabFails() {
+        this.parseInvalidCharacterFails("public\t");
+    }
+
+    @Test
+    public void testPublicParameterSeparatorFails() {
+        this.parseInvalidCharacterFails("public=");
+    }
+
+
+    @Test
+    public void testPublic() {
+        this.parseAndCheck2("public", "public");
+    }
+
+    @Test
+    public void testPublicSeparator() {
+        this.parseAndCheck2("public,", "public");
+    }
+
+    // private.....................................................
+
+    @Test
+    public void testPrivateWithoutSecondsSpaceFails() {
+        this.parseInvalidCharacterFails("private ");
+    }
+
+    @Test
+    public void testPrivateWithoutSecondsTabFails() {
+        this.parseInvalidCharacterFails("private\t");
+    }
+
+    @Test
+    public void testPrivateParameterSeparatorFails() {
+        this.parseInvalidCharacterFails("private=");
+    }
+
+    @Test
+    public void testPrivate() {
+        this.parseAndCheck2("private", "private");
+    }
+
+    @Test
+    public void testPrivateSeparator() {
+        this.parseAndCheck2("private,", "private");
+    }
+
+    // proxy-revalidate.....................................................
+
+    @Test
+    public void testProxyRevalidateWithoutSecondsSpaceFails() {
+        this.parseInvalidCharacterFails("proxy-revalidate ");
+    }
+
+    @Test
+    public void testProxyRevalidateWithoutSecondsTabFails() {
+        this.parseInvalidCharacterFails("proxy-revalidate\t");
+    }
+
+    @Test
+    public void testProxyRevalidateParameterSeparatorFails() {
+        this.parseInvalidCharacterFails("proxy-revalidate=");
+    }
+
+    @Test
+    public void testProxyRevalidate() {
+        this.parseAndCheck2("proxy-revalidate", "proxy-revalidate");
+    }
+
+    @Test
+    public void testProxyRevalidateSeparator() {
+        this.parseAndCheck2("proxy-revalidate,", "proxy-revalidate");
+    }
+
+    // s-maxage.....................................................
+
+    @Test
+    public void testSmaxAgeWithoutSecondsFails() {
+        this.parseMissingParameterFails("s-maxage", 8);
+    }
+
+    @Test
+    public void testSmaxAgeWithoutSecondsSeparatorFails() {
+        this.parseInvalidCharacterFails("s-maxage,");
+    }
+
+    @Test
+    public void testSmaxAgeWithoutSecondsSpaceFails() {
+        this.parseInvalidCharacterFails("s-maxage ");
+    }
+
+    @Test
+    public void testSmaxAgeWithoutSecondsTabFails() {
+        this.parseInvalidCharacterFails("s-maxage\t");
+    }
+
+    @Test
+    public void testSmaxAgeInvalidCharacterFails() {
+        this.parseInvalidCharacterFails("s-maxage=!");
+    }
+
+    @Test
+    public void testSmaxAgeInvalidCharacterFails2() {
+        this.parseInvalidCharacterFails("s-maxage=1!");
+    }
+
+    @Test
+    public void testSmaxAgeWithSeconds() {
+        this.parseAndCheck2("s-maxage=1", "s-maxage", 1L);
+    }
+
+    @Test
+    public void testSmaxAgeWithSeconds2() {
+        this.parseAndCheck2("s-maxage=23", "s-maxage", 23L);
+    }
+
+    // custom .....................................................................
+
+    @Test
+    public void testCustomQuotedValues() {
+        this.parseAndCheck2("custom=\"abc\"",
+                "custom",
+                "abc");
+    }
+
+    @Test
+    public void testCustomUnquotedValuesFails() {
+        this.parseInvalidCharacterFails("custom=abc", 'a');
+    }
+
+    @Test
+    public void testImmutable() {
+        this.parseAndCheck2("immutable", "immutable");
+    }
+
+    @Test
+    public void testStaleWhileRevalidateNumber() {
+        this.parseAndCheck2("stale-while-revalidate=123", "stale-while-revalidate", 123L);
+    }
+
+    @Test
+    public void testStaleIfError() {
+        this.parseAndCheck2("stale-if-error=456", "stale-if-error", 456L);
+    }
+
+    // several ....................................................................
+
+    @Test
+    public void testMaxAgeSeparatorrNoCache() {
+        this.parseAndCheck3("max-age=123,no-cache",
+                CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
+                CacheControlDirective.NO_CACHE);
+    }
+
+    @Test
+    public void testMaxAgeSpaceNoCache() {
+        this.parseAndCheck3("max-age=123, no-cache",
+                CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
+                CacheControlDirective.NO_CACHE);
+    }
+
+    @Test
+    public void testMaxAgeTabNoCache() {
+        this.parseAndCheck3("max-age=123,\tno-cache",
+                CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
+                CacheControlDirective.NO_CACHE);
+    }
+
+    @Test
+    public void testMaxAgeSeparatorMaxStale() {
+        this.parseAndCheck3("max-age=123,max-stale=456",
+                CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
+                CacheControlDirectiveName.MAX_STALE.setParameter(Optional.of(456L)));
+    }
+
+    @Test
+    public void testNoCacheSeparatorNoStoreSeparatorNoTransform() {
+        this.parseAndCheck3("no-cache,no-store,no-transform",
+                CacheControlDirective.NO_CACHE,
+                CacheControlDirective.NO_STORE,
+                CacheControlDirective.NO_TRANSFORM);
+    }
+
+    @Test
+    public void testNoCacheSeparatorSpaceNoStoreSeparatorSpaceNoTransform() {
+        this.parseAndCheck3("no-cache, no-store, no-transform",
+                CacheControlDirective.NO_CACHE,
+                CacheControlDirective.NO_STORE,
+                CacheControlDirective.NO_TRANSFORM);
+    }
+
+    @Test
+    public void testNoCacheSeparatorTabNoStoreSeparatorTabNoTransform() {
+        this.parseAndCheck3("no-cache, no-store, no-transform",
+                CacheControlDirective.NO_CACHE,
+                CacheControlDirective.NO_STORE,
+                CacheControlDirective.NO_TRANSFORM);
+    }
+
+    @Test
+    public void testNoCacheSeparatorSpaceTabSpaceTabNoStoreSeparatorNoTransform() {
+        this.parseAndCheck3("no-cache, \t \tno-store,no-transform",
+                CacheControlDirective.NO_CACHE,
+                CacheControlDirective.NO_STORE,
+                CacheControlDirective.NO_TRANSFORM);
+    }
+
+    @Test
+    public void testExtensionQuotedParameterSeparatorNoTransform() {
+        this.parseAndCheck3("extension=\"abc\",no-transform",
+                CacheControlDirectiveName.with("extension").setParameter(Cast.to(Optional.of("abc"))),
+                CacheControlDirective.NO_TRANSFORM);
+    }
+
+    // helpers ...........................................................................
+
+    private void parseMissingParameterFails(final String text) {
+        this.parseMissingParameterFails(text, text.length());
+    }
+
+    private void parseMissingParameterFails(final String text, final int at) {
+        this.parseFails(text, CacheControlDirectiveHttpHeaderParser.missingParameter(at, text));
+    }
+
+    private void parseMissingClosingQuoteFails(final String text) {
+        this.parseFails(text, CacheControlDirectiveHttpHeaderParser.missingClosingQuote(text));
+    }
+
+    private void parseAndCheck2(final String text, final String directive) {
+        this.parseAndCheck3(text,
+                CacheControlDirective.with(CacheControlDirectiveName.with(directive), Optional.empty()));
+    }
+
+    private void parseAndCheck2(final String text, final String directive, final Object value) {
+        this.parseAndCheck3(text,
+                CacheControlDirective.with(Cast.to(CacheControlDirectiveName.with(directive)), Optional.of(value)));
+    }
+
+    private void parseAndCheck3(final String text, final CacheControlDirective... directives) {
+        this.parseAndCheck(text, Lists.of(directives));
+    }
+
+    @Override
+    List<CacheControlDirective<?>> parse(final String text) {
+        return CacheControlDirectiveHttpHeaderParser.parseCacheControlDirectiveList(text);
+    }
+
+    @Override
+    protected Class<CacheControlDirectiveHttpHeaderParser> type() {
+        return CacheControlDirectiveHttpHeaderParser.class;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/CacheControlDirectiveListHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/http/CacheControlDirectiveListHeaderValueConverterTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.naming.Name;
+
+import java.util.List;
+import java.util.Optional;
+
+public final class CacheControlDirectiveListHeaderValueConverterTest extends
+        HttpHeaderValueConverterTestCase<CacheControlDirectiveListHeaderValueConverter,
+                List<CacheControlDirective<?>>> {
+
+    @Test
+    public void testCacheControlRoundtrip() {
+        this.parseAndToTextAndCheck("max-age=123, no-cache, no-store",
+                Lists.of(CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
+                        CacheControlDirective.NO_CACHE,
+                        CacheControlDirective.NO_STORE));
+    }
+
+    @Override
+    protected String requiredPrefix() {
+        return CacheControlDirective.class.getSimpleName() + List.class.getSimpleName();
+    }
+
+    @Override
+    protected String invalidHeaderValue() {
+        return "extension=\"abc";
+    }
+
+    @Override
+    protected String converterToString() {
+        return "List<CacheControlDirective>";
+    }
+
+    @Override
+    protected CacheControlDirectiveListHeaderValueConverter converter() {
+        return CacheControlDirectiveListHeaderValueConverter.INSTANCE;
+    }
+
+    @Override
+    protected Name name() {
+        return HttpHeaderName.CACHE_CONTROL;
+    }
+
+    @Override
+    protected List<CacheControlDirective<?>> value() {
+        return Lists.of(CacheControlDirective.NO_CACHE, CacheControlDirective.NO_STORE);
+    }
+
+    @Override protected Class<CacheControlDirectiveListHeaderValueConverter> type() {
+        return CacheControlDirectiveListHeaderValueConverter.class;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/CacheControlDirectiveNameComparableTest.java
+++ b/src/test/java/walkingkooka/net/http/CacheControlDirectiveNameComparableTest.java
@@ -22,30 +22,30 @@ package walkingkooka.net.http;
 import org.junit.Test;
 import walkingkooka.compare.ComparableTestCase;
 
-final public class HttpHeaderNameComparableTest extends ComparableTestCase<HttpHeaderName<?>> {
+final public class CacheControlDirectiveNameComparableTest extends ComparableTestCase<CacheControlDirectiveName<?>> {
 
     @Test
     public void testBefore() {
-        this.compareToAndCheckLess(HttpHeaderName.with("zzz"));
+        this.compareToAndCheckLess(CacheControlDirectiveName.with("z"));
     }
 
     @Test
     public void testBeforeCaseUnimportant() {
-        this.compareToAndCheckLess(HttpHeaderName.with("ZZZ"));
+        this.compareToAndCheckLess(CacheControlDirectiveName.with("Z"));
     }
 
     @Test
     public void testAfter() {
-        this.compareToAndCheckMore(HttpHeaderName.with("aaa"));
+        this.compareToAndCheckMore(CacheControlDirectiveName.MAX_AGE);
     }
 
     @Test
     public void testAfterCaseUnimportant() {
-        this.compareToAndCheckMore(HttpHeaderName.with("AAA"));
+        this.compareToAndCheckMore(CacheControlDirectiveName.with("MAX-age"));
     }
 
     @Override
-    protected HttpHeaderName<String> createComparable() {
-        return HttpHeaderName.SERVER;
+    protected CacheControlDirectiveName<?> createComparable() {
+        return CacheControlDirectiveName.MIN_FRESH;
     }
 }

--- a/src/test/java/walkingkooka/net/http/CacheControlDirectiveNameParameterTest.java
+++ b/src/test/java/walkingkooka/net/http/CacheControlDirectiveNameParameterTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class CacheControlDirectiveNameParameterTest extends PackagePrivateClassTestCase<CacheControlDirectiveNameParameter> {
+    @Override
+    protected Class<CacheControlDirectiveNameParameter> type() {
+        return CacheControlDirectiveNameParameter.class;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/CacheControlDirectiveNameTest.java
+++ b/src/test/java/walkingkooka/net/http/CacheControlDirectiveNameTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.net.header.HeaderNameTestCase;
+import walkingkooka.net.header.HeaderValueException;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+final public class CacheControlDirectiveNameTest extends HeaderNameTestCase<CacheControlDirectiveName<?>> {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWithControlCharacterFails() {
+        CacheControlDirectiveName.with("x\u0001;");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWithSpaceFails() {
+        CacheControlDirectiveName.with("x ");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWithTabFails() {
+        CacheControlDirectiveName.with("x\t");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWithNonAsciiFails() {
+        CacheControlDirectiveName.with("x\u0100;");
+    }
+
+    @Test
+    public void testWith() {
+        this.createNameAndCheck("Extension");
+    }
+
+    @Test
+    public void testConstantNameReturnsConstant() {
+        assertSame(CacheControlDirectiveName.MAX_AGE,
+                CacheControlDirectiveName.with(CacheControlDirectiveName.MAX_AGE.value()));
+    }
+
+    @Test
+    public void testConstantNameReturnsConstantCaseIgnored() {
+        assertSame(CacheControlDirectiveName.MAX_AGE, CacheControlDirectiveName.with("max-AGE"));
+    }
+
+    // isExtension..................................................................................
+
+    @Test
+    public void testIsExtensionConstant() {
+        this.isExtensionAndCheck(CacheControlDirectiveName.PUBLIC, true);
+    }
+
+    @Test
+    public void testIsExtensionCustom() {
+        this.isExtensionAndCheck(CacheControlDirectiveName.with("Custom"), false);
+    }
+
+    private void isExtensionAndCheck(final CacheControlDirectiveName<?> name, final boolean expected) {
+        assertEquals(name.toString(), expected, name.isExtension());
+    }
+
+    // scope .............................................................................................
+
+    @Test
+    public void testMaxAge() {
+        this.checkScope(CacheControlDirectiveName.MAX_AGE, HttpHeaderScope.REQUEST_RESPONSE);
+    }
+
+    @Test
+    public void testMaxStale() {
+        this.checkScope(CacheControlDirectiveName.MAX_STALE, HttpHeaderScope.REQUEST);
+    }
+
+    @Test
+    public void testMinFresh() {
+        this.checkScope(CacheControlDirectiveName.MIN_FRESH, HttpHeaderScope.REQUEST);
+    }
+
+    @Test
+    public void testMustRevalidate() {
+        this.checkScope(CacheControlDirectiveName.MUST_REVALIDATE, HttpHeaderScope.RESPONSE);
+    }
+
+    @Test
+    public void testNoCache() {
+        this.checkScope(CacheControlDirectiveName.NO_CACHE, HttpHeaderScope.REQUEST_RESPONSE);
+    }
+
+    @Test
+    public void testNoStore() {
+        this.checkScope(CacheControlDirectiveName.NO_STORE, HttpHeaderScope.REQUEST_RESPONSE);
+    }
+
+    @Test
+    public void testNoTransform() {
+        this.checkScope(CacheControlDirectiveName.NO_TRANSFORM, HttpHeaderScope.REQUEST_RESPONSE);
+    }
+
+    @Test
+    public void testOnlyIfCached() {
+        this.checkScope(CacheControlDirectiveName.ONLY_IF_CACHED, HttpHeaderScope.REQUEST);
+    }
+
+    @Test
+    public void testPrivate() {
+        this.checkScope(CacheControlDirectiveName.PRIVATE, HttpHeaderScope.RESPONSE);
+    }
+
+    @Test
+    public void testProxyRevalidate() {
+        this.checkScope(CacheControlDirectiveName.PROXY_REVALIDATE, HttpHeaderScope.RESPONSE);
+    }
+
+    @Test
+    public void testPublic() {
+        this.checkScope(CacheControlDirectiveName.PUBLIC, HttpHeaderScope.RESPONSE);
+    }
+
+    @Test
+    public void testSMaxage() {
+        this.checkScope(CacheControlDirectiveName.S_MAXAGE, HttpHeaderScope.RESPONSE);
+    }
+
+    @Test
+    public void testScopeRequestUnknown() {
+        this.checkScope(CacheControlDirectiveName.with("extension"), HttpHeaderScope.UNKNOWN);
+    }
+
+    private void checkScope(final CacheControlDirectiveName directiveName, final HttpHeaderScope scope) {
+        assertSame(scope, directiveName.scope);
+    }
+
+    // setParameter .......................................................
+
+    @Test(expected = NullPointerException.class)
+    public void testSetParameterNullFails() {
+        CacheControlDirectiveName.MAX_AGE.setParameter(null);
+    }
+
+    @Test(expected = HeaderValueException.class)
+    public void testSetParameterInvalidFails() {
+        CacheControlDirectiveName.MAX_AGE.setParameter(Optional.empty());
+    }
+
+    @Test
+    public void testSetParameter() {
+        final CacheControlDirectiveName<Long> name = CacheControlDirectiveName.MAX_AGE;
+        final Optional<Long> parameter = Optional.of(123L);
+        final CacheControlDirective<Long> directive = name.setParameter(parameter);
+        assertEquals("value", name, directive.value());
+        assertEquals("parameter", parameter, directive.parameter());
+    }
+
+    // toString.................................................................................
+
+    @Test
+    public void testToString() {
+        final String name = "X-custom";
+        assertEquals(name, CacheControlDirectiveName.with(name).toString());
+    }
+
+    @Override
+    protected CacheControlDirectiveName<Object> createName(final String name) {
+        return Cast.to(CacheControlDirectiveName.with(name));
+    }
+
+    @Override
+    protected String nameText() {
+        return "X-Custom";
+    }
+
+    @Override
+    protected Class<CacheControlDirectiveName<?>> type() {
+        return Cast.to(CacheControlDirectiveName.class);
+    }
+}

--- a/src/test/java/walkingkooka/net/http/CacheControlDirectiveTest.java
+++ b/src/test/java/walkingkooka/net/http/CacheControlDirectiveTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.net.header.HeaderValueException;
+import walkingkooka.net.header.HeaderValueTestCase;
+import walkingkooka.text.CharSequences;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+public final class CacheControlDirectiveTest extends HeaderValueTestCase<CacheControlDirective<Long>> {
+
+    // with..........................................................................
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNameNullFails() {
+        CacheControlDirective.with(null, Optional.empty());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testWithParameterNullFails() {
+        CacheControlDirective.with(CacheControlDirectiveName.PUBLIC, null);
+    }
+
+    @Test(expected = HeaderValueException.class)
+    public void testWithParameterInvalidFails() {
+        CacheControlDirective.with(CacheControlDirectiveName.MAX_AGE, Optional.empty());
+    }
+
+    @Test
+    public void testWith() {
+        final CacheControlDirectiveName<Long> name = CacheControlDirectiveName.MAX_AGE;
+        final Optional<Long> parameter = Optional.of(123L);
+        this.check(CacheControlDirective.with(name, parameter),
+                name,
+                parameter);
+    }
+
+    // setParameter..........................................................................
+
+    @Test(expected = NullPointerException.class)
+    public void testSetParameterNullFails() {
+        CacheControlDirective.NO_STORE.setParameter(null);
+    }
+
+    @Test(expected = HeaderValueException.class)
+    public void testSetParameterInvalidFails() {
+        CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L))
+                .setParameter(Optional.empty());
+    }
+
+    @Test
+    public void testSetParameterSame() {
+        final CacheControlDirectiveName<Long> name = CacheControlDirectiveName.MAX_AGE;
+        final Optional<Long> parameter = Optional.of(123L);
+        final CacheControlDirective<Long> directive = name.setParameter(parameter);
+        assertSame(directive, directive.setParameter(parameter));
+    }
+
+    @Test
+    public void testSetParameterSame2() {
+        final CacheControlDirective<Void> directive = CacheControlDirective.NO_CACHE;
+        assertSame(directive, directive.setParameter(Optional.empty()));
+    }
+
+    @Test
+    public void testSetParameterDifferent() {
+        this.setParameterAndCheck(CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
+                Optional.of(456L),
+                CacheControlDirectiveName.MAX_AGE);
+    }
+
+    @Test
+    public void testSetParameterMaxStaleDifferent() {
+        this.setParameterAndCheck(CacheControlDirectiveName.MAX_STALE.setParameter(Optional.of(123L)),
+                Optional.of(456L),
+                CacheControlDirectiveName.MAX_STALE);
+    }
+
+    @Test
+    public void testSetParameterMaxStaleDifferent2() {
+        this.setParameterAndCheck(CacheControlDirective.MAX_STALE,
+                Optional.of(123L),
+                CacheControlDirectiveName.MAX_STALE);
+    }
+
+    @Test
+    public void testSetParameterMaxStaleDifferent3() {
+        this.setParameterAndCheck(CacheControlDirectiveName.MAX_STALE.setParameter(Optional.of(123L)),
+                Optional.empty(),
+                CacheControlDirectiveName.MAX_STALE);
+    }
+
+    private <T> void setParameterAndCheck(final CacheControlDirective<T> directive,
+                                          final Optional<T> parameter,
+                                          final CacheControlDirectiveName<T> name) {
+        assertNotEquals("new parameter must be different from old",
+                parameter,
+                directive.parameter());
+        final CacheControlDirective<T> different = directive.setParameter(parameter);
+        assertNotSame("directive set parameter" + parameter + " must not return same",
+                directive,
+                different);
+
+        this.check(different, name, parameter);
+    }
+
+    private <T> void check(final CacheControlDirective<T> directive,
+                           final CacheControlDirectiveName<T> name,
+                           final Optional<T> parameter) {
+        assertEquals("value", name, directive.value());
+        assertEquals("parameter", parameter, directive.parameter());
+    }
+
+    // scope ...............................................................................
+
+    @Test
+    public void testScopeMaxAge() {
+        this.checkScope(CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
+                HttpHeaderScope.REQUEST_RESPONSE);
+    }
+
+    @Test
+    public void testScopeMaxStale() {
+        this.checkScope(CacheControlDirectiveName.MAX_STALE.setParameter(Optional.of(123L)),
+                HttpHeaderScope.REQUEST);
+    }
+
+    @Test
+    public void testScopeOnlyIfCached() {
+        this.checkScope(CacheControlDirective.ONLY_IF_CACHED, HttpHeaderScope.REQUEST);
+    }
+
+    private void checkScope(final CacheControlDirective<?> directive, final HttpHeaderScope scope) {
+        assertSame("Incorrect HeaderScope returned by " + directive,
+                scope,
+                directive.scope());
+    }
+
+    // parse..........................................................................
+
+    @Test(expected = NullPointerException.class)
+    public void testParseNullFails() {
+        CacheControlDirective.parse(null);
+    }
+
+    @Test
+    public void testParse() {
+        final String text = "no-cache, no-store, max-age=123";
+        assertEquals("parse " + CharSequences.quote(text) + " failed",
+                CacheControlDirective.parse(text),
+                Lists.of(CacheControlDirective.NO_CACHE,
+                        CacheControlDirective.NO_STORE,
+                        CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L))));
+    }
+
+    // toHeaderTextList..........................................................................
+
+    @Test(expected = NullPointerException.class)
+    public void testToHeaderTextListNullFails() {
+        CacheControlDirective.toHeaderTextList(null);
+    }
+
+    @Test
+    public void testToHeaderTextListNoCache() {
+        this.toHeaderTextListAndCheck("no-cache",
+                CacheControlDirective.NO_CACHE);
+    }
+
+    @Test
+    public void testToHeaderTextListMaxAge() {
+        this.toHeaderTextListAndCheck("max-age=123",
+                CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)));
+    }
+
+    @Test
+    public void testToHeaderTextListMaxAgeNoCacheNoStore() {
+        this.toHeaderTextListAndCheck("max-age=123, no-cache, no-store",
+                CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
+                CacheControlDirective.NO_CACHE,
+                CacheControlDirective.NO_STORE);
+    }
+
+    private void toHeaderTextListAndCheck(final String toString,
+                                          final CacheControlDirective<?>... directives) {
+        assertEquals("toHeaderTextList returned wrong toString " + Arrays.toString(directives),
+                toString,
+                CacheControlDirective.toHeaderTextList(Lists.of(directives)));
+    }
+
+    @Override
+    protected Class<CacheControlDirective<Long>> type() {
+        return Cast.to(CacheControlDirective.class);
+    }
+}

--- a/src/test/java/walkingkooka/net/http/HttpETagHttpHeaderParserTestCase.java
+++ b/src/test/java/walkingkooka/net/http/HttpETagHttpHeaderParserTestCase.java
@@ -19,88 +19,72 @@
 package walkingkooka.net.http;
 
 import org.junit.Test;
-import walkingkooka.net.header.HeaderValueException;
-import walkingkooka.test.PackagePrivateClassTestCase;
-import walkingkooka.text.CharSequences;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+public abstract class HttpETagHttpHeaderParserTestCase<P extends HttpETagHttpHeaderParser>
+        extends HttpHeaderParserTestCase<P, HttpETag> {
 
-public abstract class HttpETagParserTestCase<P extends HttpETagParser>
-        extends PackagePrivateClassTestCase<P> {
-
-    HttpETagParserTestCase() {
+    HttpETagHttpHeaderParserTestCase() {
         super();
     }
 
     // parse ...........................................................................................
 
-    @Test(expected = NullPointerException.class)
-    public final void testNullFails() {
-        this.parseOne(null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public final void testEmpty() {
-        this.parseOne("");
-    }
-
-    @Test
-    public final void testInvalidInitialFails() {
-        this.parseFails("w");
-    }
-
     @Test
     public final void testInvalidInitialFails2() {
-        this.parseFails("0");
+        this.parseInvalidCharacterFails("w");
+    }
+
+    @Test
+    public final void testInvalidInitialFails3() {
+        this.parseInvalidCharacterFails("0");
     }
 
     @Test
     public final void testInvalidQuotedCharacterFails() {
-        this.parseFails("\"abc\0\"", '\0');
+        this.parseInvalidCharacterFails("\"abc\0\"", '\0');
     }
 
     @Test
     public final void testInvalidQuotedCharacterFails2() {
-        this.parseFails("W/\"abc\0\"", '\0');
+        this.parseInvalidCharacterFails("W/\"abc\0\"", '\0');
     }
 
     @Test
     public final void testWFails() {
-        this.parseFails("W", HttpETagParser.incompleteWeakIndicator("W"));
+        this.parseFails("W", HttpETagHttpHeaderParser.incompleteWeakIndicator("W"));
     }
 
     @Test
     public final void testWeaknessWithoutQuotedValueFails() {
-        this.parseFails("W/", HttpETagParser.missingETagValue("W/"));
+        this.parseFails("W/", HttpETagHttpHeaderParser.missingETagValue("W/"));
     }
 
     @Test
     public final void testWeakInvalidFails() {
-        this.parseFails("WA");
+        this.parseInvalidCharacterFails("WA");
     }
 
     @Test
     public final void testWeakInvalidFails2() {
-        this.parseFails("W0");
+        this.parseInvalidCharacterFails("W0");
     }
 
     @Test
     public final void testBeginQuoteFails() {
         final String text = "\"";
-        this.parseFails(text, HttpETagParser.missingClosingQuote(text));
+        this.parseFails(text, HttpETagHttpHeaderParser.missingClosingQuote(text));
     }
 
     @Test
     public final void testBeginQuoteFails2() {
         final String text = "\"A";
-        this.parseFails(text, HttpETagParser.missingClosingQuote(text));
+        this.parseFails(text, HttpETagHttpHeaderParser.missingClosingQuote(text));
     }
 
     @Test
     public final void testBeginQuoteFails3() {
         final String text = "\"'";
-        this.parseFails(text, HttpETagParser.missingClosingQuote(text));
+        this.parseFails(text, HttpETagHttpHeaderParser.missingClosingQuote(text));
     }
 
     @Test
@@ -143,37 +127,6 @@ public abstract class HttpETagParserTestCase<P extends HttpETagParser>
     }
 
     final void parseAndCheck(final String text, final String value, final HttpETagValidator validator) {
-       this.parseAndCheck(text, HttpETag.with(value, validator));
+        this.parseAndCheck(text, HttpETag.with(value, validator));
     }
-
-    final void parseAndCheck(final String text, final HttpETag tag) {
-        assertEquals("Incorrect result parsing " + CharSequences.quote(text),
-                tag,
-                this.parseOne(text));
-    }
-
-    final void parseFails(final String text) {
-        this.parseFails(text, text.length() - 1);
-    }
-
-    final void parseFails(final String text, final char pos) {
-        this.parseFails(text, text.indexOf(pos));
-    }
-
-    final void parseFails(final String text, final int pos) {
-        parseFails(text, HttpETagParser.invalidCharacter(pos, text));
-    }
-
-    final void parseFails(final String text, final String message) {
-        try {
-            this.parseOne(text);
-            fail();
-        } catch (final HeaderValueException expected) {
-            assertEquals("Incorrect failure message for " + CharSequences.quoteIfChars(text),
-                    message,
-                    expected.getMessage());
-        }
-    }
-
-    abstract HttpETag parseOne(final String text);
 }

--- a/src/test/java/walkingkooka/net/http/HttpETagListHttpHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpETagListHttpHeaderParserTest.java
@@ -26,36 +26,36 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-public final class HttpETagListParserTest extends HttpETagParserTestCase<HttpETagListParser> {
+public final class HttpETagListHttpHeaderParserTest extends HttpETagHttpHeaderParserTestCase<HttpETagListHttpHeaderParser> {
 
     @Test
     public final void testSeparatorFails() {
         final String text = "\"ABC\",";
-        this.parseFails(text, HttpETagParser.missingETagValue(text));
+        this.parseFails(text, HttpETagHttpHeaderParser.missingETagValue(text));
     }
 
     @Test
     public final void testSeparatorSpaceFails() {
         final String text = "\"ABC\", ";
-        this.parseFails(text, HttpETagParser.missingETagValue(text));
+        this.parseFails(text, HttpETagHttpHeaderParser.missingETagValue(text));
     }
 
     @Test
     public final void testSeparatorTabFails() {
         final String text = "\"ABC\",\t";
-        this.parseFails(text, HttpETagParser.missingETagValue(text));
+        this.parseFails(text, HttpETagHttpHeaderParser.missingETagValue(text));
     }
 
     @Test
     public final void testWeakSeparatorSpaceFails() {
         final String text = "W/\"ABC\", ";
-        this.parseFails(text, HttpETagParser.missingETagValue(text));
+        this.parseFails(text, HttpETagHttpHeaderParser.missingETagValue(text));
     }
 
     @Test
     public final void testWeakSeparatorTabFails() {
         final String text = "W/\"ABC\",\t";
-        this.parseFails(text, HttpETagParser.missingETagValue(text));
+        this.parseFails(text, HttpETagHttpHeaderParser.missingETagValue(text));
     }
 
     @Test
@@ -110,18 +110,18 @@ public final class HttpETagListParserTest extends HttpETagParserTestCase<HttpETa
     final void parseAndCheck2(final String text, final HttpETag... tags) {
         assertEquals("Incorrect result parsing " + CharSequences.quote(text),
                 Lists.of(tags),
-                HttpETagListParser.parseList(text));
+                HttpETagListHttpHeaderParser.parseList(text));
     }
 
     @Override
-    HttpETag parseOne(final String text) {
-        final List<HttpETag> tags = HttpETagListParser.parseList(text);
+    HttpETag parse(final String text) {
+        final List<HttpETag> tags = HttpETagListHttpHeaderParser.parseList(text);
         assertEquals("expected one tag =" + CharSequences.quote(text) + "=" + tags, 1, tags.size());
         return tags.get(0);
     }
 
     @Override
-    protected Class<HttpETagListParser> type() {
-        return HttpETagListParser.class;
+    protected Class<HttpETagListHttpHeaderParser> type() {
+        return HttpETagListHttpHeaderParser.class;
     }
 }

--- a/src/test/java/walkingkooka/net/http/HttpETagOneHttpHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpETagOneHttpHeaderParserTest.java
@@ -20,35 +20,35 @@ package walkingkooka.net.http;
 
 import org.junit.Test;
 
-public final class HttpETagOneParserTest extends HttpETagParserTestCase<HttpETagOneParser> {
+public final class HttpETagOneHttpHeaderParserTest extends HttpETagHttpHeaderParserTestCase<HttpETagOneHttpHeaderParser> {
 
     @Test
     public final void testSeparatorFails() {
-        this.parseFails("\"ABC\",", ',');
+        this.parseInvalidCharacterFails("\"ABC\",", ',');
     }
 
     @Test
     public final void testSeparatorWhitespaceFails() {
-        this.parseFails("\"ABC\", ", ',');
+        this.parseInvalidCharacterFails("\"ABC\", ", ',');
     }
 
     @Test
     public final void testWeakSeparatorWhitespaceFails() {
-        this.parseFails("W/\"ABC\", ", ',');
+        this.parseInvalidCharacterFails("W/\"ABC\", ", ',');
     }
 
     @Test
     public void testManyTags() {
-        this.parseFails("\"A\",\"B\"", ',');
+        this.parseInvalidCharacterFails("\"A\",\"B\"", ',');
     }
 
     @Override
-    HttpETag parseOne(final String text) {
-        return HttpETagOneParser.parseOne(text);
+    HttpETag parse(final String text) {
+        return HttpETagOneHttpHeaderParser.parseOne(text);
     }
 
     @Override
-    protected Class<HttpETagOneParser> type() {
-        return HttpETagOneParser.class;
+    protected Class<HttpETagOneHttpHeaderParser> type() {
+        return HttpETagOneHttpHeaderParser.class;
     }
 }

--- a/src/test/java/walkingkooka/net/http/HttpHeaderParserTestCase.java
+++ b/src/test/java/walkingkooka/net/http/HttpHeaderParserTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http;
+
+import org.junit.Test;
+import walkingkooka.net.header.HeaderValueException;
+import walkingkooka.test.PackagePrivateClassTestCase;
+import walkingkooka.text.CharSequences;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public abstract class HttpHeaderParserTestCase<P extends HttpHeaderParser, T>
+        extends PackagePrivateClassTestCase<P> {
+
+    HttpHeaderParserTestCase() {
+        super();
+    }
+
+    // parse ...........................................................................................
+
+    @Test(expected = NullPointerException.class)
+    public final void testNullFails() {
+        this.parse(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public final void testEmpty() {
+        this.parse("");
+    }
+
+    @Test
+    public final void testInvalidInitialFails() {
+        this.parseInvalidCharacterFails("\0");
+    }
+
+    final void parseAndCheck(final String text, final T expected) {
+        assertEquals("Incorrect result parsing " + CharSequences.quote(text),
+                expected,
+                this.parse(text));
+    }
+
+    final void parseInvalidCharacterFails(final String text) {
+        this.parseInvalidCharacterFails(text, text.length() - 1);
+    }
+
+    final void parseInvalidCharacterFails(final String text, final char c) {
+        this.parseInvalidCharacterFails(text, text.indexOf(c));
+    }
+
+    final void parseInvalidCharacterFails(final String text, final int pos) {
+        parseFails(text, HttpHeaderParser.invalidCharacter(pos, text));
+    }
+
+    final void parseFails(final String text, final String message) {
+        try {
+            this.parse(text);
+            fail();
+        } catch (final HeaderValueException expected) {
+            assertEquals("Incorrect failure message for " + CharSequences.quoteIfChars(text),
+                    message,
+                    expected.getMessage());
+        }
+    }
+
+    abstract T parse(final String text);
+}


### PR DESCRIPTION
- pushed PARAMETER_NAME_VALUE_SEPARATOR constant from HeaderValueWithParameters to HeaderValue.
- extracted HttpHeaderParser from HttpETagParser also renamed HttpETagParser to HttpETagHttpHeaderParser.
- HttpHeaderName.CACHE_CONTROL<List<CacheControlDirective<?>> was <String>
- HttpHeaderName.CACHE_CONTROL scope= request + response was request.