### PR TITLE
RangeAwareHttpResponse creates multipart http entities for ranges whe…

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/RangeAwareHttpResponse.java
+++ b/src/main/java/walkingkooka/net/http/server/RangeAwareHttpResponse.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server;
+
+import walkingkooka.collect.map.Maps;
+import walkingkooka.compare.Range;
+import walkingkooka.compare.RangeBound;
+import walkingkooka.net.header.MediaType;
+import walkingkooka.net.header.MediaTypeBoundary;
+import walkingkooka.net.http.ContentRange;
+import walkingkooka.net.http.ETag;
+import walkingkooka.net.http.HasHeaders;
+import walkingkooka.net.http.HttpEntity;
+import walkingkooka.net.http.HttpHeaderName;
+import walkingkooka.net.http.HttpStatus;
+import walkingkooka.net.http.HttpStatusCode;
+import walkingkooka.net.http.HttpStatusCodeCategory;
+import walkingkooka.net.http.IfRange;
+import walkingkooka.net.http.RangeHeaderValue;
+import walkingkooka.net.http.RangeHeaderValueUnit;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * A {@link HttpResponse} wrapper that honours any range header ranges for 2xx responses, creating multi parts for each range.
+ */
+final class RangeAwareHttpResponse extends BufferingHttpResponse {
+
+    /**
+     * Conditionally creates a {@link RangeAwareHttpResponse} if the request has a range header.
+     */
+    static HttpResponse with(final HttpRequest request,
+                             final HttpResponse response,
+                             final Supplier<Byte> boundaryCharacters) {
+        check(request);
+        check(response);
+        Objects.requireNonNull(boundaryCharacters, "boundaryCharacters");
+
+        HttpResponse result = response;
+
+        final Map<HttpHeaderName<?>, Object> requestHeaders = request.headers();
+
+        // range must be absent
+        final Optional<RangeHeaderValue> maybeRange = HttpHeaderName.RANGE.headerValue(requestHeaders);
+        if (maybeRange.isPresent()) {
+            result = new RangeAwareHttpResponse(response,
+                    maybeRange.get(),
+                    HttpHeaderName.IF_RANGE.headerValue(requestHeaders).orElse(null),
+                    boundaryCharacters);
+        }
+
+        return result;
+    }
+
+    /**
+     * Private ctor use factory
+     */
+    private RangeAwareHttpResponse(final HttpResponse response,
+                                   final RangeHeaderValue range,
+                                   final IfRange<?> ifRange,
+                                   final Supplier<Byte> boundaryCharacters) {
+        super(response);
+        this.range = range;
+        this.ifRange = ifRange;
+        this.boundaryCharacters = boundaryCharacters;
+    }
+
+    @Override
+    void addEntity(final HttpStatus status,
+                   final HttpEntity entity) {
+
+        // only range chunk 2xx responses...
+        if (status.value().category() == HttpStatusCodeCategory.SUCCESSFUL) {
+
+            // if-range is absent
+            // if-range etag is satisifed by response etag
+            // if-range/lastmodified == response.lastmodified
+            final IfRange<?> ifRange = this.ifRange;
+            if (null == ifRange ||
+                    ifRange.isETag() && this.isETagSatisified(ifRange, entity) ||
+                    ifRange.isLastModified() && this.isLastModifiedSatisified(ifRange, entity)) {
+
+                final byte[] body = entity.body();
+                if (this.canSatisfyRange(body.length)) {
+                    this.addMultipartEntities(entity);
+                } else {
+                    this.response.setStatus(HttpStatusCode.REQUESTED_RANGE_NOT_SATISFIABLE.status());
+                    this.response.addEntity(entity.setBody(HttpEntity.NO_BODY)); // need to remove content-headers.
+                }
+            } else {
+                this.response.setStatus(status);
+                this.response.addEntity(entity);
+            }
+        } else {
+            this.response.setStatus(status);
+            this.response.addEntity(entity);
+        }
+    }
+
+    private boolean isETagSatisified(final IfRange<?> ifRange,
+                                     final HasHeaders response) {
+        final Optional<ETag> etag = HttpHeaderName.E_TAG.headerValue(response.headers());
+        return etag.isPresent() &&
+                ifRange.etag().value().isMatch(etag.get());
+    }
+
+    private boolean isLastModifiedSatisified(final IfRange<?> ifRange,
+                                             final HasHeaders response) {
+        final Optional<LocalDateTime> lastModified = HttpHeaderName.LAST_MODIFIED.headerValue(response.headers());
+        return lastModified.isPresent() &&
+                ifRange.lastModified().value().equals(lastModified.get());
+    }
+
+    /**
+     * Will return true if all ranges address bytes within 0 and the content length.
+     */
+    private boolean canSatisfyRange(final int contentLength) {
+        return this.range.value()
+                .stream()
+                .allMatch(r -> this.canSatisfyRange0(contentLength, r));
+    }
+
+    private static boolean canSatisfyRange0(final int contentLength, final Range<Long> range) {
+        return canSatisfyRange1(contentLength, range.lowerBound()) &&
+                canSatisfyRange1(contentLength, range.upperBound());
+    }
+
+    private static boolean canSatisfyRange1(final int contentLength, final RangeBound<Long> bound) {
+        return bound.isAll() || bound.value().get() <= contentLength;
+    }
+
+    /**
+     * ~# curl -s -D - -H "Range: bytes=100-200, 300-400" http://www.example.com
+     * HTTP/1.1 206 Partial Content
+     * Accept-Ranges: bytes
+     * Content-Type: multipart/byteranges; boundary=3d6b6a416f9b5
+     * Content-Length: 385
+     * Server: ECS (fll/0761)
+     * <p>
+     * <p>
+     * --3d6b6a416f9b5
+     * Content-Type: text/html
+     * Content-Range: bytes 100-200/1270
+     * <p>
+     * eta http-equiv="Content-type" content="text/html; charset=utf-8" />
+     * <meta name="vieport" content
+     * --3d6b6a416f9b5
+     * Content-Type: text/html
+     * Content-Range: bytes 300-400/1270
+     * <p>
+     * -color: #f0f0f2;
+     * margin: 0;
+     * padding: 0;
+     * font-family: "Open Sans", "Helvetica
+     * --3d6b6a416f9b5--
+     */
+    private void addMultipartEntities(final HttpEntity entity) {
+        final byte[] body = entity.body();
+        final Optional<Long> contentLength = Optional.of(Long.valueOf(body.length));
+
+        final MediaTypeBoundary boundary = MediaTypeBoundary.generate(body, this.boundaryCharacters);
+
+        this.response.setStatus(HttpStatusCode.PARTIAL_CONTENT.status());
+        this.response.addEntity(
+                entity.removeHeader(HttpHeaderName.CONTENT_TYPE)
+                        .addHeader(HttpHeaderName.CONTENT_TYPE, boundary.multipartByteRanges())
+                .setBody(HttpEntity.NO_BODY)
+        );
+
+        final MediaType contentType = HttpHeaderName.CONTENT_TYPE.headerValueOrFail(entity.headers());
+        final ContentRange contentRange = ContentRange.with(RangeHeaderValueUnit.BYTES, ContentRange.NO_RANGE, contentLength);
+
+        for (Range<Long> range : this.range.value()) {
+            final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
+            headers.put(HttpHeaderName.CONTENT_TYPE, contentType);
+            headers.put(HttpHeaderName.CONTENT_RANGE, contentRange.setRange(Optional.of(this.replaceUpperBoundsIfWildcard(range, body.length))));
+
+            this.response.addEntity(entity.extractRange(range).setHeaders(headers));
+        }
+    }
+
+    private Range replaceUpperBoundsIfWildcard(final Range<Long> range, final long contentLength) {
+        return range.upperBound().isAll() ?
+                Range.greaterThanEquals(range.lowerBound().value().get()).and(Range.lessThanEquals(contentLength -1)) :
+                range;
+    }
+
+    /**
+     * The requested ranges.
+     */
+    private final RangeHeaderValue range;
+
+    private final IfRange<?> ifRange;
+
+    private final Supplier<Byte> boundaryCharacters;
+}

--- a/src/test/java/walkingkooka/net/http/server/RangeAwareHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/RangeAwareHttpResponseTest.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.compare.Range;
+import walkingkooka.net.header.CharsetName;
+import walkingkooka.net.header.MediaType;
+import walkingkooka.net.header.MediaTypeBoundary;
+import walkingkooka.net.http.ContentRange;
+import walkingkooka.net.http.ETag;
+import walkingkooka.net.http.ETagValidator;
+import walkingkooka.net.http.HttpEntity;
+import walkingkooka.net.http.HttpHeaderName;
+import walkingkooka.net.http.HttpStatusCode;
+import walkingkooka.net.http.IfRange;
+import walkingkooka.net.http.RangeHeaderValue;
+import walkingkooka.net.http.RangeHeaderValueUnit;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertSame;
+
+public final class RangeAwareHttpResponseTest extends BufferingHttpResponseTestCase<RangeAwareHttpResponse> {
+
+    private final static Supplier<Byte> BOUNDARY_CHARACTERS = new Supplier<Byte>() {
+        @Override
+        public Byte get() {
+            return (byte)"0123456789".charAt(this.i++% 10);
+        }
+
+        int i = 0;
+    };
+    
+    private final static ETag ETAG_ABSENT = null;
+    private final static IfRange<?> IF_RANGE_ABSENT = null;
+    private final static LocalDateTime LASTMODIFIED_ABSENT = null;
+
+    private final static byte[] BODY = "abcdefghijklmnopqrstuvwxyz".getBytes(CharsetName.UTF_8.charset().get());
+    private final static long BODY_LENGTH = BODY.length;
+    private final static byte[] NO_BODY = new byte[0];
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullRequestFails() {
+        RangeAwareHttpResponse.with(null,
+                HttpResponses.fake(),
+                BOUNDARY_CHARACTERS);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullBoundaryCharactersFails() {
+        RangeAwareHttpResponse.with(HttpRequests.fake(),
+                HttpResponses.fake(),
+                null);
+    }
+
+    @Test
+    public void testRangeAbsentNotWrapped() {
+        final HttpResponse response = HttpResponses.fake();
+        assertSame(response,
+                RangeAwareHttpResponse.with(createRequest(null, ifRange()),
+                        response,
+                        BOUNDARY_CHARACTERS));
+    }
+
+    // wrapped...
+
+    @Test
+    public void testResponseInformation1XX() {
+        this.setStatusAddEntityAndCheck(HttpStatusCode.CONTINUE);
+    }
+
+    @Test
+    public void testResponseRedirect3XX() {
+        this.setStatusAddEntityAndCheck(HttpStatusCode.TEMPORARY_REDIRECT);
+    }
+
+    @Test
+    public void testResponseBadRequest4XX() {
+        this.setStatusAddEntityAndCheck(HttpStatusCode.TEMPORARY_REDIRECT);
+    }
+
+    @Test
+    public void testResponseServerFailure5XX() {
+        this.setStatusAddEntityAndCheck(HttpStatusCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private void setStatusAddEntityAndCheck(final HttpStatusCode status) {
+        this.setStatusAddEntityAndCheck(status.status(), this.httpEntity());
+    }
+
+    @Test
+    public void testIfRangeETagRequiredAndAbsent() {
+        this.ifRangeFailSetStatusAddEntityAndCheck(
+                this.ranges(),
+                IfRange.with(this.etag()),
+                ETAG_ABSENT,
+                this.lastModified());
+    }
+
+    @Test
+    public void testIfRangeETagRequiredAndIncorrect() {
+        this.ifRangeFailSetStatusAddEntityAndCheck(
+                this.ranges(),
+                IfRange.with(this.etag()),
+                this.etagDifferent(),
+                this.lastModified());
+    }
+
+    @Test
+    public void testIfRangeLastModifiedRequiredAndAbsent() {
+        this.ifRangeFailSetStatusAddEntityAndCheck(
+                this.ranges(),
+                IfRange.with(this.lastModified()),
+                this.etag(),
+                null);
+    }
+
+    @Test
+    public void testIfRangeLastModifiedRequiredAndIncorrect() {
+        this.ifRangeFailSetStatusAddEntityAndCheck(
+                this.ranges(),
+                IfRange.with(this.lastModified()),
+                this.etag(),
+                this.lastModifiedDifferent());
+    }
+
+    private void ifRangeFailSetStatusAddEntityAndCheck(final RangeHeaderValue requestRanges,
+                                                       final IfRange requestIfRange,
+                                                       final ETag responseETag,
+                                                       final LocalDateTime responseLastModified) {
+
+        this.setStatusAddEntityAndCheck4(requestRanges,
+                requestIfRange,
+                responseETag,
+                responseLastModified,
+                BODY,
+                HttpStatusCode.OK,
+                BODY);
+    }
+
+    // range unsatisfiable.....................................
+
+    @Test
+    public void testRangeUnsatisfiable() {
+        this.invalidRangeSetStatusAddEntityAndCheck(IF_RANGE_ABSENT,
+                ETAG_ABSENT,
+                this.lastModified());
+    }
+
+    @Test
+    public void testIfRangeETagAndRangeUnsatisfiable() {
+        this.invalidRangeSetStatusAddEntityAndCheck(IF_RANGE_ABSENT,
+                this.etag(),
+                LASTMODIFIED_ABSENT);
+    }
+
+    @Test
+    public void testIfRangeLastModifiedAndRangeUnsatisfiable() {
+        this.invalidRangeSetStatusAddEntityAndCheck(IF_RANGE_ABSENT,
+                ETAG_ABSENT,
+                this.lastModified());
+    }
+
+    private void invalidRangeSetStatusAddEntityAndCheck(final IfRange requestIfRange,
+                                                        final ETag responseETag,
+                                                        final LocalDateTime responseLastModified) {
+        this.setStatusAddEntityAndCheck4(RangeHeaderValue.parse("bytes=1-9999"),
+                requestIfRange,
+                responseETag,
+                responseLastModified,
+                BODY,
+                HttpStatusCode.REQUESTED_RANGE_NOT_SATISFIABLE,
+                NO_BODY);
+    }
+
+    private void setStatusAddEntityAndCheck4(final RangeHeaderValue requestRanges,
+                                             final IfRange requestIfRange,
+                                             final ETag responseETag,
+                                             final LocalDateTime responseLastModified,
+                                             final byte[] body,
+                                             final HttpStatusCode expectedStatus,
+                                             final byte[] expectedBody) {
+
+        final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
+        if(null!=responseETag) {
+            headers.put(HttpHeaderName.E_TAG, responseETag);
+        }
+        if(null!=responseLastModified) {
+            headers.put(HttpHeaderName.LAST_MODIFIED, responseLastModified);
+        }
+        headers.put(HttpHeaderName.SERVER, "Server123");
+
+        this.setStatusAddEntityAndCheck(
+                this.createRequest(requestRanges, requestIfRange),
+                HttpStatusCode.OK.status(),
+                HttpEntity.with(headers, body),
+                expectedStatus.status(),
+                HttpEntity.with(headers, expectedBody));
+    }
+
+    // range ............................................................................................
+
+    @Test
+    public void testRangeBeginning() {
+        this.rangeAndCheck("bytes=0-2", 0, 2, "abc");
+    }
+
+    @Test
+    public void testRangeMiddle() {
+        this.rangeAndCheck("bytes=1-3", 1, 3, "bcd");
+    }
+
+    @Test
+    public void testRangeEnd() {
+        this.rangeAndCheck("bytes=22-25", 22, 25, "wxyz");
+    }
+
+    @Test
+    public void testRangeOpenEnd() {
+        this.rangeAndCheck("bytes=22-", 22, 25, "wxyz");
+    }
+
+    private void rangeAndCheck(final String requestRange, final int lower, final int upper, final String multipart2Body) {
+        final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
+        headers.put(HttpHeaderName.SERVER, "Server123");
+        headers.put(HttpHeaderName.E_TAG, this.etag());
+        headers.put(HttpHeaderName.LAST_MODIFIED, this.lastModified());
+        headers.put(HttpHeaderName.CONTENT_TYPE, MediaType.TEXT_PLAIN);
+        headers.put(HttpHeaderName.CONTENT_LENGTH, BODY_LENGTH);
+
+        final Map<HttpHeaderName<?>, Object> multipart1 = Maps.ordered();
+        multipart1.put(HttpHeaderName.SERVER, "Server123");
+        multipart1.put(HttpHeaderName.E_TAG, this.etag());
+        multipart1.put(HttpHeaderName.LAST_MODIFIED, this.lastModified());
+        multipart1.put(HttpHeaderName.CONTENT_TYPE, this.multipartContentType());
+        multipart1.put(HttpHeaderName.CONTENT_LENGTH, BODY_LENGTH);
+
+        final Map<HttpHeaderName<?>, Object> multipart2 = Maps.ordered();
+        multipart2.put(HttpHeaderName.CONTENT_TYPE, MediaType.TEXT_PLAIN);
+        multipart2.put(HttpHeaderName.CONTENT_RANGE, this.contentRange(lower, upper));
+
+        this.setStatusAddEntityAndCheck(requestRange,
+                IF_RANGE_ABSENT,
+                headers,
+                HttpEntity.with(multipart1, HttpEntity.NO_BODY),
+                this.httpEntity(multipart2, multipart2Body));
+    }
+
+    @Test
+    public void testRangeTwoParts() {
+        final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
+        headers.put(HttpHeaderName.SERVER, "Server123");
+        headers.put(HttpHeaderName.E_TAG, this.etag());
+        headers.put(HttpHeaderName.LAST_MODIFIED, this.lastModified());
+        headers.put(HttpHeaderName.CONTENT_TYPE, MediaType.TEXT_PLAIN);
+        headers.put(HttpHeaderName.CONTENT_LENGTH, BODY_LENGTH);
+
+        final Map<HttpHeaderName<?>, Object> multipart1 = Maps.ordered();
+        multipart1.put(HttpHeaderName.SERVER, "Server123");
+        multipart1.put(HttpHeaderName.E_TAG, this.etag());
+        multipart1.put(HttpHeaderName.LAST_MODIFIED, this.lastModified());
+        multipart1.put(HttpHeaderName.CONTENT_TYPE, this.multipartContentType());
+        multipart1.put(HttpHeaderName.CONTENT_LENGTH, BODY_LENGTH);
+
+        final Map<HttpHeaderName<?>, Object> multipart2 = Maps.ordered();
+        multipart2.put(HttpHeaderName.CONTENT_TYPE, MediaType.TEXT_PLAIN);
+        multipart2.put(HttpHeaderName.CONTENT_RANGE, this.contentRange(1, 2));
+
+        final Map<HttpHeaderName<?>, Object> multipart3 = Maps.ordered();
+        multipart3.put(HttpHeaderName.CONTENT_TYPE, MediaType.TEXT_PLAIN);
+        multipart3.put(HttpHeaderName.CONTENT_RANGE, this.contentRange(10, 12));
+
+        this.setStatusAddEntityAndCheck("bytes=1-2,10-12",
+                IF_RANGE_ABSENT,
+                headers,
+                HttpEntity.with(multipart1, HttpEntity.NO_BODY),
+                this.httpEntity(multipart2, "bc"),
+                this.httpEntity(multipart3, "klm"));
+    }
+
+    private ContentRange contentRange(final long lower, final long upper) {
+        return ContentRange.with(RangeHeaderValueUnit.BYTES,
+                Optional.of(Range.greaterThanEquals(lower).and(Range.lessThanEquals(upper))),
+                Optional.of(BODY_LENGTH));
+    }
+
+    private void setStatusAddEntityAndCheck(final String requestRanges,
+                                             final IfRange requestIfRange,
+                                             final Map<HttpHeaderName<?>, Object> headers,
+                                             final HttpEntity...expectedEntities) {
+        this.setStatusAddEntityAndCheck(
+                this.createRequest(RangeHeaderValue.parse(requestRanges), requestIfRange),
+                HttpStatusCode.OK.status(),
+                HttpEntity.with(headers, BODY),
+                HttpStatusCode.PARTIAL_CONTENT.status(),
+                expectedEntities);
+    }
+
+    // helpers ............................................................................................
+
+    @Override
+    RangeAwareHttpResponse createResponse(final HttpResponse response) {
+        return this.createResponse(this.createRequest(this.ranges(), this.ifRange()), response);
+    }
+
+    @Override
+    RangeAwareHttpResponse createResponse(final HttpRequest request, final HttpResponse response) {
+        return Cast.to(RangeAwareHttpResponse.with(request, response, BOUNDARY_CHARACTERS));
+    }
+
+    @Override
+    HttpRequest createRequest() {
+        return this.createRequest(this.ranges(), this.ifRange());
+    }
+
+    private RangeHeaderValue ranges() {
+        return RangeHeaderValue.parse("bytes=1-100");
+    }
+
+    private IfRange<?> ifRange() {
+        return IfRange.with(this.etag());
+    }
+
+    private ETag etag() {
+        return ETagValidator.STRONG.setValue("etag-correct");
+    }
+
+    private ETag etagDifferent() {
+        return ETagValidator.STRONG.setValue("etag-incorrect");
+    }
+
+    private LocalDateTime lastModified() {
+        return LocalDateTime.of(2000, 12, 31, 6, 28, 29);
+    }
+
+    private LocalDateTime lastModifiedDifferent() {
+        return LocalDateTime.of(2001, 1, 1, 1, 1, 1);
+    }
+
+    private MediaType multipartContentType() {
+        return MediaTypeBoundary.with("mnopqrstuvmnopqrstuvmnopqrstuvmnopqrstuv").multipartByteRanges();
+    }
+
+    private HttpEntity httpEntity() {
+        return this.httpEntity(HttpHeaderName.SERVER, "server abc123", BODY);
+    }
+
+    private <T> HttpEntity httpEntity(final HttpHeaderName<T> header,
+                                      final T value,
+                                      final byte[] bytes) {
+        return HttpEntity.with(Maps.one(header, value), bytes);
+    }
+
+    private <T> HttpEntity httpEntity(final Map<HttpHeaderName<?>, Object> headers,
+                                      final String bytes) {
+        return this.httpEntity(headers, bytes.getBytes(CharsetName.UTF_8.charset().get()));
+    }
+
+    private <T> HttpEntity httpEntity(final Map<HttpHeaderName<?>, Object> headers,
+                                      final byte[] bytes) {
+        return HttpEntity.with(headers, bytes);
+    }
+
+    private HttpRequest createRequest(final RangeHeaderValue ranges, final IfRange<?> ifRange) {
+        final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
+
+        if(null!=ranges) {
+            headers.put(HttpHeaderName.RANGE, ranges);
+        }
+
+        if(null!=ifRange) {
+            headers.put(HttpHeaderName.IF_RANGE, ifRange);
+        }
+
+        return new FakeHttpRequest() {
+            @Override
+            public Map<HttpHeaderName<?>, Object> headers() {
+                return Maps.readOnly(headers);
+            }
+
+            @Override
+            public String toString() {
+                return this.headers().toString();
+            }
+        };
+    }
+
+    @Override
+    protected Class<RangeAwareHttpResponse> type() {
+        return RangeAwareHttpResponse.class;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/TestHttpResponse.java
+++ b/src/test/java/walkingkooka/net/http/server/TestHttpResponse.java
@@ -87,6 +87,8 @@ final class TestHttpResponse implements HttpResponse {
     @Override
     public String toString() {
         return ToStringBuilder.create()
+                .valueSeparator("\n")
+                .separator("\n")
                 .value(this.status)
                 .value(this.entities)
                 .build();

--- a/src/test/java/walkingkooka/net/http/server/WrapperHttpResponseTestCase.java
+++ b/src/test/java/walkingkooka/net/http/server/WrapperHttpResponseTestCase.java
@@ -85,14 +85,28 @@ public abstract class WrapperHttpResponseTestCase<R extends WrapperHttpResponse>
     abstract R createResponse(final HttpRequest request, final HttpResponse response);
 
     final void setStatusAddEntityAndCheck(final HttpStatus status,
+                                          final HttpEntity entity) {
+        this.setStatusAddEntityAndCheck(status,
+                entity,
+                status,
+                entity);
+    }
+
+    final void setStatusAddEntityAndCheck(final HttpStatus status,
                                           final HttpEntity entity,
                                           final HttpStatus expectedStatus,
                                           final HttpEntity... expectedEntities) {
-        this.setStatusAddEntityAndCheck(HttpRequests.fake(),
+        this.setStatusAddEntityAndCheck(this.createRequest(),
                 status,
                 entity,
                 expectedStatus,
                 expectedEntities);
+    }
+
+    final void setStatusAddEntityAndCheck(final HttpRequest request,
+                                          final HttpStatus status,
+                                          final HttpEntity entity) {
+        this.setStatusAddEntityAndCheck(request, status, entity, status, entity);
     }
 
     final void setStatusAddEntityAndCheck(final HttpRequest request,


### PR DESCRIPTION
…re possible.

- Honours IfRange when deciding whether possible to send ranges rather than full response.
- WrapperHttpResponseTestCase helper overloads added.
- TestHttpResponse.toString almost http text response form.