### PR TITLE
HttpHeaderRangeUnit renamed from HttpRangeUnit.

### DIFF
--- a/src/main/java/walkingkooka/net/http/ContentRange.java
+++ b/src/main/java/walkingkooka/net/http/ContentRange.java
@@ -179,7 +179,7 @@ public final class ContentRange implements HeaderValue {
         int mode = MODE_UNIT;
         int i = 0;
 
-        HttpRangeUnit unit = null;
+        HttpHeaderRangeUnit unit = null;
         long lower = 0;
         long upper = 0;
         Range<Long> range = null;
@@ -196,7 +196,7 @@ public final class ContentRange implements HeaderValue {
                         if (i == 0) {
                             throw new HeaderValueException("Unit missing from " + CharSequences.quote(text));
                         }
-                        unit = HttpRangeUnit.fromHeaderText(text.substring(0, i));
+                        unit = HttpHeaderRangeUnit.parse(text.substring(0, i));
                         mode = MODE_RANGE_START_INITIAL;
                         break;
                     }
@@ -316,7 +316,7 @@ public final class ContentRange implements HeaderValue {
     /**
      * Factory that creates a new {@link ContentRange} with the provided name and parameter.
      */
-    public static ContentRange with(final HttpRangeUnit unit,
+    public static ContentRange with(final HttpHeaderRangeUnit unit,
                                     final Optional<Range<Long>> range,
                                     final Optional<Long> size) {
         checkUnit(unit);
@@ -329,7 +329,7 @@ public final class ContentRange implements HeaderValue {
     /**
      * Private use factory.
      */
-    private ContentRange(final HttpRangeUnit unit,
+    private ContentRange(final HttpHeaderRangeUnit unit,
                          final Optional<Range<Long>> range,
                          final Optional<Long> size) {
         super();
@@ -343,7 +343,7 @@ public final class ContentRange implements HeaderValue {
     /**
      * Returns the unit.
      */
-    public final HttpRangeUnit unit() {
+    public final HttpHeaderRangeUnit unit() {
         return this.unit;
     }
 
@@ -351,7 +351,7 @@ public final class ContentRange implements HeaderValue {
      * Would be setter that returns a {@link ContentRange} with the given unit value
      * creating a new instance if necessary.
      */
-    public final ContentRange setUnit(final HttpRangeUnit unit) {
+    public final ContentRange setUnit(final HttpHeaderRangeUnit unit) {
         checkUnit(unit);
 
         return this.unit().equals(unit) ?
@@ -359,9 +359,9 @@ public final class ContentRange implements HeaderValue {
                 this.replace(unit.httpHeaderRangeCheck(), this.range, this.size);
     }
 
-    private final HttpRangeUnit unit;
+    private final HttpHeaderRangeUnit unit;
 
-    private static void checkUnit(final HttpRangeUnit unit) {
+    private static void checkUnit(final HttpHeaderRangeUnit unit) {
         Objects.requireNonNull(unit, "unit");
     }
 
@@ -454,7 +454,7 @@ public final class ContentRange implements HeaderValue {
     /**
      * Factory that creates a new {@link ContentRange}
      */
-    private ContentRange replace(final HttpRangeUnit unit,
+    private ContentRange replace(final HttpHeaderRangeUnit unit,
                                  final Optional<Range<Long>> range,
                                  final Optional<Long> size) {
         return new ContentRange(unit, range, size);

--- a/src/main/java/walkingkooka/net/http/HttpHeaderName.java
+++ b/src/main/java/walkingkooka/net/http/HttpHeaderName.java
@@ -154,11 +154,11 @@ final public class HttpHeaderName<T> implements HeaderName<T>,
     }
 
     /**
-     * Creates and adds a new {@link HttpHeaderName} to the cache being built that handles {@link HttpRangeUnit} header values.
+     * Creates and adds a new {@link HttpHeaderName} to the cache being built that handles {@link HttpHeaderRangeUnit} header values.
      */
-    private static HttpHeaderName<HttpRangeUnit> registerHttpRangeUnitConstant(final String header,
-                                                                               final HttpHeaderScope scope) {
-        return registerConstant(header, scope, HttpHeaderValueConverter.httpRangeUnit());
+    private static HttpHeaderName<HttpHeaderRangeUnit> registerHttpHeaderRangeUnitConstant(final String header,
+                                                                                           final HttpHeaderScope scope) {
+        return registerConstant(header, scope, HttpHeaderValueConverter.httpHeaderRangeUnit());
     }
 
     /**
@@ -557,7 +557,7 @@ final public class HttpHeaderName<T> implements HeaderName<T>,
      * Accept-Ranges: none
      * </pre>
      */
-    public final static HttpHeaderName<HttpRangeUnit> ACCEPT_RANGES = registerHttpRangeUnitConstant("Accept-Ranges",
+    public final static HttpHeaderName<HttpHeaderRangeUnit> ACCEPT_RANGES = registerHttpHeaderRangeUnitConstant("Accept-Ranges",
             HttpHeaderScope.RESPONSE);
 
     /**

--- a/src/main/java/walkingkooka/net/http/HttpHeaderRange.java
+++ b/src/main/java/walkingkooka/net/http/HttpHeaderRange.java
@@ -79,7 +79,7 @@ public final class HttpHeaderRange implements HeaderValue,
                 .collect(Collectors.toList());
 
         try {
-            final HttpRangeUnit unit = HttpRangeUnit.fromHeaderText(header.substring(0, equalsAfterUnit));
+            final HttpHeaderRangeUnit unit = HttpHeaderRangeUnit.parse(header.substring(0, equalsAfterUnit));
             unit.httpHeaderRangeCheck();
             checkValue(ranges);
 
@@ -112,7 +112,7 @@ public final class HttpHeaderRange implements HeaderValue,
     /**
      * Factory that creates a new {@link HttpHeaderRange}
      */
-    public static HttpHeaderRange with(final HttpRangeUnit unit, final List<Range<Long>> ranges) {
+    public static HttpHeaderRange with(final HttpHeaderRangeUnit unit, final List<Range<Long>> ranges) {
         checkUnit(unit);
 
         return new HttpHeaderRange(unit, copyAndCheckValue(ranges));
@@ -121,7 +121,7 @@ public final class HttpHeaderRange implements HeaderValue,
     /**
      * Private ctor use factory.
      */
-    private HttpHeaderRange(final HttpRangeUnit unit, final List<Range<Long>> ranges) {
+    private HttpHeaderRange(final HttpHeaderRangeUnit unit, final List<Range<Long>> ranges) {
         super();
         this.unit = unit;
         this.ranges = ranges;
@@ -129,20 +129,20 @@ public final class HttpHeaderRange implements HeaderValue,
 
     // unit ........................................................................................
 
-    public HttpRangeUnit unit() {
+    public HttpHeaderRangeUnit unit() {
         return this.unit;
     }
 
-    public HttpHeaderRange setUnit(final HttpRangeUnit unit) {
+    public HttpHeaderRange setUnit(final HttpHeaderRangeUnit unit) {
         checkUnit(unit);
         return this.unit.equals(unit) ?
                 this :
                 this.replace(unit, this.ranges);
     }
 
-    private final HttpRangeUnit unit;
+    private final HttpHeaderRangeUnit unit;
 
-    private static void checkUnit(final HttpRangeUnit unit) {
+    private static void checkUnit(final HttpHeaderRangeUnit unit) {
         Objects.requireNonNull(unit, "unit");
 
         unit.httpHeaderRangeCheck();
@@ -213,7 +213,7 @@ public final class HttpHeaderRange implements HeaderValue,
 
     // replace.............................................................................
 
-    private HttpHeaderRange replace(final HttpRangeUnit unit, final List<Range<Long>> ranges) {
+    private HttpHeaderRange replace(final HttpHeaderRangeUnit unit, final List<Range<Long>> ranges) {
         return new HttpHeaderRange(unit, ranges);
     }
 

--- a/src/main/java/walkingkooka/net/http/HttpHeaderRangeUnit.java
+++ b/src/main/java/walkingkooka/net/http/HttpHeaderRangeUnit.java
@@ -27,27 +27,27 @@ import java.util.Optional;
 /**
  * The range unit used in headers such as content-range.
  */
-public enum HttpRangeUnit implements HeaderValue {
+public enum HttpHeaderRangeUnit implements HeaderValue {
 
     NONE("none") {
         @Override
-        HttpRangeUnit httpHeaderRangeCheck() {
+        HttpHeaderRangeUnit httpHeaderRangeCheck() {
             throw new IllegalArgumentException("Invalid range unit=" + this);
         }
     },
 
     BYTES("bytes") {
         @Override
-        HttpRangeUnit httpHeaderRangeCheck() {
+        HttpHeaderRangeUnit httpHeaderRangeCheck() {
             return this;
         }
     };
 
-    HttpRangeUnit(final String headerText) {
+    HttpHeaderRangeUnit(final String headerText) {
         this.headerText = headerText;
     }
 
-    abstract HttpRangeUnit httpHeaderRangeCheck();
+    abstract HttpHeaderRangeUnit httpHeaderRangeCheck();
 
     @Override
     public String toHeaderText() {
@@ -62,10 +62,10 @@ public enum HttpRangeUnit implements HeaderValue {
     }
 
     /**
-     * Finds a matching {@link HttpRangeUnit} for the given text or throw an {@link IllegalArgumentException}.
+     * Finds a matching {@link HttpHeaderRangeUnit} for the given text or throw an {@link IllegalArgumentException}.
      */
-    public static HttpRangeUnit fromHeaderText(final String text) {
-        final Optional<HttpRangeUnit> found = Arrays.stream(values())
+    public static HttpHeaderRangeUnit parse(final String text) {
+        final Optional<HttpHeaderRangeUnit> found = Arrays.stream(values())
                 .filter(u -> u.headerText.equalsIgnoreCase(text))
                 .findFirst();
         if(!found.isPresent()){

--- a/src/main/java/walkingkooka/net/http/HttpHeaderRangeUnitHttpHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/http/HttpHeaderRangeUnitHttpHeaderValueConverter.java
@@ -21,7 +21,7 @@ package walkingkooka.net.http;
 import walkingkooka.naming.Name;
 
 /**
- * A {@link HttpHeaderValueConverter} that parses a header value into a {@link HttpRangeUnit>}.
+ * A {@link HttpHeaderValueConverter} that parses a header value into a {@link HttpHeaderRangeUnit >}.
  * This is useful for headers such as {@link HttpHeaderName#ACCEPT_RANGES}.
  * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Ranges"></a>
  * <pre>
@@ -29,37 +29,37 @@ import walkingkooka.naming.Name;
  * Accept-Ranges: none
  * </pre>
  */
-final class HttpRangeUnitHttpHeaderValueConverter extends HttpHeaderValueConverter<HttpRangeUnit> {
+final class HttpHeaderRangeUnitHttpHeaderValueConverter extends HttpHeaderValueConverter<HttpHeaderRangeUnit> {
 
     /**
      * Singleton
      */
-    final static HttpRangeUnitHttpHeaderValueConverter INSTANCE = new HttpRangeUnitHttpHeaderValueConverter();
+    final static HttpHeaderRangeUnitHttpHeaderValueConverter INSTANCE = new HttpHeaderRangeUnitHttpHeaderValueConverter();
 
     /**
      * Private ctor use singleton.
      */
-    private HttpRangeUnitHttpHeaderValueConverter() {
+    private HttpHeaderRangeUnitHttpHeaderValueConverter() {
         super();
     }
 
     @Override
-    HttpRangeUnit parse0(final String value, final Name name) {
-        return HttpRangeUnit.fromHeaderText(value);
+    HttpHeaderRangeUnit parse0(final String value, final Name name) {
+        return HttpHeaderRangeUnit.parse(value);
     }
 
     @Override
     void check0(final Object value) {
-        this.checkType(value, HttpRangeUnit.class);
+        this.checkType(value, HttpHeaderRangeUnit.class);
     }
 
     @Override
-    String toText0(final HttpRangeUnit value, final Name name) {
+    String toText0(final HttpHeaderRangeUnit value, final Name name) {
         return value.toHeaderText();
     }
 
     @Override
     public String toString() {
-        return this.toStringType(HttpRangeUnit.class);
+        return this.toStringType(HttpHeaderRangeUnit.class);
     }
 }

--- a/src/main/java/walkingkooka/net/http/HttpHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/http/HttpHeaderValueConverter.java
@@ -78,10 +78,10 @@ abstract class HttpHeaderValueConverter<T> implements HeaderValueConverter<T> {
     }
 
     /**
-     * {@see HttpRangeUnitHttpHeaderValueConverter}
+     * {@see HttpHeaderRangeUnitHttpHeaderValueConverter}
      */
-    static HttpHeaderValueConverter<HttpRangeUnit> httpRangeUnit() {
-        return HttpRangeUnitHttpHeaderValueConverter.INSTANCE;
+    static HttpHeaderValueConverter<HttpHeaderRangeUnit> httpHeaderRangeUnit() {
+        return HttpHeaderRangeUnitHttpHeaderValueConverter.INSTANCE;
     }
 
     /**

--- a/src/test/java/walkingkooka/net/http/ContentRangeEqualityTest.java
+++ b/src/test/java/walkingkooka/net/http/ContentRangeEqualityTest.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 public final class ContentRangeEqualityTest extends HashCodeEqualsDefinedEqualityTestCase<ContentRange> {
 
-    private final static HttpRangeUnit UNIT = HttpRangeUnit.BYTES;
+    private final static HttpHeaderRangeUnit UNIT = HttpHeaderRangeUnit.BYTES;
     private final static Optional<Long> SIZE = Optional.of(123L);
 
     @Test
@@ -70,7 +70,7 @@ public final class ContentRangeEqualityTest extends HashCodeEqualsDefinedEqualit
         return Optional.of(Range.greaterThanEquals(lower).and(Range.lessThanEquals(upper)));
     }
 
-    private final ContentRange range(final HttpRangeUnit unit,
+    private final ContentRange range(final HttpHeaderRangeUnit unit,
                                      final Optional<Range<Long>> range,
                                      final Optional<Long> size) {
         return ContentRange.with(unit, range, size);

--- a/src/test/java/walkingkooka/net/http/ContentRangeHttpHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/http/ContentRangeHttpHeaderValueConverterTest.java
@@ -49,7 +49,7 @@ public final class ContentRangeHttpHeaderValueConverterTest extends
     }
 
     private ContentRange contentRange() {
-        return ContentRange.with(HttpRangeUnit.BYTES,
+        return ContentRange.with(HttpHeaderRangeUnit.BYTES,
                 Optional.of(Range.greaterThanEquals(123L).and(Range.lessThanEquals(456L))),
                 Optional.of(789L));
     }

--- a/src/test/java/walkingkooka/net/http/ContentRangeTest.java
+++ b/src/test/java/walkingkooka/net/http/ContentRangeTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.fail;
 
 public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> {
 
-    private final static HttpRangeUnit UNIT = HttpRangeUnit.BYTES;
+    private final static HttpHeaderRangeUnit UNIT = HttpHeaderRangeUnit.BYTES;
     private final static Optional<Long> SIZE = Optional.of(789L);
 
     // with.
@@ -107,7 +107,7 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> {
 
     @Test(expected = IllegalArgumentException.class)
     public void testSetUnitNoneFails() {
-        this.contentRange().setUnit(HttpRangeUnit.NONE);
+        this.contentRange().setUnit(HttpHeaderRangeUnit.NONE);
     }
 
     @Test
@@ -205,7 +205,7 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> {
     }
 
     private void check(final ContentRange contentRange,
-                       final HttpRangeUnit unit,
+                       final HttpHeaderRangeUnit unit,
                        final Optional<Range<Long>> range,
                        final Optional<Long> size) {
         assertEquals("unit", unit, contentRange.unit());
@@ -333,7 +333,7 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> {
     }
 
     private void parseAndCheck(final String headerValue,
-                               final HttpRangeUnit unit,
+                               final HttpHeaderRangeUnit unit,
                                final Optional<Range<Long>> range,
                                final Optional<Long> size) {
         assertEquals("Incorrect result when parsing " + CharSequences.quote(headerValue),
@@ -377,7 +377,7 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> {
     }
 
     private final void toHeaderTextAndCheck(final String headerText,
-                                            final HttpRangeUnit unit,
+                                            final HttpHeaderRangeUnit unit,
                                             final Optional<Range<Long>> range,
                                             final Optional<Long> size) {
         this.toHeaderTextAndCheck(
@@ -412,7 +412,7 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> {
     }
 
     private final void toStringAndCheck(final String toString,
-                                        final HttpRangeUnit unit,
+                                        final HttpHeaderRangeUnit unit,
                                         final Optional<Range<Long>> range,
                                         final Optional<Long> size) {
         assertEquals("toString",

--- a/src/test/java/walkingkooka/net/http/HttpHeaderRangeEqualityTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpHeaderRangeEqualityTest.java
@@ -25,7 +25,7 @@ import walkingkooka.test.HashCodeEqualsDefinedEqualityTestCase;
 
 public final class HttpHeaderRangeEqualityTest extends HashCodeEqualsDefinedEqualityTestCase<HttpHeaderRange> {
 
-    private final static HttpRangeUnit UNIT = HttpRangeUnit.BYTES;
+    private final static HttpHeaderRangeUnit UNIT = HttpHeaderRangeUnit.BYTES;
 
     @Test
     public void testDifferentRanges() {
@@ -42,7 +42,7 @@ public final class HttpHeaderRangeEqualityTest extends HashCodeEqualsDefinedEqua
     }
 
     @SafeVarargs
-    private final HttpHeaderRange range(final HttpRangeUnit unit, final Range<Long>... ranges) {
+    private final HttpHeaderRange range(final HttpHeaderRangeUnit unit, final Range<Long>... ranges) {
         return HttpHeaderRange.with(unit, Lists.of(ranges));
     }
 }

--- a/src/test/java/walkingkooka/net/http/HttpHeaderRangeHttpHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpHeaderRangeHttpHeaderValueConverterTest.java
@@ -43,7 +43,7 @@ public final class HttpHeaderRangeHttpHeaderValueConverterTest extends
     }
 
     private HttpHeaderRange range() {
-        return HttpHeaderRange.with(HttpRangeUnit.BYTES,
+        return HttpHeaderRange.with(HttpHeaderRangeUnit.BYTES,
                 Lists.of(Range.greaterThanEquals(123L).and(Range.lessThanEquals(456L)),
                         Range.greaterThanEquals(789L)));
     }

--- a/src/test/java/walkingkooka/net/http/HttpHeaderRangeTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpHeaderRangeTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertSame;
 
 public final class HttpHeaderRangeTest extends HeaderValueTestCase<HttpHeaderRange> {
 
-    private final static HttpRangeUnit UNIT = HttpRangeUnit.BYTES;
+    private final static HttpHeaderRangeUnit UNIT = HttpHeaderRangeUnit.BYTES;
 
     // with.......................................................
 
@@ -80,7 +80,7 @@ public final class HttpHeaderRangeTest extends HeaderValueTestCase<HttpHeaderRan
 
     @Test(expected = IllegalArgumentException.class)
     public void testSetUnitNoneFails() {
-        this.range().setUnit(HttpRangeUnit.NONE);
+        this.range().setUnit(HttpHeaderRangeUnit.NONE);
     }
 
     @Test
@@ -131,7 +131,7 @@ public final class HttpHeaderRangeTest extends HeaderValueTestCase<HttpHeaderRan
     }
 
     private void check(final HttpHeaderRange range,
-                       final HttpRangeUnit unit,
+                       final HttpHeaderRangeUnit unit,
                        final List<Range<Long>> values) {
         assertEquals("unit", unit, range.unit());
         assertEquals("value", values, range.value());
@@ -222,7 +222,7 @@ public final class HttpHeaderRangeTest extends HeaderValueTestCase<HttpHeaderRan
 
     @SafeVarargs
     private final void parseAndCheck(final String headerValue,
-                                     final HttpRangeUnit unit,
+                                     final HttpHeaderRangeUnit unit,
                                      final Range<Long>... values) {
         assertEquals("Incorrect result when  parsing " + CharSequences.quote(headerValue),
                 HttpHeaderRange.with(unit, Lists.of(values)),
@@ -263,7 +263,7 @@ public final class HttpHeaderRangeTest extends HeaderValueTestCase<HttpHeaderRan
 
     @SafeVarargs
     private final void toHeaderTextAndCheck(final String headerText,
-                                            final HttpRangeUnit unit,
+                                            final HttpHeaderRangeUnit unit,
                                             final Range<Long>... ranges) {
         this.toHeaderTextAndCheck(this.range(unit, ranges), headerText);
     }
@@ -302,7 +302,7 @@ public final class HttpHeaderRangeTest extends HeaderValueTestCase<HttpHeaderRan
 
     @SafeVarargs
     private final void toStringAndCheck(final String toString,
-                                        final HttpRangeUnit unit,
+                                        final HttpHeaderRangeUnit unit,
                                         final Range<Long>... ranges) {
         final HttpHeaderRange range = this.range(unit, ranges);
         assertEquals("toString", toString, range.toString());
@@ -313,7 +313,7 @@ public final class HttpHeaderRangeTest extends HeaderValueTestCase<HttpHeaderRan
     }
 
     @SafeVarargs
-    private final HttpHeaderRange range(final HttpRangeUnit unit,
+    private final HttpHeaderRange range(final HttpHeaderRangeUnit unit,
                                         final Range<Long>... ranges) {
         return HttpHeaderRange.with(unit, Lists.of(ranges));
     }

--- a/src/test/java/walkingkooka/net/http/HttpHeaderRangeUnitHttpHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpHeaderRangeUnitHttpHeaderValueConverterTest.java
@@ -20,14 +20,14 @@ package walkingkooka.net.http;
 
 import org.junit.Test;
 
-public final class HttpRangeUnitHttpHeaderValueConverterTest extends
-        HttpHeaderValueConverterTestCase<HttpRangeUnitHttpHeaderValueConverter, HttpRangeUnit> {
+public final class HttpHeaderRangeUnitHttpHeaderValueConverterTest extends
+        HttpHeaderValueConverterTestCase<HttpHeaderRangeUnitHttpHeaderValueConverter, HttpHeaderRangeUnit> {
 
     private final static String TEXT = "bytes";
 
     @Override
     protected String requiredPrefix() {
-        return HttpRangeUnit.class.getSimpleName();
+        return HttpHeaderRangeUnit.class.getSimpleName();
     }
 
     @Test
@@ -40,17 +40,17 @@ public final class HttpRangeUnitHttpHeaderValueConverterTest extends
         this.toTextAndCheck(this.range(), TEXT);
     }
 
-    private HttpRangeUnit range() {
-        return HttpRangeUnit.BYTES;
+    private HttpHeaderRangeUnit range() {
+        return HttpHeaderRangeUnit.BYTES;
     }
 
     @Override
-    protected HttpRangeUnitHttpHeaderValueConverter converter() {
-        return HttpRangeUnitHttpHeaderValueConverter.INSTANCE;
+    protected HttpHeaderRangeUnitHttpHeaderValueConverter converter() {
+        return HttpHeaderRangeUnitHttpHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<HttpRangeUnit> name() {
+    protected HttpHeaderName<HttpHeaderRangeUnit> name() {
         return HttpHeaderName.ACCEPT_RANGES;
     }
 
@@ -60,17 +60,17 @@ public final class HttpRangeUnitHttpHeaderValueConverterTest extends
     }
 
     @Override
-    protected HttpRangeUnit value() {
-        return HttpRangeUnit.fromHeaderText(TEXT);
+    protected HttpHeaderRangeUnit value() {
+        return HttpHeaderRangeUnit.parse(TEXT);
     }
 
     @Override
     protected String converterToString() {
-        return HttpRangeUnit.class.getSimpleName();
+        return HttpHeaderRangeUnit.class.getSimpleName();
     }
 
     @Override
-    protected Class<HttpRangeUnitHttpHeaderValueConverter> type() {
-        return HttpRangeUnitHttpHeaderValueConverter.class;
+    protected Class<HttpHeaderRangeUnitHttpHeaderValueConverter> type() {
+        return HttpHeaderRangeUnitHttpHeaderValueConverter.class;
     }
 }

--- a/src/test/java/walkingkooka/net/http/HttpHeaderRangeUnitTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpHeaderRangeUnitTest.java
@@ -23,41 +23,41 @@ import walkingkooka.net.header.HeaderValueTestCase;
 
 import static org.junit.Assert.assertSame;
 
-public final class HttpRangeUnitTest extends HeaderValueTestCase<HttpRangeUnit> {
+public final class HttpHeaderRangeUnitTest extends HeaderValueTestCase<HttpHeaderRangeUnit> {
 
     @Test(expected = NullPointerException.class)
-    public void testFromHeaderTextNullFails() {
-        HttpRangeUnit.fromHeaderText(null);
+    public void testParseNullFails() {
+        HttpHeaderRangeUnit.parse(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testFromHeaderTextEmptyFails() {
-        HttpRangeUnit.fromHeaderText("");
+    public void testParseEmptyFails() {
+        HttpHeaderRangeUnit.parse("");
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testFromHeaderTextUnkownFails() {
-        HttpRangeUnit.fromHeaderText("unknown");
+    public void testParseUnknownFails() {
+        HttpHeaderRangeUnit.parse("unknown");
     }
 
     @Test
-    public void testFromHeaderTextBytes() {
-        assertSame(HttpRangeUnit.BYTES, HttpRangeUnit.fromHeaderText("bytes"));
+    public void testParseBytes() {
+        assertSame(HttpHeaderRangeUnit.BYTES, HttpHeaderRangeUnit.parse("bytes"));
     }
 
     @Test
-    public void testFromHeaderTextBytesCaseUnimportant() {
-        assertSame(HttpRangeUnit.BYTES, HttpRangeUnit.fromHeaderText("BYtes"));
+    public void testParseBytesCaseUnimportant() {
+        assertSame(HttpHeaderRangeUnit.BYTES, HttpHeaderRangeUnit.parse("BYtes"));
     }
 
     @Test
-    public void testFromHeaderTextNone() {
-        assertSame(HttpRangeUnit.NONE, HttpRangeUnit.fromHeaderText("none"));
+    public void testParseNone() {
+        assertSame(HttpHeaderRangeUnit.NONE, HttpHeaderRangeUnit.parse("none"));
     }
 
     @Override
-    protected HttpRangeUnit createHeaderValue() {
-        return HttpRangeUnit.BYTES;
+    protected HttpHeaderRangeUnit createHeaderValue() {
+        return HttpHeaderRangeUnit.BYTES;
     }
 
     @Override
@@ -66,7 +66,7 @@ public final class HttpRangeUnitTest extends HeaderValueTestCase<HttpRangeUnit> 
     }
 
     @Override
-    protected Class<HttpRangeUnit> type() {
-        return HttpRangeUnit.class;
+    protected Class<HttpHeaderRangeUnit> type() {
+        return HttpHeaderRangeUnit.class;
     }
 }


### PR DESCRIPTION
- naming matches HttpHeaderRange.
- renamed HttpHeaderRangeUnit.fromHeaderText to parse
- also renamed matching converter (HttpHeaderRangeUnitHttpHeaderValueConverter).