### PR TITLE
UrlScheme improvements.

### DIFF
--- a/src/main/java/walkingkooka/net/UrlScheme.java
+++ b/src/main/java/walkingkooka/net/UrlScheme.java
@@ -23,6 +23,7 @@ import walkingkooka.naming.Name;
 import walkingkooka.predicate.character.CharPredicate;
 import walkingkooka.predicate.character.CharPredicateBuilder;
 import walkingkooka.predicate.character.CharPredicates;
+import walkingkooka.text.CaseSensitivity;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -41,7 +42,7 @@ public final class UrlScheme
     /**
      * A read only cache of already prepared {@link UrlScheme schemes}.
      */
-    final static Map<String, UrlScheme> CONSTANTS = Maps.sorted();
+    final static Map<String, UrlScheme> CONSTANTS = Maps.sorted(String.CASE_INSENSITIVE_ORDER);
 
     /**
      * Creates and adds a new {@link UrlScheme} to the cache being built.
@@ -62,6 +63,30 @@ public final class UrlScheme
      */
     public final static UrlScheme HTTPS = UrlScheme.registerConstant("https");
 
+    /**
+     * <a href="https://tools.ietf.org/html/rfc3986#section-3"></a>
+     * <pre>
+     * 3.1.  Scheme
+     *
+     * Each URI begins with a scheme name that refers to a specification for
+     * assigning identifiers within that scheme.  As such, the URI syntax is
+     * a federated and extensible naming system wherein each scheme's
+     * specification may further restrict the syntax and semantics of
+     * identifiers using that scheme.
+     *
+     * Scheme names consist of a sequence of characters beginning with a
+     * letter and followed by any combination of letters, digits, plus
+     * ("+"), period ("."), or hyphen ("-").  Although schemes are case-
+     * insensitive, the canonical form is lowercase and documents that
+     * specify schemes must do so with lowercase letters.  An implementation
+     * should accept uppercase letters as equivalent to lowercase in scheme
+     * names (e.g., allow "HTTP" as well as "http") for the sake of
+     * robustness but should only produce lowercase scheme names for
+     * consistency.
+     *
+     *    scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )    
+     * </pre>
+     */
     private final static CharPredicate INITIAL = CharPredicates.range('A', 'Z').or(CharPredicates.range('a', 'z'));
 
     /**
@@ -100,7 +125,7 @@ public final class UrlScheme
     UrlScheme(final String name) {
         super();
         this.name = name;
-        this.nameWithSlashes = name + "://";
+        this.nameWithSlashes = name.toLowerCase() + "://";
     }
 
     // Name
@@ -135,14 +160,14 @@ public final class UrlScheme
 
     @Override
     public int compareTo(final UrlScheme scheme) {
-        return this.name.compareToIgnoreCase(scheme.name);
+        return CASE_SENSITIVITY.comparator().compare(this.name, scheme.name);
     }
 
     // Object
 
     @Override
     public int hashCode() {
-        return this.name.hashCode();
+        return CASE_SENSITIVITY.hash(this.name);
     }
 
     @Override
@@ -152,8 +177,10 @@ public final class UrlScheme
     }
 
     private boolean equals0(final UrlScheme other) {
-        return this.name.equalsIgnoreCase(other.name);
+        return this.compareTo(other) == 0;
     }
+
+    private final static CaseSensitivity CASE_SENSITIVITY = CaseSensitivity.INSENSITIVE;
 
     /**
      * Returns the raw {@link String}.

--- a/src/test/java/walkingkooka/net/AbsoluteUrlTest.java
+++ b/src/test/java/walkingkooka/net/AbsoluteUrlTest.java
@@ -338,6 +338,18 @@ public final class AbsoluteUrlTest extends UrlTestCase<AbsoluteUrl> {
         assertEquals("http://host:123/path?query=value#fragment", this.createUrl().toString());
     }
 
+    @Test
+    public void testToStringUpperCasedScheme() {
+        assertEquals("test://host:123",
+                AbsoluteUrl.with(UrlScheme.with("TEST"),
+                        AbsoluteUrl.NO_CREDENTIALS,
+                        HOST,
+                        PORT,
+                        UrlPath.EMPTY,
+                        UrlQueryString.EMPTY,
+                        UrlFragment.EMPTY).toString());
+    }
+
     // factory
 
     @Override

--- a/src/test/java/walkingkooka/net/UrlSchemeComparableTest.java
+++ b/src/test/java/walkingkooka/net/UrlSchemeComparableTest.java
@@ -19,17 +19,32 @@
 package walkingkooka.net;
 
 import org.junit.Test;
-import walkingkooka.test.HashCodeEqualsDefinedEqualityTestCase;
+import walkingkooka.compare.ComparableTestCase;
 
-public final class UrlSchemeEqualityTest extends HashCodeEqualsDefinedEqualityTestCase<UrlScheme> {
+public final class UrlSchemeComparableTest extends ComparableTestCase<UrlScheme> {
+
+    @Test
+    public void testLess() {
+        this.compareToAndCheckLess(UrlScheme.with("z"));
+    }
+
+    @Test
+    public void testLessIgnoresCase() {
+        this.compareToAndCheckLess(UrlScheme.with("Z"));
+    }
 
     @Test
     public void testDifferent() {
         this.checkNotEquals(UrlScheme.with("different"));
     }
 
+    @Test
+    public void testEqualityCaseIgnored() {
+        this.checkEquals(UrlScheme.with("CUSTOM"));
+    }
+
     @Override
-    protected UrlScheme createObject() {
+    protected UrlScheme createComparable() {
         return UrlScheme.with("custom");
     }
 }

--- a/src/test/java/walkingkooka/net/UrlSchemeTest.java
+++ b/src/test/java/walkingkooka/net/UrlSchemeTest.java
@@ -44,6 +44,11 @@ public final class UrlSchemeTest extends NameTestCase<UrlScheme> {
         assertSame(UrlScheme.HTTPS, UrlScheme.with("https"));
     }
 
+    @Test
+    public void testHttpsUpperCaseUnimportantConstants() {
+        assertSame(UrlScheme.HTTPS, UrlScheme.with("HTTPS"));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidFirstCharFails() {
         this.createName("1http");
@@ -57,6 +62,22 @@ public final class UrlSchemeTest extends NameTestCase<UrlScheme> {
     @Test
     public void testIncludesPlusMinusDot() {
         this.createName("A123456789+-.abcABCxyzXYZ");
+    }
+
+    @Test
+    public void testNameWithSlashes() {
+        this.createNameAndCheckWithSlashes("http", "http://");
+    }
+
+    @Test
+    public void testNameWithSlashes2() {
+        this.createNameAndCheckWithSlashes("HTTP", "http://");
+    }
+
+    private void createNameAndCheckWithSlashes(final String value,
+                                               final String nameWithSlashes) {
+        final UrlScheme urlScheme = UrlScheme.with(value);
+        assertEquals("nameWithSlashes", nameWithSlashes, urlScheme.nameWithSlashes());
     }
 
     // withHost...........................................................................................


### PR DESCRIPTION
- UrlScheme.nameWithSlashes always returns lower case scheme.
- Fixed constant lookups to ignore case.
- Improvements to use CaseSensitivity when hashing, comparing, equality testing.

- Implements #809 