### PR TITLE
HttpResponse.addEntity replaces methods to add headers and set body.

### DIFF
--- a/src/main/java/walkingkooka/net/http/HttpEntity.java
+++ b/src/main/java/walkingkooka/net/http/HttpEntity.java
@@ -69,6 +69,11 @@ public final class HttpEntity implements HasHeaders, HashCodeEqualsDefined {
     }
 
     /**
+     * A constant with no headers.
+     */
+    public final static Map<HttpHeaderName<?>, Object> NO_HEADERS = Maps.empty();
+
+    /**
      * Creates a new {@link HttpEntity}
      */
     public static HttpEntity with(final Map<HttpHeaderName<?>, Object> headers, final byte[] body) {

--- a/src/main/java/walkingkooka/net/http/HttpHeaderName.java
+++ b/src/main/java/walkingkooka/net/http/HttpHeaderName.java
@@ -36,7 +36,6 @@ import walkingkooka.net.header.HeaderValueToken;
 import walkingkooka.net.header.MediaType;
 import walkingkooka.net.http.cookie.ClientCookie;
 import walkingkooka.net.http.cookie.ServerCookie;
-import walkingkooka.net.http.server.HttpResponse;
 import walkingkooka.predicate.character.CharPredicate;
 import walkingkooka.predicate.character.CharPredicates;
 import walkingkooka.text.CaseSensitivity;
@@ -836,17 +835,6 @@ final public class HttpHeaderName<T> implements HeaderName<T>,
         Objects.requireNonNull(value, "value");
 
         return this.valueConverter.parse(value, this);
-    }
-
-    /**
-     * Sets the value upon the {@link HttpResponse}
-     */
-    public void addHeaderValue(final T value, final HttpResponse response) {
-        Objects.requireNonNull(value, "value");
-        Objects.requireNonNull(response, "response");
-
-        HttpHeaderScope.RESPONSE.check(this, value);
-        response.addHeader(this, value);
     }
 
     /**

--- a/src/main/java/walkingkooka/net/http/server/FakeHttpResponse.java
+++ b/src/main/java/walkingkooka/net/http/server/FakeHttpResponse.java
@@ -18,11 +18,10 @@
 
 package walkingkooka.net.http.server;
 
-import walkingkooka.net.http.HttpHeaderName;
+import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpStatus;
 import walkingkooka.test.Fake;
 
-import java.util.Map;
 import java.util.Objects;
 
 public class FakeHttpResponse implements HttpResponse, Fake {
@@ -34,26 +33,8 @@ public class FakeHttpResponse implements HttpResponse, Fake {
     }
 
     @Override
-    public Map<HttpHeaderName<?>, Object> headers() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <T> void addHeader(final HttpHeaderName<T> name, final T value) {
-        Objects.requireNonNull(name, "name");
-        Objects.requireNonNull(value, "value");
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setBody(final byte[] body) {
-        Objects.requireNonNull(body, "body");
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setBodyText(final String body) {
-        Objects.requireNonNull(body, "body");
+    public void addEntity(final HttpEntity entity) {
+        Objects.requireNonNull(entity, "entity");
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/net/http/server/HttpHeaderScopeHttpRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpHeaderScopeHttpRequest.java
@@ -43,8 +43,7 @@ final class HttpHeaderScopeHttpRequest implements HttpRequest {
     private HttpHeaderScopeHttpRequest(final HttpRequest request) {
         super();
         this.request = request;
-        this.headers = HttpHeaderScopeHttpRequestHttpResponseHeadersMap.with(request.headers(),
-                HttpHeaderScope.REQUEST);
+        this.headers = HttpHeaderScopeHttpRequestHeadersMap.with(request.headers(), HttpHeaderScope.REQUEST);
     }
 
     @Override
@@ -72,7 +71,7 @@ final class HttpHeaderScopeHttpRequest implements HttpRequest {
         return this.headers;
     }
 
-    private final HttpHeaderScopeHttpRequestHttpResponseHeadersMap headers;
+    private final HttpHeaderScopeHttpRequestHeadersMap headers;
 
     @Override
     public List<ClientCookie> cookies() {

--- a/src/main/java/walkingkooka/net/http/server/HttpHeaderScopeHttpRequestHeadersMap.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpHeaderScopeHttpRequestHeadersMap.java
@@ -30,15 +30,15 @@ import java.util.Set;
 /**
  * A {@link Map} that checks the header (or key) passed to {@link #containsKey(Object)} and {@link #get(Object)}.
  */
-final class HttpHeaderScopeHttpRequestHttpResponseHeadersMap extends AbstractMap<HttpHeaderName<?>, Object> {
+final class HttpHeaderScopeHttpRequestHeadersMap extends AbstractMap<HttpHeaderName<?>, Object> {
 
-    static HttpHeaderScopeHttpRequestHttpResponseHeadersMap with(final Map<HttpHeaderName<?>, Object> map,
-                                                                 final HttpHeaderScope scope) {
-        return new HttpHeaderScopeHttpRequestHttpResponseHeadersMap(map, scope);
+    static HttpHeaderScopeHttpRequestHeadersMap with(final Map<HttpHeaderName<?>, Object> map,
+                                                     final HttpHeaderScope scope) {
+        return new HttpHeaderScopeHttpRequestHeadersMap(map, scope);
     }
 
-    private HttpHeaderScopeHttpRequestHttpResponseHeadersMap(final Map<HttpHeaderName<?>, Object> map,
-                                                             final HttpHeaderScope scope) {
+    private HttpHeaderScopeHttpRequestHeadersMap(final Map<HttpHeaderName<?>, Object> map,
+                                                 final HttpHeaderScope scope) {
         super();
         this.map = map;
         this.scope = scope;

--- a/src/main/java/walkingkooka/net/http/server/HttpResponse.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpResponse.java
@@ -18,14 +18,13 @@
 
 package walkingkooka.net.http.server;
 
-import walkingkooka.net.http.HasHeaders;
-import walkingkooka.net.http.HttpHeaderName;
+import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpStatus;
 
 /**
  * Defines a HTTP response.
  */
-public interface HttpResponse extends HasHeaders {
+public interface HttpResponse {
 
     /**
      * Sets the response status
@@ -33,17 +32,7 @@ public interface HttpResponse extends HasHeaders {
     void setStatus(final HttpStatus status);
 
     /**
-     * Adds a new header and its value.
+     * Adds an entity to the response.
      */
-    <T> void addHeader(final HttpHeaderName<T> name, final T value);
-
-    /**
-     * Sets the body of the response.
-     */
-    void setBody(final byte[] body);
-
-    /**
-     * Sets text that will be encoded and set upon the body.
-     */
-    void setBodyText(final String text);
+    void addEntity(final HttpEntity entity);
 }

--- a/src/main/java/walkingkooka/net/http/server/HttpResponseTestCase.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpResponseTestCase.java
@@ -19,7 +19,6 @@
 package walkingkooka.net.http.server;
 
 import org.junit.Test;
-import walkingkooka.net.http.HttpHeaderName;
 import walkingkooka.test.PackagePrivateClassTestCase;
 
 public abstract class HttpResponseTestCase<R extends HttpResponse> extends PackagePrivateClassTestCase<R> {
@@ -30,23 +29,8 @@ public abstract class HttpResponseTestCase<R extends HttpResponse> extends Packa
     }
 
     @Test(expected = NullPointerException.class)
-    public void testAddHeaderNullNameFails() {
-        this.createResponse().addHeader(null, "header-value");
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testAddHeaderNullValueFails() {
-        this.createResponse().addHeader(HttpHeaderName.CONTENT_LENGTH, null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testSetBodyNullFails() {
-        this.createResponse().setBody(null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testSetBodyTextNullFails() {
-        this.createResponse().setBodyText(null);
+    public void testAddEntityNullFails() {
+        this.createResponse().addEntity(null);
     }
 
     protected abstract R createResponse();

--- a/src/test/java/walkingkooka/net/http/HttpHeaderNameTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpHeaderNameTest.java
@@ -26,9 +26,6 @@ import walkingkooka.collect.map.Maps;
 import walkingkooka.net.header.HeaderNameTestCase;
 import walkingkooka.net.header.HeaderValueException;
 import walkingkooka.net.header.MediaType;
-import walkingkooka.net.header.NotAcceptableHeaderException;
-import walkingkooka.net.http.server.FakeHttpResponse;
-import walkingkooka.net.http.server.HttpResponses;
 import walkingkooka.text.CharSequences;
 
 import java.util.List;
@@ -197,51 +194,6 @@ final public class HttpHeaderNameTest extends HeaderNameTestCase<HttpHeaderName<
         this.toValueAndCheck(HttpHeaderName.CONTENT_LENGTH,
                 "123",
                 123L);
-    }
-
-    // addHeaderValue.........................................................................
-
-    @Test(expected = NullPointerException.class)
-    public void testAddHeaderValueNullValueFails() {
-        HttpHeaderName.CONNECTION.addHeaderValue(null, HttpResponses.fake());
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testAddHeaderValueNullResponseFails() {
-        HttpHeaderName.CONNECTION.addHeaderValue("*", null);
-    }
-
-    @Test(expected = NotAcceptableHeaderException.class)
-    public void testAddHeaderScopeFails() {
-        HttpHeaderName.USER_AGENT.addHeaderValue("xyz", HttpResponses.fake());
-    }
-
-    @Test
-    public void testAddHeaderValueScopeResponse() {
-        this.addHeaderValueAndCheck(HttpHeaderName.SERVER, "Server xyz");
-    }
-
-    @Test
-    public void testAddHeaderValueScopeRequest() {
-        this.addHeaderValueAndCheck(HttpHeaderName.CONTENT_LENGTH, 123L);
-    }
-
-    @Test
-    public void testAddHeaderValueScopeUnknown() {
-        this.addHeaderValueAndCheck(Cast.to(HttpHeaderName.with("xyz")), "abc");
-    }
-
-    private <T> void addHeaderValueAndCheck(final HttpHeaderName<T> header, final T value) {
-        final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
-
-        header.addHeaderValue(value,
-                new FakeHttpResponse() {
-                    @Override
-                    public <T> void addHeader(final HttpHeaderName<T> name, final T value) {
-                        headers.put(name, value);
-                    }
-                });
-        assertEquals("set headers", Maps.one(header, value), headers);
     }
 
     // headerText.........................................................................

--- a/src/test/java/walkingkooka/net/http/server/BufferingHttpResponseTestCase.java
+++ b/src/test/java/walkingkooka/net/http/server/BufferingHttpResponseTestCase.java
@@ -19,7 +19,6 @@
 package walkingkooka.net.http.server;
 
 import org.junit.Test;
-import walkingkooka.net.http.HttpHeaderName;
 import walkingkooka.net.http.HttpStatusCode;
 
 public abstract class BufferingHttpResponseTestCase<R extends BufferingHttpResponse> extends WrapperHttpResponseTestCase<R> {
@@ -32,11 +31,5 @@ public abstract class BufferingHttpResponseTestCase<R extends BufferingHttpRespo
     public void testSetStatus() {
         this.createResponse(HttpResponses.fake())
                 .setStatus(HttpStatusCode.OK.status());
-    }
-
-    @Test
-    public void testAddHeader() {
-        this.createResponse(HttpResponses.fake())
-        .addHeader(HttpHeaderName.CONTENT_LENGTH, 123L);
     }
 }

--- a/src/test/java/walkingkooka/net/http/server/HttpHeaderScopeHttpRequestHeadersMapTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HttpHeaderScopeHttpRequestHeadersMapTest.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-public final class HttpHeaderScopeHttpRequestHttpResponseHeadersMapTest extends MapTestCase<HttpHeaderScopeHttpRequestHttpResponseHeadersMap,
+public final class HttpHeaderScopeHttpRequestHeadersMapTest extends MapTestCase<HttpHeaderScopeHttpRequestHeadersMap,
         HttpHeaderName<?>,
         Object> {
 
@@ -103,12 +103,12 @@ public final class HttpHeaderScopeHttpRequestHttpResponseHeadersMapTest extends 
     }
 
     @Override
-    protected HttpHeaderScopeHttpRequestHttpResponseHeadersMap createMap() {
-        return HttpHeaderScopeHttpRequestHttpResponseHeadersMap.with(HEADERS, HttpHeaderScope.REQUEST);
+    protected HttpHeaderScopeHttpRequestHeadersMap createMap() {
+        return HttpHeaderScopeHttpRequestHeadersMap.with(HEADERS, HttpHeaderScope.REQUEST);
     }
 
     @Override
-    protected Class<HttpHeaderScopeHttpRequestHttpResponseHeadersMap> type() {
-        return HttpHeaderScopeHttpRequestHttpResponseHeadersMap.class;
+    protected Class<HttpHeaderScopeHttpRequestHeadersMap> type() {
+        return HttpHeaderScopeHttpRequestHeadersMap.class;
     }
 }

--- a/src/test/java/walkingkooka/net/http/server/HttpHeaderScopeHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HttpHeaderScopeHttpResponseTest.java
@@ -19,19 +19,17 @@
 package walkingkooka.net.http.server;
 
 import org.junit.Test;
-import walkingkooka.collect.map.Maps;
-import walkingkooka.net.header.NotAcceptableHeaderException;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpHeaderName;
 import walkingkooka.net.http.HttpStatus;
 import walkingkooka.net.http.HttpStatusCode;
-import walkingkooka.net.http.cookie.Cookie;
 import walkingkooka.test.Latch;
 
-import java.util.Map;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 public final class HttpHeaderScopeHttpResponseTest extends WrapperHttpResponseTestCase<HttpHeaderScopeHttpResponse> {
 
@@ -53,142 +51,37 @@ public final class HttpHeaderScopeHttpResponseTest extends WrapperHttpResponseTe
                 assertSame("status", status, s);
             }
 
-            @Override
-            public Map<HttpHeaderName<?>, Object> headers() {
-                return Maps.fake();
-            }
-
         }).setStatus(status);
 
         assertEquals("status not set", true, set.value());
     }
 
-    @Test(expected = NotAcceptableHeaderException.class)
-    public void testAddHeaderRequestScopeFails() {
-        this.createResponse()
-                .addHeader(HttpHeaderName.COOKIE, Cookie.parseClientHeader("cookie123=456"));
-    }
-
     @Test
-    public void testAddHeaderResponseHeader() {
-        final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
+    public void testAddEntity() {
+        final List<HttpEntity> added = Lists.array();
+        final HttpEntity entity = HttpEntity.with(HttpEntity.NO_HEADERS, new byte[123]);
 
         HttpHeaderScopeHttpResponse.with(new FakeHttpResponse() {
 
             @Override
-            public Map<HttpHeaderName<?>, Object> headers() {
-                return Maps.fake();
+            public void addEntity(final HttpEntity e) {
+                added.add(e);
             }
 
-            @Override
-            public <T> void addHeader(final HttpHeaderName<T> name, final T value) {
-                headers.put(name, value);
-            }
-        }).addHeader(HEADER, VALUE);
+        }).addEntity(entity);
 
-        assertEquals("header after addHeader", Maps.one(HEADER, VALUE), headers);
-    }
-
-    @Test(expected = NotAcceptableHeaderException.class)
-    public void testHeaderContainsKeyRequestHeaderScopeFails() {
-        this.createResponse().headers().containsKey(HttpHeaderName.COOKIE);
-    }
-
-    @Test
-    public void testHeaderContainsResponseHeader() {
-        assertTrue(VALUE,
-                HttpHeaderScopeHttpResponse.with(new FakeHttpResponse() {
-                    @Override
-                    public Map<HttpHeaderName<?>, Object> headers() {
-                        return Maps.one(HEADER, VALUE);
-                    }
-                }).headers().containsKey(HEADER));
-    }
-
-    @Test(expected = NotAcceptableHeaderException.class)
-    public void testHeaderGetRequestHeaderScopeFails() {
-        this.createResponse().headers().get(HttpHeaderName.COOKIE);
-    }
-
-    @Test
-    public void testHeaderGetResponseHeader() {
-        assertSame(VALUE,
-                HttpHeaderScopeHttpResponse.with(new FakeHttpResponse() {
-                    @Override
-                    public Map<HttpHeaderName<?>, Object> headers() {
-                        return Maps.one(HEADER, VALUE);
-                    }
-                }).headers().get(HEADER));
-    }
-
-    @Test
-    public void testSetBody() {
-        final Latch set = Latch.create();
-        final byte[] body = new byte[123];
-
-        HttpHeaderScopeHttpResponse.with(new FakeHttpResponse() {
-
-            @Override
-            public void setBody(final byte[] b) {
-                set.set("Body already set to " + body);
-                assertSame("body", body, b);
-            }
-
-            @Override
-            public Map<HttpHeaderName<?>, Object> headers() {
-                return Maps.fake();
-            }
-
-        }).setBody(body);
-
-        assertEquals("body not set", true, set.value());
-    }
-
-    @Test
-    public void testSetBodyText() {
-        final Latch set = Latch.create();
-        final String text = "body text 123";
-
-        HttpHeaderScopeHttpResponse.with(new FakeHttpResponse() {
-
-            @Override
-            public void setBodyText(final String t) {
-                set.set("Body already set to " + text);
-                assertSame("text", text, t);
-            }
-
-            @Override
-            public Map<HttpHeaderName<?>, Object> headers() {
-                return Maps.fake();
-            }
-
-        }).setBodyText(text);
-
-        assertEquals("text not set", true, set.value());
-    }
-
-    @Test
-    public void testToString() {
-        assertEquals(TOSTRING, this.createResponse().toString());
+        assertEquals("added entities", Lists.of(entity), added);
     }
 
     @Override
-    protected HttpHeaderScopeHttpResponse createResponse(final HttpResponse response) {
+    HttpHeaderScopeHttpResponse createResponse(final HttpRequest request,
+                                               final HttpResponse response) {
         return HttpHeaderScopeHttpResponse.with(response);
     }
 
     @Override
-    HttpResponse wrappedHttpResponse() {
-        return new FakeHttpResponse() {
-            @Override
-            public Map<HttpHeaderName<?>, Object> headers() {
-                return Maps.fake();
-            }
-
-            public String toString() {
-                return TOSTRING;
-            }
-        };
+    HttpRequest createRequest() {
+        return HttpRequests.fake();
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/http/server/IfNoneMatchAwareHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/IfNoneMatchAwareHttpResponseTest.java
@@ -24,19 +24,17 @@ import walkingkooka.collect.map.Maps;
 import walkingkooka.net.header.MediaType;
 import walkingkooka.net.http.HttpETag;
 import walkingkooka.net.http.HttpETagValidator;
+import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpHeaderName;
 import walkingkooka.net.http.HttpMethod;
-import walkingkooka.net.http.HttpStatus;
 import walkingkooka.net.http.HttpStatusCode;
 
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 
 public final class IfNoneMatchAwareHttpResponseTest extends BufferingHttpResponseTestCase<IfNoneMatchAwareHttpResponse> {
 
@@ -44,7 +42,6 @@ public final class IfNoneMatchAwareHttpResponseTest extends BufferingHttpRespons
     private final static Function<byte[], HttpETag> COMPUTER = (b) -> HttpETagValidator.STRONG.setValue("X" + b.length);
 
     private final static byte[] BODY = new byte[]{1, 2, 3, 4};
-    private final static byte[] NO_BODY = null;
 
     private final static String SERVER = "Server 123";
     private final static HttpETag E_TAG_ABSENT = null;
@@ -91,25 +88,6 @@ public final class IfNoneMatchAwareHttpResponseTest extends BufferingHttpRespons
                         response));
     }
 
-    // response setBodyText fails.........................................................................
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetBodyTextFails() {
-        final IfNoneMatchAwareHttpResponse  response = this.createResponse(new FakeHttpResponse(){
-            @Override
-            public void setStatus(final HttpStatus status) {
-
-            }
-
-            @Override
-            public void setBodyText(final String body) {
-                fail("setBodyText should not have been called.");
-            }
-        });
-        response.setStatus(HttpStatusCode.OK.status());
-        response.setBodyText("body text");
-    }
-
     // server response body status code.........................................................................
 
     @Test
@@ -133,7 +111,7 @@ public final class IfNoneMatchAwareHttpResponseTest extends BufferingHttpRespons
     }
 
     private void statusBodyAndCheck(final HttpStatusCode status) {
-        this.makeResponseAndCheck(status,
+        this.setStatusAddEntityAndCheck(status,
                 this.headersWithContentHeaders(E_TAG_ABSENT),
                 BODY);
     }
@@ -142,14 +120,14 @@ public final class IfNoneMatchAwareHttpResponseTest extends BufferingHttpRespons
 
     @Test
     public void testStatusOkIfNoneMatchFail() {
-        this.responseOkAndCheck(E_TAG_ABSENT,
+        this.setStatusOkAndAddEntityAndCheck(E_TAG_ABSENT,
                 this.etag(9),
                 new byte[9]);
     }
 
     @Test
     public void testStatusOkComputedETagFailMatchesWeak() {
-        this.responseOkAndCheck(E_TAG_ABSENT,
+        this.setStatusOkAndAddEntityAndCheck(E_TAG_ABSENT,
                 this.etag(1),
                 new byte[1]);
     }
@@ -157,15 +135,15 @@ public final class IfNoneMatchAwareHttpResponseTest extends BufferingHttpRespons
     @Test
     public void testStatusOkETagIfNoneMatchFail() {
         final HttpETag etag = this.etag(9);
-        this.responseOkAndCheck(etag,
+        this.setStatusOkAndAddEntityAndCheck(etag,
                 etag,
                 new byte[9]);
     }
 
-    private void responseOkAndCheck(final HttpETag etag,
-                                               final HttpETag expectedETag,
-                                               final byte[] body) {
-        this.makeResponseAndCheck(HttpStatusCode.OK,
+    private void setStatusOkAndAddEntityAndCheck(final HttpETag etag,
+                                                 final HttpETag expectedETag,
+                                                 final byte[] body) {
+        this.setStatusAddEntityAndCheck(HttpStatusCode.OK,
                 this.headersWithContentHeaders(etag),
                 body,
                 HttpStatusCode.OK,
@@ -178,34 +156,34 @@ public final class IfNoneMatchAwareHttpResponseTest extends BufferingHttpRespons
     @Test
     public void testStatusOkEtagPrecomputedIfNoneMatchMatched() {
         final HttpETag etag = this.etag(2);
-        this.responseOkAndNotModifiedCheck(etag,
+        this.setStatusOkAndNotModifiedCheck(etag,
                 etag,
                 new byte[2]);
     }
 
     @Test
     public void testStatusOkEtagIfNoneMatchMatched() {
-        this.responseOkAndNotModifiedCheck(E_TAG_ABSENT,
+        this.setStatusOkAndNotModifiedCheck(E_TAG_ABSENT,
                 this.etag(2),
                 new byte[2]);
     }
 
     @Test
     public void testStatusOkEtagIfNoneMatchMatched2() {
-        this.responseOkAndNotModifiedCheck(E_TAG_ABSENT,
+        this.setStatusOkAndNotModifiedCheck(E_TAG_ABSENT,
                 this.etag(3),
                 new byte[3]);
     }
 
-    private void responseOkAndNotModifiedCheck(final HttpETag etag,
-                                                           final HttpETag expectedETag,
-                                                           final byte[] body) {
-        this.makeResponseAndCheck(HttpStatusCode.OK,
+    private void setStatusOkAndNotModifiedCheck(final HttpETag etag,
+                                                final HttpETag expectedETag,
+                                                final byte[] body) {
+        this.setStatusAddEntityAndCheck(HttpStatusCode.OK,
                 this.headersWithContentHeaders(etag),
                 body,
                 HttpStatusCode.NOT_MODIFIED,
                 this.headers(expectedETag),
-                NO_BODY);
+                body);
     }
 
     // helpers.........................................................................................
@@ -226,31 +204,24 @@ public final class IfNoneMatchAwareHttpResponseTest extends BufferingHttpRespons
         return headers;
     }
 
-    private void makeResponseAndCheck(final HttpStatusCode status,
-                                      final Map<HttpHeaderName<?>, Object> headers,
-                                      final byte[] body) {
-        this.makeResponseAndCheck(status, headers, body, status, headers, body);
+    private void setStatusAddEntityAndCheck(final HttpStatusCode status,
+                                            final Map<HttpHeaderName<?>, Object> headers,
+                                            final byte[] body) {
+        this.setStatusAddEntityAndCheck(status, headers, body, status, headers, body);
     }
 
-    private void makeResponseAndCheck(final HttpStatusCode status,
-                                      final Map<HttpHeaderName<?>, Object> headers,
-                                      final byte[] body,
-                                      final HttpStatusCode expectedStatus,
-                                      final Map<HttpHeaderName<?>, Object> expectedHeaders,
-                                      final byte[] expectedBody) {
-        final TestHttpResponse wrapped = new TestHttpResponse();
-        final HttpRequest request = this.request(HttpMethod.GET, this.ifNoneMatch());
-        final HttpResponse response = IfNoneMatchAwareHttpResponse.with(request, wrapped, COMPUTER);
-        assertEquals("not wrapped", IfNoneMatchAwareHttpResponse.class, response.getClass());
-
-        response.setStatus(status.status());
-        headers.entrySet()
-                .stream()
-                .forEach(headerAndValue -> response.addHeader(Cast.to(headerAndValue.getKey()), headerAndValue.getValue()));
-
-        response.setBody(body);
-        wrapped.check(request, expectedStatus.status(), expectedHeaders, expectedBody);
-
+    private void setStatusAddEntityAndCheck(final HttpStatusCode status,
+                                            final Map<HttpHeaderName<?>, Object> headers,
+                                            final byte[] body,
+                                            final HttpStatusCode expectedStatus,
+                                            final Map<HttpHeaderName<?>, Object> expectedHeaders,
+                                            final byte[] expectedBody) {
+        this.setStatusAddEntityAndCheck(
+                this.createRequest(),
+                status.status(),
+                HttpEntity.with(headers, body),
+                expectedStatus.status(),
+                HttpEntity.with(expectedHeaders, expectedBody));
     }
 
     @Override
@@ -264,27 +235,32 @@ public final class IfNoneMatchAwareHttpResponseTest extends BufferingHttpRespons
                                                          final List<HttpETag> ifNoneMatch,
                                                          final HttpResponse response) {
         return Cast.to(this.createResponse(
-                request(method, ifNoneMatch),
+                createRequest(method, ifNoneMatch),
                 response));
     }
 
-    private IfNoneMatchAwareHttpResponse createResponse(final HttpRequest request,
-                                                         final HttpResponse response) {
+    @Override
+    IfNoneMatchAwareHttpResponse createResponse(final HttpRequest request,
+                                                final HttpResponse response) {
         return Cast.to(IfNoneMatchAwareHttpResponse.with(request, response, COMPUTER));
     }
 
-
-    private static HttpResponse createResponseWithoutCast(final HttpMethod method,
+    private HttpResponse createResponseWithoutCast(final HttpMethod method,
                                                           final List<HttpETag> ifNoneMatch,
                                                           final HttpResponse response) {
         return IfNoneMatchAwareHttpResponse.with(
-                request(method, ifNoneMatch),
+                createRequest(method, ifNoneMatch),
                 response,
                 COMPUTER);
     }
 
-    private static HttpRequest request(final HttpMethod method,
-                                       final List<HttpETag> ifNoneMatch) {
+    @Override
+    HttpRequest createRequest() {
+        return createRequest(HttpMethod.GET, this.ifNoneMatch());
+    }
+
+    private HttpRequest createRequest(final HttpMethod method,
+                                      final List<HttpETag> ifNoneMatch) {
         assertNotNull("method", method);
 
         final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();

--- a/src/test/java/walkingkooka/net/http/server/LastModifiedAwareHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/LastModifiedAwareHttpResponseTest.java
@@ -24,6 +24,7 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.net.header.MediaType;
 import walkingkooka.net.http.HttpETag;
+import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpHeaderName;
 import walkingkooka.net.http.HttpMethod;
 import walkingkooka.net.http.HttpStatusCode;
@@ -43,10 +44,7 @@ public final class LastModifiedAwareHttpResponseTest extends BufferingHttpRespon
     private final static LocalDateTime LAST_MODIFIED_ABSENT = null;
 
     private final static byte[] BODY = new byte[]{1, 2, 3, 4};
-    private final static byte[] NO_BODY = null;
-
-    private final static String BODY_TEXT = "<html><body>hello</body></html>";
-    private final static String NO_BODY_TEXT = null;
+    private final static byte[] NO_BODY = new byte[0];
 
     private final static String SERVER = "Server 123";
 
@@ -120,58 +118,28 @@ public final class LastModifiedAwareHttpResponseTest extends BufferingHttpRespon
 
     @Test
     public void testStatusContinueBody() {
-        this.statusBodyAndCheck(HttpStatusCode.CONTINUE);
+        this.setStatusLastModifiedAbsentBodyAndCheck(HttpStatusCode.CONTINUE);
     }
 
     @Test
     public void testStatusRedirectBody() {
-        this.statusBodyAndCheck(HttpStatusCode.TEMPORARY_REDIRECT);
+        this.setStatusLastModifiedAbsentBodyAndCheck(HttpStatusCode.TEMPORARY_REDIRECT);
     }
 
     @Test
     public void testStatusClientErrorBody() {
-        this.statusBodyAndCheck(HttpStatusCode.BAD_REQUEST);
+        this.setStatusLastModifiedAbsentBodyAndCheck(HttpStatusCode.BAD_REQUEST);
     }
 
     @Test
     public void testStatusServerErrorBody() {
-        this.statusBodyAndCheck(HttpStatusCode.SERVICE_UNAVAILABLE);
+        this.setStatusLastModifiedAbsentBodyAndCheck(HttpStatusCode.SERVICE_UNAVAILABLE);
     }
 
-    private void statusBodyAndCheck(final HttpStatusCode status) {
-        this.makeResponseAndCheck(status,
+    private void setStatusLastModifiedAbsentBodyAndCheck(final HttpStatusCode status) {
+        this.setStatusAddEntityAndCheck(status,
                 this.headersWithContentHeaders(LAST_MODIFIED_ABSENT),
-                BODY,
-                NO_BODY_TEXT);
-    }
-
-    // server response body text status code.........................................................................
-
-    @Test
-    public void testStatusContinueBodyText() {
-        this.statusBodyTextAndCheck(HttpStatusCode.CONTINUE);
-    }
-
-    @Test
-    public void testStatusRedirectBodyText() {
-        this.statusBodyTextAndCheck(HttpStatusCode.TEMPORARY_REDIRECT);
-    }
-
-    @Test
-    public void testStatusClientErrorBodyText() {
-        this.statusBodyTextAndCheck(HttpStatusCode.BAD_REQUEST);
-    }
-
-    @Test
-    public void testStatusServerErrorBodyText() {
-        this.statusBodyTextAndCheck(HttpStatusCode.SERVICE_UNAVAILABLE);
-    }
-
-    private void statusBodyTextAndCheck(final HttpStatusCode status) {
-        this.makeResponseAndCheck(status,
-                this.headersWithContentHeaders(LAST_MODIFIED_ABSENT),
-                NO_BODY,
-                BODY_TEXT);
+                BODY);
     }
 
     // server last modified incorrect last modified body..............................................................
@@ -180,43 +148,23 @@ public final class LastModifiedAwareHttpResponseTest extends BufferingHttpRespon
 
     @Test
     public void testStatusOkMissingLastModifiedBody() {
-        this.serverOkLastModifiedBodyAndCheck(NO_LAST_MODIFIED);
+        this.setStatusOkLastModifiedBodyAndCheck(NO_LAST_MODIFIED);
     }
 
     @Test
     public void testStatusOkLastModifiedAfterRequestLastModifiedBody() {
-        this.serverOkLastModifiedBodyAndCheck(LAST_MODIFIED.plusYears(1));
+        this.setStatusOkLastModifiedBodyAndCheck(LAST_MODIFIED.plusYears(1));
     }
 
-    private void serverOkLastModifiedBodyAndCheck(final LocalDateTime lastModified) {
-        this.responseOkLastModifiedAndCheck(lastModified,
-                BODY,
-                NO_BODY_TEXT);
+    private void setStatusOkLastModifiedBodyAndCheck(final LocalDateTime lastModified) {
+        this.setStatusOkLastModifiedAndCheck(lastModified, BODY);
     }
 
-    @Test
-    public void testStatusOkMissingLastModifiedBodyText() {
-        this.serverOkLastModifiedBodyTextAndCheck(NO_LAST_MODIFIED);
-    }
-
-    @Test
-    public void testStatusOkLastModifiedAfterRequestLastModifiedBodyText() {
-        this.serverOkLastModifiedBodyTextAndCheck(LAST_MODIFIED.plusYears(1));
-    }
-
-    private void serverOkLastModifiedBodyTextAndCheck(final LocalDateTime lastModified) {
-        this.responseOkLastModifiedAndCheck(lastModified,
-                BODY,
-                NO_BODY_TEXT);
-    }
-
-    private void responseOkLastModifiedAndCheck(final LocalDateTime lastModified,
-                                                final byte[] body,
-                                                final String bodyText) {
-        this.makeResponseAndCheck(HttpStatusCode.OK,
+    private void setStatusOkLastModifiedAndCheck(final LocalDateTime lastModified,
+                                                 final byte[] body) {
+        this.setStatusAddEntityAndCheck(HttpStatusCode.OK,
                 this.headersWithContentHeaders(lastModified),
-                body,
-                bodyText);
+                body);
     }
 
     // response not modified ...........................................................
@@ -233,8 +181,7 @@ public final class LastModifiedAwareHttpResponseTest extends BufferingHttpRespon
 
     private void responseOkLastModifiedAndNotModifiedCheckBody(final LocalDateTime lastModified) {
         this.responseOkLastModifiedAndNotModifiedCheck(lastModified,
-                BODY,
-                NO_BODY_TEXT);
+                BODY);
     }
 
     @Test
@@ -249,21 +196,17 @@ public final class LastModifiedAwareHttpResponseTest extends BufferingHttpRespon
 
     private void responseOkLastModifiedAndNotModifiedCheckBodyText(final LocalDateTime lastModified) {
         this.responseOkLastModifiedAndNotModifiedCheck(lastModified,
-                NO_BODY,
-                BODY_TEXT);
+                NO_BODY);
     }
 
     private void responseOkLastModifiedAndNotModifiedCheck(final LocalDateTime lastModified,
-                                                           final byte[] body,
-                                                           final String bodyText) {
-        this.makeResponseAndCheck(HttpStatusCode.OK,
+                                                           final byte[] body) {
+        this.setStatusAddEntityAndCheck(HttpStatusCode.OK,
                 this.headersWithContentHeaders(lastModified),
                 body,
-                bodyText,
                 HttpStatusCode.NOT_MODIFIED,
                 this.headers(lastModified),
-                NO_BODY,
-                NO_BODY_TEXT);
+                body);
     }
 
     // helpers.........................................................................................
@@ -284,76 +227,57 @@ public final class LastModifiedAwareHttpResponseTest extends BufferingHttpRespon
         return headers;
     }
 
-    private void makeResponseAndCheck(final HttpStatusCode status,
-                                      final Map<HttpHeaderName<?>, Object> headers,
-                                      final byte[] body,
-                                      final String bodyText) {
-        this.makeResponseAndCheck(status, headers, body, bodyText, status, headers, body, bodyText);
+    private void setStatusAddEntityAndCheck(final HttpStatusCode status,
+                                            final Map<HttpHeaderName<?>, Object> headers,
+                                            final byte[] body) {
+        this.setStatusAddEntityAndCheck(status, headers, body, status, headers, body);
     }
 
-    private void makeResponseAndCheck(final HttpStatusCode status,
-                                      final Map<HttpHeaderName<?>, Object> headers,
-                                      final byte[] body,
-                                      final String bodyText,
-                                      final HttpStatusCode expectedStatus,
-                                      final Map<HttpHeaderName<?>, Object> expectedHeaders,
-                                      final byte[] expectedBody,
-                                      final String expectedBodyText) {
-        final TestHttpResponse wrapped = new TestHttpResponse();
-        final HttpRequest request = this.request(HttpMethod.GET,
-                IF_NONE_MATCH_ABSENT,
-                LAST_MODIFIED);
-        final HttpResponse response = LastModifiedAwareHttpResponse.with(request, wrapped);
-        response.setStatus(status.status());
-        headers.entrySet()
-                .stream()
-                .forEach(headerAndValue -> response.addHeader(Cast.to(headerAndValue.getKey()), headerAndValue.getValue()));
-
-        if (null != body) {
-            response.setBody(body);
-            wrapped.check(request, expectedStatus.status(), expectedHeaders, expectedBody);
-        }
-        if (null != bodyText) {
-            response.setBodyText(bodyText);
-            wrapped.check(request, expectedStatus.status(), expectedHeaders, expectedBodyText);
-        }
+    private void setStatusAddEntityAndCheck(final HttpStatusCode status,
+                                            final Map<HttpHeaderName<?>, Object> headers,
+                                            final byte[] body,
+                                            final HttpStatusCode expectedStatus,
+                                            final Map<HttpHeaderName<?>, Object> expectedHeaders,
+                                            final byte[] expectedBody) {
+        this.setStatusAddEntityAndCheck(
+                createRequest(),
+                status.status(),
+                HttpEntity.with(headers, body),
+                expectedStatus.status(),
+                HttpEntity.with(expectedHeaders, expectedBody));
     }
 
     @Override
     LastModifiedAwareHttpResponse createResponse(final HttpResponse response) {
-        return this.createResponse(HttpMethod.GET,
-                IF_NONE_MATCH_ABSENT,
-                LAST_MODIFIED,
-                response);
+        return this.createResponse(this.createRequest(), response);
     }
 
-    private LastModifiedAwareHttpResponse createResponse(final HttpMethod method,
-                                                         final List<HttpETag> ifNoneMatch,
-                                                         final LocalDateTime lastModified,
-                                                         final HttpResponse response) {
-        return Cast.to(this.createResponse(
-                request(method, ifNoneMatch, lastModified),
-                response));
-    }
-
-    private LastModifiedAwareHttpResponse createResponse(final HttpRequest request,
-                                                         final HttpResponse response) {
+    @Override
+    LastModifiedAwareHttpResponse createResponse(final HttpRequest request,
+                                                 final HttpResponse response) {
         return Cast.to(LastModifiedAwareHttpResponse.with(request, response));
     }
 
 
-    private static HttpResponse createResponseWithoutCast(final HttpMethod method,
+    private HttpResponse createResponseWithoutCast(final HttpMethod method,
                                                           final List<HttpETag> ifNoneMatch,
                                                           final LocalDateTime lastModified,
                                                           final HttpResponse response) {
         return LastModifiedAwareHttpResponse.with(
-                request(method, ifNoneMatch, lastModified),
+                createRequest(method, ifNoneMatch, lastModified),
                 response);
     }
 
-    private static HttpRequest request(final HttpMethod method,
-                                       final List<HttpETag> ifNoneMatch,
-                                       final LocalDateTime lastModified) {
+    @Override
+    HttpRequest createRequest() {
+        return this.createRequest(HttpMethod.GET,
+                IF_NONE_MATCH_ABSENT,
+                LAST_MODIFIED);
+    }
+
+    private HttpRequest createRequest(final HttpMethod method,
+                                      final List<HttpETag> ifNoneMatch,
+                                      final LocalDateTime lastModified) {
         assertNotNull("method", method);
 
         final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
@@ -379,7 +303,6 @@ public final class LastModifiedAwareHttpResponseTest extends BufferingHttpRespon
             public String toString() {
                 return this.method() + " " + this.headers();
             }
-
         };
     }
 

--- a/src/test/java/walkingkooka/net/http/server/TestHttpResponse.java
+++ b/src/test/java/walkingkooka/net/http/server/TestHttpResponse.java
@@ -20,12 +20,11 @@ package walkingkooka.net.http.server;
 
 import walkingkooka.Cast;
 import walkingkooka.build.tostring.ToStringBuilder;
-import walkingkooka.collect.map.Maps;
-import walkingkooka.net.http.HttpHeaderName;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpStatus;
 
-import java.util.Arrays;
-import java.util.Map;
+import java.util.List;
 import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
@@ -34,20 +33,16 @@ import static org.junit.Assert.assertEquals;
  * A response that records all parameters set up on it for later verification.
  */
 final class TestHttpResponse implements HttpResponse {
+
     TestHttpResponse() {
         super();
-        this.headers = Maps.ordered();
     }
 
     TestHttpResponse(final HttpStatus status,
-                     final Map<HttpHeaderName<?>, Object> headers,
-                     final byte[] body,
-                     final String bodyText) {
+                     final List<HttpEntity> entities) {
         super();
         this.status = status;
-        this.headers = headers;
-        this.body = body;
-        this.bodyText = bodyText;
+        this.entities.addAll(entities);
     }
 
     @Override
@@ -58,58 +53,26 @@ final class TestHttpResponse implements HttpResponse {
     HttpStatus status;
 
     @Override
-    public Map<HttpHeaderName<?>, Object> headers() {
-        return Maps.readOnly(this.headers);
+    public void addEntity(final HttpEntity entity) {
+        Objects.requireNonNull(entity, "entity");
+        this.entities.add(entity);
     }
 
-    @Override
-    public <T> void addHeader(final HttpHeaderName<T> name, final T value) {
-        this.headers.put(name, value);
-    }
-
-    final Map<HttpHeaderName<?>, Object> headers;
-
-    @Override
-    public void setBody(final byte[] body) {
-        this.body = body;
-    }
-
-    byte[] body;
-
-    @Override
-    public void setBodyText(final String bodyText) {
-        this.bodyText = bodyText;
-    }
+    private final List<HttpEntity> entities = Lists.array();
 
     String bodyText;
 
     void check(final HttpRequest request,
                final HttpStatus status,
-               final Map<HttpHeaderName<?>, Object> headers,
-               final byte[] body) {
-        this.check(request, status, headers, body, null);
-    }
-
-    void check(final HttpRequest request,
-               final HttpStatus status,
-               final Map<HttpHeaderName<?>, Object> headers,
-               final String bodyText) {
-        this.check(request, status, headers, null, bodyText);
-    }
-
-    void check(final HttpRequest request,
-               final HttpStatus status,
-               final Map<HttpHeaderName<?>, Object> headers,
-               final byte[] body,
-               final String bodyText) {
+               final HttpEntity...entities) {
         assertEquals(request.toString(),
-                new TestHttpResponse(status, headers, body, bodyText),
+                new TestHttpResponse(status, Lists.of(entities)),
                 this);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.status, this.headers, this.body, this.bodyText);
+        return Objects.hash(this.status, this.entities);
     }
 
     public boolean equals(final Object other) {
@@ -118,18 +81,14 @@ final class TestHttpResponse implements HttpResponse {
 
     private boolean equals0(final TestHttpResponse other) {
         return Objects.equals(this.status, other.status) &&
-                Objects.equals(this.headers, other.headers) &&
-                Arrays.equals(this.body, other.body) &&
-                Objects.equals(this.bodyText, other.bodyText);
+                Objects.equals(this.entities, other.entities);
     }
 
     @Override
     public String toString() {
         return ToStringBuilder.create()
                 .value(this.status)
-                .value(this.headers)
-                .value(this.body)
-                .value(this.bodyText)
+                .value(this.entities)
                 .build();
     }
 }

--- a/src/test/java/walkingkooka/net/http/server/WrapperHttpRequestHttpResponseTestCase.java
+++ b/src/test/java/walkingkooka/net/http/server/WrapperHttpRequestHttpResponseTestCase.java
@@ -19,12 +19,6 @@
 package walkingkooka.net.http.server;
 
 import org.junit.Test;
-import walkingkooka.collect.map.Maps;
-import walkingkooka.net.http.HttpHeaderName;
-
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
 
 public abstract class WrapperHttpRequestHttpResponseTestCase<R extends WrapperHttpRequestHttpResponse>
         extends WrapperHttpResponseTestCase<R> {
@@ -38,50 +32,14 @@ public abstract class WrapperHttpRequestHttpResponseTestCase<R extends WrapperHt
         this.createResponse(null, HttpResponses.fake());
     }
 
-    final <T> void addHeaderAndCheck(final HttpRequest request,
-                                     final HttpHeaderName<T> header,
-                                     final T value) {
-        this.addHeaderAndCheck(request,
-                header,
-                value,
-                null,
-                null);
-    }
-
-    final <T, U> void addHeaderAndCheck(final HttpRequest request,
-                                        final HttpHeaderName<T> header,
-                                        final T value,
-                                        final HttpHeaderName<U> header2,
-                                        final U value2) {
-        final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
-        final Map<HttpHeaderName<?>, Object> expectedHeaders = Maps.ordered();
-
-        final R response = this.createResponse(request,
-                new FakeHttpResponse() {
-
-                    public <T> void addHeader(final HttpHeaderName<T> n, final T v) {
-                        headers.put(n, v);
-                    }
-                });
-        response.addHeader(header, value);
-        expectedHeaders.put(header, value);
-
-        if (null != header2 && null != value2) {
-            response.addHeader(header2, value2);
-            expectedHeaders.put(header2, value2);
-        }
-
-        assertEquals("headers", expectedHeaders, headers);
-    }
-
     // helpers..................................................................................................
 
     final R createResponse(final HttpResponse response) {
-        return this.createResponse(this.request(), response);
+        return this.createResponse(this.createRequest(), response);
     }
 
     abstract R createResponse(final HttpRequest request,
                               final HttpResponse response);
 
-    abstract HttpRequest request();
+    abstract HttpRequest createRequest();
 }


### PR DESCRIPTION
- Refactored HttpResponse implementations.
- tidy up WrapperHttpResponseTestCase and sub class template methods.
- HttpEntity. NO_HEADERS constant added.
- removed HttpHeader.addHeaderValue