### PR TITLE
HeaderValue.toHeaderTextList

### DIFF
--- a/src/main/java/walkingkooka/net/header/CacheControlDirective.java
+++ b/src/main/java/walkingkooka/net/header/CacheControlDirective.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * <pre>
@@ -62,19 +61,6 @@ public final class CacheControlDirective<T> implements HeaderValue {
     public static List<CacheControlDirective<?>> parse(final String text) {
         return CacheControlDirectiveHeaderParser.parseCacheControlDirectiveList(text);
     }
-
-    /**
-     * Makes a header text from a list of directives.
-     */
-    public static String toHeaderTextList(final List<CacheControlDirective<?>> directives) {
-        Objects.requireNonNull(directives, "directives");
-
-        return directives.stream()
-                .map(d -> d.toHeaderText())
-                .collect(Collectors.joining(TO_STRING_SEPARATOR));
-    }
-
-    private final static String TO_STRING_SEPARATOR = SEPARATOR + " ";
 
     // constants................................................................................................
 

--- a/src/main/java/walkingkooka/net/header/CacheControlDirectiveListHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/header/CacheControlDirectiveListHeaderValueConverter.java
@@ -51,7 +51,7 @@ final class CacheControlDirectiveListHeaderValueConverter extends HeaderValueCon
 
     @Override
     String toText0(final List<CacheControlDirective<?>> directives, final Name name) {
-        return CacheControlDirective.toHeaderTextList(directives);
+        return HeaderValue.toHeaderTextList(directives);
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/CharsetHeaderValue.java
+++ b/src/main/java/walkingkooka/net/header/CharsetHeaderValue.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 
 /**
@@ -94,20 +93,6 @@ final public class CharsetHeaderValue extends HeaderValueWithParameters2<Charset
                 result :
                 new CharsetHeaderValue(charset, parameters);
     }
-
-    /**
-     * Formats or converts a list of media types back to a String. Basically
-     * an inverse of {@link #parse(String)}.
-     */
-    public static String toHeaderTextList(final List<CharsetHeaderValue> charsetHeaderValues) {
-        Objects.requireNonNull(charsetHeaderValues, "charsetHeaderValues");
-
-        return charsetHeaderValues.stream()
-                .map(m -> m.toString())
-                .collect(Collectors.joining(TOSTRING_CHARSET_SEPARATOR));
-    }
-
-    private final static String TOSTRING_CHARSET_SEPARATOR = SEPARATOR + " ";
 
     // ctor ...................................................................................................
 

--- a/src/main/java/walkingkooka/net/header/CharsetHeaderValueListHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/header/CharsetHeaderValueListHeaderValueConverter.java
@@ -52,7 +52,7 @@ final class CharsetHeaderValueListHeaderValueConverter extends HeaderValueConver
 
     @Override
     String toText0(final List<CharsetHeaderValue> value, final Name name) {
-        return CharsetHeaderValue.toHeaderTextList(value);
+        return HeaderValue.toHeaderTextList(value);
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ETag.java
+++ b/src/main/java/walkingkooka/net/header/ETag.java
@@ -24,7 +24,6 @@ import walkingkooka.text.CharacterConstant;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Holds a ETAG.
@@ -63,19 +62,6 @@ public abstract class ETag implements HeaderValue,
     public static List<ETag> parseList(final String text) {
         return ETagListHeaderParser.parseList(text);
     }
-
-    /**
-     * Builds a header value representation of a list of tags.
-     */
-    public static String toHeaderTextList(final List<ETag> tags) {
-        Objects.requireNonNull(tags, "tags");
-
-        return tags.stream()
-                .map(t -> t.toString())
-                .collect(Collectors.joining(TOSTRING_SEPARATOR));
-    }
-
-    private final static String TOSTRING_SEPARATOR = SEPARATOR.string().concat(" ");
 
     /**
      * Package private to limit sub classing.

--- a/src/main/java/walkingkooka/net/header/ETagListHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/header/ETagListHeaderValueConverter.java
@@ -51,7 +51,7 @@ final class ETagListHeaderValueConverter extends HeaderValueConverter<List<ETag>
 
     @Override
     String toText0(final List<ETag> value, final Name name) {
-        return ETag.toHeaderTextList(value);
+        return HeaderValue.toHeaderTextList(value);
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/HeaderValue.java
+++ b/src/main/java/walkingkooka/net/header/HeaderValue.java
@@ -21,10 +21,25 @@ package walkingkooka.net.header;
 import walkingkooka.test.HashCodeEqualsDefined;
 import walkingkooka.text.CharacterConstant;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 /**
  * Contract implemented by header value types.
  */
 public interface HeaderValue extends HashCodeEqualsDefined, HasHeaderScope {
+
+    /**
+     * Builds a header value representation of a list of headerValues.
+     */
+    static <H extends HeaderValue> String toHeaderTextList(final List<H> headerValues) {
+        Objects.requireNonNull(headerValues, "headerValues");
+
+        return headerValues.stream()
+                .map(t -> t.toHeaderText())
+                .collect(Collectors.joining(SEPARATOR.string().concat(" ")));
+    }
 
     /**
      * The separator character that separates multiple header values.

--- a/src/main/java/walkingkooka/net/header/HeaderValueTestCase.java
+++ b/src/main/java/walkingkooka/net/header/HeaderValueTestCase.java
@@ -19,7 +19,10 @@
 package walkingkooka.net.header;
 
 import org.junit.Test;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.test.ClassTestCase;
+
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 
@@ -61,6 +64,13 @@ public abstract class HeaderValueTestCase<V extends HeaderValue> extends ClassTe
     protected void toHeaderTextAndCheck(final HeaderValue headerValue, final String expected) {
         assertEquals("headerText of " + headerValue, expected, headerValue.toHeaderText());
         this.isWildcardAndCheck0(headerValue, String.valueOf(HeaderValue.WILDCARD).equals(expected));
+    }
+
+    protected void toHeaderTextListAndCheck(final String toString,
+                                            final HeaderValue... headerValues) {
+        assertEquals("toHeaderTextList returned wrong toString " + Arrays.toString(headerValues),
+                toString,
+                HeaderValue.toHeaderTextList(Lists.of(headerValues)));
     }
 
     protected void isWildcardAndCheck(final boolean expected) {

--- a/src/main/java/walkingkooka/net/header/LanguageTag.java
+++ b/src/main/java/walkingkooka/net/header/LanguageTag.java
@@ -28,7 +28,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Holds a LanguageTag which is the value of a accept-language and similar headers.
@@ -78,19 +77,6 @@ public abstract class LanguageTag extends HeaderValueWithParameters2<LanguageTag
     public static List<LanguageTag> parseList(final String text) {
         return LanguageTagListHeaderParser.parseList(text);
     }
-
-    /**
-     * Builds a header value representation of a list of tags.
-     */
-    public static String toHeaderTextList(final List<LanguageTag> tags) {
-        Objects.requireNonNull(tags, "tags");
-
-        return tags.stream()
-                .map(t -> t.toString())
-                .collect(Collectors.joining(TOSTRING_SEPARATOR));
-    }
-
-    private final static String TOSTRING_SEPARATOR = SEPARATOR.string().concat(" ");
 
     /**
      * Package private to limit sub classing.

--- a/src/main/java/walkingkooka/net/header/LanguageTagListHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/header/LanguageTagListHeaderValueConverter.java
@@ -51,7 +51,7 @@ final class LanguageTagListHeaderValueConverter extends HeaderValueConverter<Lis
 
     @Override
     String toText0(final List<LanguageTag> values, final Name name) {
-        return LanguageTag.toHeaderTextList(values);
+        return HeaderValue.toHeaderTextList(values);
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/MediaType.java
+++ b/src/main/java/walkingkooka/net/header/MediaType.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 
 /**
@@ -257,20 +256,6 @@ final public class MediaType extends HeaderValueWithParameters2<MediaType,
                         subType,
                         parameters);
     }
-
-    /**
-     * Formats or converts a list of media types back to a String. Basically
-     * an inverse of {@link #parseList(String)}.
-     */
-    public static String toHeaderTextList(final List<MediaType> mediaTypes) {
-        Objects.requireNonNull(mediaTypes, "mediaTypes");
-
-        return mediaTypes.stream()
-                .map(m -> m.toString())
-                .collect(Collectors.joining(TOSTRING_MEDIATYPE_SEPARATOR));
-    }
-
-    private final static String TOSTRING_MEDIATYPE_SEPARATOR = SEPARATOR.character() + " ";
 
     // ctor ...................................................................................................
 

--- a/src/main/java/walkingkooka/net/header/MediaTypeListHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/header/MediaTypeListHeaderValueConverter.java
@@ -51,7 +51,7 @@ final class MediaTypeListHeaderValueConverter extends HeaderValueConverter<List<
 
     @Override
     String toText0(final List<MediaType> values, final Name name) {
-        return MediaType.toHeaderTextList(values);
+        return HeaderValue.toHeaderTextList(values);
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/TokenHeaderValue.java
+++ b/src/main/java/walkingkooka/net/header/TokenHeaderValue.java
@@ -25,9 +25,7 @@ import walkingkooka.text.CaseSensitivity;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Holds a simple header value, and any accompanying parameters. Parameter values will be of the type
@@ -61,17 +59,6 @@ public final class TokenHeaderValue extends HeaderValueWithParameters2<TokenHead
      */
     public static List<TokenHeaderValue> parseList(final String text) {
         return TokenHeaderValueListHeaderParser.parseTokenHeaderValueList(text);
-    }
-
-    /**
-     * Formats a charsets of tokens, basically the inverse of {@link #parseList(String)}
-     */
-    public static String toHeaderTextList(final List<TokenHeaderValue> tokens) {
-        Objects.requireNonNull(tokens, "tokens");
-
-        return tokens.stream()
-                .map(t -> t.toString())
-                .collect(Collectors.joining(", "));
     }
 
     /**

--- a/src/main/java/walkingkooka/net/header/TokenHeaderValueListHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/header/TokenHeaderValueListHeaderValueConverter.java
@@ -51,7 +51,7 @@ final class TokenHeaderValueListHeaderValueConverter extends HeaderValueConverte
 
     @Override
     String toText0(final List<TokenHeaderValue> values, final Name name) {
-        return TokenHeaderValue.toHeaderTextList(values);
+        return HeaderValue.toHeaderTextList(values);
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/http/HttpEntity.java
+++ b/src/main/java/walkingkooka/net/http/HttpEntity.java
@@ -26,6 +26,7 @@ import walkingkooka.compare.Range;
 import walkingkooka.compare.RangeBound;
 import walkingkooka.net.header.CharsetHeaderValue;
 import walkingkooka.net.header.CharsetName;
+import walkingkooka.net.header.HeaderValue;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.header.MediaType;
 import walkingkooka.net.header.MediaTypeParameterName;
@@ -72,7 +73,7 @@ public final class HttpEntity implements HasHeaders, HashCodeEqualsDefined {
                 .stream()
                 .anyMatch(v -> v.value().matches(contentTypeCharset))) {
             throw new NotAcceptableHeaderException("Content type " + contentTypeCharset +
-                    " not in accept-charset=" + CharsetHeaderValue.toHeaderTextList(acceptCharset));
+                    " not in accept-charset=" + HeaderValue.toHeaderTextList(acceptCharset));
         }
 
         final byte[] body = text.getBytes(contentTypeCharset.charset().get());

--- a/src/test/java/walkingkooka/net/header/CacheControlDirectiveTest.java
+++ b/src/test/java/walkingkooka/net/header/CacheControlDirectiveTest.java
@@ -204,11 +204,6 @@ public final class CacheControlDirectiveTest extends HeaderValueTestCase<CacheCo
 
     // toHeaderTextList..........................................................................
 
-    @Test(expected = NullPointerException.class)
-    public void testToHeaderTextListNullFails() {
-        CacheControlDirective.toHeaderTextList(null);
-    }
-
     @Test
     public void testToHeaderTextListNoCache() {
         this.toHeaderTextListAndCheck("no-cache",
@@ -227,13 +222,6 @@ public final class CacheControlDirectiveTest extends HeaderValueTestCase<CacheCo
                 CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
                 CacheControlDirective.NO_CACHE,
                 CacheControlDirective.NO_STORE);
-    }
-
-    private void toHeaderTextListAndCheck(final String toString,
-                                          final CacheControlDirective<?>... directives) {
-        assertEquals("toHeaderTextList returned wrong toString " + Arrays.toString(directives),
-                toString,
-                CacheControlDirective.toHeaderTextList(Lists.of(directives)));
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/CharsetHeaderValueTest.java
+++ b/src/test/java/walkingkooka/net/header/CharsetHeaderValueTest.java
@@ -154,11 +154,6 @@ public final class CharsetHeaderValueTest extends HeaderValueWithParametersTestC
 
     // toHeaderTextList ...........................................................................................
 
-    @Test(expected = NullPointerException.class)
-    public void testToHeaderTextListNullFails() {
-        CharsetHeaderValue.toHeaderTextList(null);
-    }
-
     @Test
     public void testToHeaderTextListOne() {
         final String text = "a";
@@ -178,12 +173,6 @@ public final class CharsetHeaderValueTest extends HeaderValueWithParametersTestC
         this.toHeaderTextListAndCheck("a, b",
                 CharsetHeaderValue.with(CharsetName.with("a")),
                 CharsetHeaderValue.with(CharsetName.with("b")));
-    }
-
-    private void toHeaderTextListAndCheck(final String toString, final CharsetHeaderValue... tokens) {
-        assertEquals("header text of " + Arrays.toString(tokens),
-                toString,
-                CharsetHeaderValue.toHeaderTextList(Lists.of(tokens)));
     }
 
     // helpers ...........................................................................................

--- a/src/test/java/walkingkooka/net/header/ETagTest.java
+++ b/src/test/java/walkingkooka/net/header/ETagTest.java
@@ -81,45 +81,40 @@ public final class ETagTest extends HeaderValueTestCase<ETag> {
 
     // toHeaderTextList.......................................................................................
 
-    @Test(expected = NullPointerException.class)
-    public void testToHeaderTextListListNullFails() {
-        ETag.toHeaderTextList(null);
-    }
-
     @Test
-    public void testToHeaderTextListListOfOne() {
+    public void testToHeaderTextListOne() {
         this.toHeaderTextListAndCheck("\"abc123\"",
                 ETag.with("abc123", ETagValidator.STRONG));
     }
 
     @Test
-    public void testToHeaderTextListListOfOne2() {
+    public void testToHeaderTextListOne2() {
         this.toHeaderTextListAndCheck("W/\"abc123\"",
                 ETag.with("abc123", ETagValidator.WEAK));
     }
 
     @Test
-    public void testToHeaderTextListListOfOneWildcard() {
+    public void testToHeaderTextListOneWildcard() {
         this.toHeaderTextListAndCheck("*",
                 ETag.wildcard());
     }
 
     @Test
-    public void testToHeaderTextListListOfMany() {
+    public void testToHeaderTextListSeveral() {
         this.toHeaderTextListAndCheck("\"1\", \"2\"",
                 ETag.with("1", ETagValidator.STRONG),
                 ETag.with("2", ETagValidator.STRONG));
     }
 
     @Test
-    public void testToHeaderTextListListOfMany2() {
+    public void testToHeaderTextListSeveral2() {
         this.toHeaderTextListAndCheck("\"11\", \"22\"",
                 ETag.with("11", ETagValidator.STRONG),
                 ETag.with("22", ETagValidator.STRONG));
     }
 
     @Test
-    public void testToHeaderTextListListOfMany3() {
+    public void testToHeaderTextListSeveral3() {
         this.toHeaderTextListAndCheck("W/\"11\", \"22\"",
                 ETag.with("11", ETagValidator.WEAK),
                 ETag.with("22", ETagValidator.STRONG));
@@ -128,7 +123,7 @@ public final class ETagTest extends HeaderValueTestCase<ETag> {
     private void toHeaderTextListAndCheck(final String toString, final ETag... tags) {
         assertEquals("ETag.toString(List) failed =" + CharSequences.quote(toString),
                 toString,
-                ETag.toHeaderTextList(Lists.of(tags)));
+                HeaderValue.toHeaderTextList(Lists.of(tags)));
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/LanguageTagTest.java
+++ b/src/test/java/walkingkooka/net/header/LanguageTagTest.java
@@ -19,21 +19,12 @@
 package walkingkooka.net.header;
 
 import org.junit.Test;
-import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
-import walkingkooka.text.CharSequences;
 import walkingkooka.type.MemberVisibility;
-
-import static org.junit.Assert.assertEquals;
 
 public final class LanguageTagTest extends LanguageTagTestCase<LanguageTag> {
 
     // toHeaderTextList.......................................................................................
-
-    @Test(expected = NullPointerException.class)
-    public void testToHeaderTextListListNullFails() {
-        LanguageTag.toHeaderTextList(null);
-    }
 
     @Test
     public void testToHeaderTextListListOfOne() {
@@ -67,12 +58,6 @@ public final class LanguageTagTest extends LanguageTagTestCase<LanguageTag> {
 
     private LanguageTag fr() {
         return LanguageTag.with("fr");
-    }
-
-    private void toHeaderTextListAndCheck(final String toString, final LanguageTag... tags) {
-        assertEquals("LanguageTag.toString(List) failed =" + CharSequences.quote(toString),
-                toString,
-                LanguageTag.toHeaderTextList(Lists.of(tags)));
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/MediaTypeTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeTest.java
@@ -615,11 +615,6 @@ final public class MediaTypeTest extends HeaderValueWithParametersTestCase<Media
 
     // toHeaderTextList...............................................................................................
 
-    @Test(expected = NullPointerException.class)
-    public void testToHeaderTextListNullFails() {
-        MediaType.toHeaderTextList(null);
-    }
-
     @Test
     public void testToHeaderTextListOne() {
         this.toHeaderTextListAndCheck("type1/subtype1",
@@ -631,12 +626,6 @@ final public class MediaTypeTest extends HeaderValueWithParametersTestCase<Media
         this.toHeaderTextListAndCheck("type1/subtype1, type2/subtype2",
                 MediaType.with("type1", "subtype1"),
                 MediaType.with("type2", "subtype2"));
-    }
-
-    private void toHeaderTextListAndCheck(final String toString, final MediaType... mediaTypes) {
-        assertEquals("Format " + Arrays.toString(mediaTypes) + " failed",
-                toString,
-                MediaType.toHeaderTextList(Lists.of(mediaTypes)));
     }
 
     // helpers........................................................................................................

--- a/src/test/java/walkingkooka/net/header/TokenHeaderValueTest.java
+++ b/src/test/java/walkingkooka/net/header/TokenHeaderValueTest.java
@@ -160,11 +160,6 @@ public final class TokenHeaderValueTest extends HeaderValueWithParametersTestCas
 
     // toHeaderTextList ...........................................................................................
 
-    @Test(expected = NullPointerException.class)
-    public void testToHeaderTextListNullFails() {
-        TokenHeaderValue.toHeaderTextList(null);
-    }
-
     @Test
     public void testToHeaderTextListOne() {
         this.toHeaderTextListAndCheck("A",
@@ -183,12 +178,6 @@ public final class TokenHeaderValueTest extends HeaderValueWithParametersTestCas
         this.toHeaderTextListAndCheck("A, B",
                 TokenHeaderValue.with("A"),
                 TokenHeaderValue.with("B"));
-    }
-
-    private void toHeaderTextListAndCheck(final String toString, final TokenHeaderValue... tokens) {
-        assertEquals("toheaderTextList of " + Arrays.toString(tokens),
-                toString,
-                TokenHeaderValue.toHeaderTextList(Lists.of(tokens)));
     }
 
     // helpers ...........................................................................................


### PR DESCRIPTION
- replaced duplicate methods in numerous HeaderValue implementations.