### PR TITLE
HeaderParser test improvements.

### DIFF
--- a/src/main/java/walkingkooka/net/header/HeaderParser2Mode.java
+++ b/src/main/java/walkingkooka/net/header/HeaderParser2Mode.java
@@ -120,7 +120,6 @@ enum HeaderParser2Mode {
 
         @Override
         void endOfText(final HeaderParser2<?> parser) {
-            parser.position--;
             parser.missingParameterValue();
         }
     },
@@ -140,7 +139,7 @@ enum HeaderParser2Mode {
 
         @Override
         void endOfText(final HeaderParser2<?> parser) {
-            parser.position--;
+            //parser.position--;
             parser.missingParameterValue();
         }
     },
@@ -153,7 +152,6 @@ enum HeaderParser2Mode {
 
         @Override
         void endOfText(final HeaderParser2<?> parser) {
-            parser.position--;
             parser.missingParameterValue();
         }
     },
@@ -167,7 +165,6 @@ enum HeaderParser2Mode {
 
         @Override
         void endOfText(final HeaderParser2<?> parser) {
-            parser.position--;
             parser.missingParameterValue();
         }
     },

--- a/src/test/java/walkingkooka/net/header/CharsetHeaderValueListHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/CharsetHeaderValueListHeaderParserTest.java
@@ -66,34 +66,44 @@ public final class CharsetHeaderValueListHeaderParserTest extends HeaderParser2T
         this.parseInvalidCharacterFails("UTF-8BC<");
     }
 
-    @Test(expected = HeaderValueException.class)
+    @Test
     public void testCharsetEqualsFails() {
-        CharsetHeaderValue.parse("UTF-8;b=");
+        this.parseMissingParameterValueFails("UTF-8;b=");
     }
 
-    @Test(expected = HeaderValueException.class)
+    @Test
     public void testCharsetSpaceEqualsFails() {
-        CharsetHeaderValue.parse("UTF-8;b =");
+        this.parseMissingParameterValueFails("UTF-8;b =");
     }
 
-    @Test(expected = HeaderValueException.class)
+    @Test
     public void testCharsetTabEqualsFails() {
-        CharsetHeaderValue.parse("UTF-8;b =");
+        this.parseMissingParameterValueFails("UTF-8;b =");
     }
 
-    @Test(expected = HeaderValueException.class)
+    @Test
     public void testCharsetSpaceTabSpaceTabEqualsFails() {
-        CharsetHeaderValue.parse("UTF-8;b \t \t=");
+        this.parseMissingParameterValueFails("UTF-8;b \t \t=");
     }
 
-    @Test(expected = HeaderValueException.class)
+    @Test
     public void testCharsetEqualsSpaceFails() {
-        CharsetHeaderValue.parse("UTF-8;b= ");
+        this.parseMissingParameterValueFails("UTF-8;b= ");
     }
 
-    @Test(expected = HeaderValueException.class)
+    @Test
     public void testCharsetEqualsTabFails() {
-        CharsetHeaderValue.parse("UTF-8;b=\t");
+        this.parseMissingParameterValueFails("UTF-8;b=\t");
+    }
+
+    @Test
+    public void testCharsetEqualsCrNlSpaceFails() {
+        this.parseMissingParameterValueFails("UTF-8;b=\r\n ");
+    }
+
+    @Test
+    public void testCharsetEqualsCrNlTabFails() {
+        this.parseMissingParameterValueFails("UTF-8;b=\r\n\t");
     }
 
     @Test
@@ -314,10 +324,7 @@ public final class CharsetHeaderValueListHeaderParserTest extends HeaderParser2T
 
     @Test
     public void testCharsetParameterSeparatorParameterNameFails() {
-        final String text = "UTF-8;b=c;D";
-        this.parseFails(text,
-                HeaderParser2.missingParameterValue(10,
-                        text));
+        this.parseMissingParameterValueFails("UTF-8;b=c;D");
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/ContentDispositionHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentDispositionHeaderParserTest.java
@@ -61,34 +61,44 @@ public final class ContentDispositionHeaderParserTest extends HeaderParser2TestC
         this.parseInvalidCharacterFails("ABC<");
     }
 
-    @Test(expected = HeaderValueException.class)
+    @Test
     public void testTypeEqualsFails() {
-        ContentDisposition.parse("A;b=");
+        this.parseMissingParameterValueFails("A;b=");
     }
 
-    @Test(expected = HeaderValueException.class)
+    @Test
     public void testTypeSpaceEqualsFails() {
-        ContentDisposition.parse("A;b =");
+        this.parseMissingParameterValueFails("A;b =");
     }
 
-    @Test(expected = HeaderValueException.class)
+    @Test
     public void testTypeTabEqualsFails() {
-        ContentDisposition.parse("A;b =");
+        this.parseMissingParameterValueFails("A;b =");
     }
 
-    @Test(expected = HeaderValueException.class)
+    @Test
     public void testTypeSpaceTabSpaceTabEqualsFails() {
-        ContentDisposition.parse("A;b \t \t=");
+        this.parseMissingParameterValueFails("A;b \t \t=");
     }
 
-    @Test(expected = HeaderValueException.class)
+    @Test
     public void testTypeEqualsSpaceFails() {
-        ContentDisposition.parse("A;b= ");
+        parseMissingParameterValueFails("A;b= ");
     }
 
-    @Test(expected = HeaderValueException.class)
+    @Test
     public void testTypeEqualsTabFails() {
-        ContentDisposition.parse("A;b=\t");
+        parseMissingParameterValueFails("A;b=\t");
+    }
+
+    @Test
+    public void testTypeEqualsCrNlSpaceFails() {
+        parseMissingParameterValueFails("A;b=\r\n ");
+    }
+
+    @Test
+    public void testTypeEqualsCrNlTabFails() {
+        parseMissingParameterValueFails("A;b=\r\n\t");
     }
 
     @Test
@@ -325,9 +335,7 @@ public final class ContentDispositionHeaderParserTest extends HeaderParser2TestC
     @Test
     public void testTypeParameterSeparatorParameterNameFails() {
         final String text = "A;b=c;D";
-        this.parseFails(text,
-                HeaderParser2.missingParameterValue(6,
-                        text));
+        this.parseMissingParameterValueFails(text);
     }
 
     @Test
@@ -396,7 +404,7 @@ public final class ContentDispositionHeaderParserTest extends HeaderParser2TestC
 
     @Test
     public void testFilenameMissingFails() {
-        this.parseMissingParameterValueFails("V; filename=", 11);
+        this.parseMissingParameterValueFails("V; filename=");
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/MediaTypeHeaderParserTestCase.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeHeaderParserTestCase.java
@@ -95,22 +95,22 @@ public abstract class MediaTypeHeaderParserTestCase<P extends MediaTypeHeaderPar
 
     @Test
     public final void testParameterValueMissingFails() {
-        this.parseMissingParameterValueFails("type/subtype;parameter", 21);
+        this.parseMissingParameterValueFails("type/subtype;parameter");
     }
 
     @Test
     public final void testParameterValueMissingFails2() {
-        this.parseMissingParameterValueFails("type/subtype;parameter=", 22);
+        this.parseMissingParameterValueFails("type/subtype;parameter=");
     }
 
     @Test
     public final void testParameterValueMissingFails3() {
-        this.parseMissingParameterValueFails("type/subtype;p1=v1;p2", 20);
+        this.parseMissingParameterValueFails("type/subtype;p1=v1;p2");
     }
 
     @Test
     public final void testParameterValueMissingFails4() {
-        this.parseMissingParameterValueFails("type/subtype;p1=v1;p2=", 21);
+        this.parseMissingParameterValueFails("type/subtype;p1=v1;p2=");
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/TokenHeaderValueHeaderParserTestCase.java
+++ b/src/test/java/walkingkooka/net/header/TokenHeaderValueHeaderParserTestCase.java
@@ -53,33 +53,32 @@ public abstract class TokenHeaderValueHeaderParserTestCase<P extends TokenHeader
 
     @Test
     public final void testValueEqualsFails() {
-        this.parseFails("A;b=",
-                "Missing parameter value at 3 in \"A;b=\"");
+        this.parseMissingParameterValueFails("A;b=");
     }
 
     @Test
     public final void testValueSpaceEqualsFails() {
-        this.parseMissingParameterValueFails("A;b =", 4);
+        this.parseMissingParameterValueFails("A;b =");
     }
 
     @Test
     public final void testValueTabEqualsFails() {
-        this.parseMissingParameterValueFails("A;b =", 4);
+        this.parseMissingParameterValueFails("A;b =");
     }
 
     @Test
     public final void testValueSpaceTabSpaceTabEqualsFails() {
-        this.parseMissingParameterValueFails("A;b \t \t=", 7);
+        this.parseMissingParameterValueFails("A;b \t \t=");
     }
 
     @Test
     public final void testValueEqualsSpaceFails() {
-        this.parseMissingParameterValueFails("A;b= ", 4);
+        this.parseMissingParameterValueFails("A;b= ");
     }
 
     @Test
     public final void testValueEqualsTabFails() {
-        this.parseMissingParameterValueFails("A;b=\t", 4);
+        this.parseMissingParameterValueFails("A;b=\t");
     }
 
     @Test


### PR DESCRIPTION
- standardised missing parameter value error messages.
- replaced @Test(expected=HeaderValueException) with call to appropriate parseXXXFail.