### PR TITLE
JsonObjectNode equals order unimportant

### DIFF
--- a/src/main/java/walkingkooka/tree/json/JsonBooleanNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonBooleanNode.java
@@ -46,7 +46,7 @@ public final class JsonBooleanNode extends JsonLeafNode<Boolean>{
         return this.setValue0(value).cast();
     }
 
-    final JsonBooleanNode wrap0(final JsonNodeName name, final int index, final Boolean value) {
+    final JsonBooleanNode create(final JsonNodeName name, final int index, final Boolean value) {
         return new JsonBooleanNode(name, index, value);
     }
 

--- a/src/main/java/walkingkooka/tree/json/JsonLeafNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonLeafNode.java
@@ -53,18 +53,17 @@ abstract class JsonLeafNode<V> extends JsonNode implements Value<V> {
     }
 
     final JsonLeafNode<V> replaceValue(final V value) {
-        return this.wrap0(this.name, this.index, value)
-                .replaceChild(this.parent())
+        return this.create(this.name, this.index, value)
+                .replaceChild(this.parent(), this.index)
                 .cast();
     }
 
     @Override
-    final JsonNode wrap(final JsonNodeName name, final int index) {
-        return this.wrap0(name, index, this.value)
-                .replaceChild(this.parent());
+    final JsonNode create(final JsonNodeName name, final int index) {
+        return this.create(name, index, this.value);
     }
 
-    abstract JsonLeafNode wrap0(final JsonNodeName name, final int index, final V value);
+    abstract JsonLeafNode create(final JsonNodeName name, final int index, final V value);
 
     @Override
     public final boolean isArray() {
@@ -88,7 +87,7 @@ abstract class JsonLeafNode<V> extends JsonNode implements Value<V> {
     }
 
     @Override
-    final JsonNode setChild(final JsonNode newChild) {
+    final JsonNode setChild(final JsonNode newChild, final int index) {
         throw new NeverError(this.getClass().getSimpleName() + ".setChild");
     }
 
@@ -107,12 +106,12 @@ abstract class JsonLeafNode<V> extends JsonNode implements Value<V> {
     }
 
     @Override
-    boolean equalsDescendants0(final JsonNode other) {
+    final boolean equalsDescendants(final JsonNode other) {
         return true;
     }
 
     @Override
-    final boolean equalsIgnoringParentAndChildren0(final JsonNode other) {
+    final boolean equalsValue(final JsonNode other) {
         return Objects.equals(this.value, JsonLeafNode.class.cast(other).value);
     }
 }

--- a/src/main/java/walkingkooka/tree/json/JsonNullNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonNullNode.java
@@ -48,7 +48,7 @@ public final class JsonNullNode extends JsonLeafNode<Void>{
     }
 
     @Override
-    JsonNullNode wrap0(final JsonNodeName name, final int index, final Void value) {
+    JsonNullNode create(final JsonNodeName name, final int index, final Void value) {
         return new JsonNullNode(name, index, value);
     }
 

--- a/src/main/java/walkingkooka/tree/json/JsonNumberNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonNumberNode.java
@@ -48,7 +48,7 @@ public final class JsonNumberNode extends JsonLeafNode<Double>{
     }
 
     @Override
-    JsonNumberNode wrap0(final JsonNodeName name, final int index, final Double value) {
+    JsonNumberNode create(final JsonNodeName name, final int index, final Double value) {
         return new JsonNumberNode(name, index, value);
     }
 

--- a/src/main/java/walkingkooka/tree/json/JsonObjectNodeList.java
+++ b/src/main/java/walkingkooka/tree/json/JsonObjectNodeList.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.json;
+
+import walkingkooka.collect.map.Maps;
+
+import java.util.AbstractList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * An immutable {@link List} view of elements belonging to a {@link JsonObjectNode}.
+ */
+final class JsonObjectNodeList extends AbstractList<JsonNode> {
+
+    /**
+     * Empty list constant.
+     */
+    static final JsonObjectNodeList EMPTY = new JsonObjectNodeList(Maps.empty());
+
+    /**
+     * Factory only used by {@link JsonObjectNode}
+     */
+    static JsonObjectNodeList with(final Map<JsonNodeName, JsonNode> nameToValues) {
+        return new JsonObjectNodeList(nameToValues);
+    }
+
+    /**
+     * Private ctor use factory.
+     */
+    private JsonObjectNodeList(final Map<JsonNodeName, JsonNode> nameToValues) {
+        super();
+        this.nameToValues = nameToValues;
+    }
+
+    @Override
+    public JsonNode get(int index) {
+        return this.list().get(index);
+    }
+
+    @Override
+    public int size() {
+        return this.nameToValues.size();
+    }
+
+    @Override
+    public String toString() {
+        return "[[[MAP=" + this.nameToValues.toString() + " LIST=" + this.list() + "]]]";
+    }
+
+    final Map<JsonNodeName, JsonNode> nameToValues;
+
+    /**
+     * Lazily loaded list view of json object properties.
+     */
+    private List<JsonNode> list() {
+        if(null==this.list) {
+            this.list = this.nameToValues.values().stream().collect(Collectors.toList());
+        }
+        return this.list;
+    }
+
+    private List<JsonNode> list;
+}

--- a/src/main/java/walkingkooka/tree/json/JsonParentNodeChildPredicate.java
+++ b/src/main/java/walkingkooka/tree/json/JsonParentNodeChildPredicate.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.tree.json;
+
+import java.util.function.BiPredicate;
+
+/**
+ * A {@link BiPredicate} used by {@link JsonParentNode} to compare values after fetching nodes by name.
+ */
+final class JsonParentNodeChildPredicate implements BiPredicate<JsonNode, JsonNode> {
+
+    /**
+     * Singleton
+     */
+    final static JsonParentNodeChildPredicate INSTANCE = new JsonParentNodeChildPredicate();
+
+    /**
+     * Private ctor use singleton.
+     */
+    private JsonParentNodeChildPredicate() {
+        super();
+    }
+
+    /**
+     * Tests for equality ignoring the name as this assumes the name fetched the child.
+     */
+    @Override
+    public boolean test(final JsonNode first, final JsonNode other) {
+        return null != first &&
+                first.equalsValue(other) &&
+                first.equalsDescendants(other);
+    }
+}

--- a/src/main/java/walkingkooka/tree/json/JsonStringNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonStringNode.java
@@ -51,7 +51,7 @@ public final class JsonStringNode extends JsonLeafNode<String>{
     }
 
     @Override
-    JsonStringNode wrap0(final JsonNodeName name, final int index, final String value) {
+    JsonStringNode create(final JsonNodeName name, final int index, final String value) {
         return new JsonStringNode(name, index, value);
     }
 

--- a/src/test/java/walkingkooka/tree/json/JsonNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonNodeTest.java
@@ -76,6 +76,22 @@ public final class JsonNodeTest extends ClassTestCase<JsonNode> {
                 JsonNode.object().set(JsonNodeName.with("prop1"), JsonNode.string("value1")));
     }
 
+    @Test
+    public void testParseObjectManyProperties() {
+        this.parseAndCheck("{\"prop1\": \"value1\", \"prop2\": \"value2\"}",
+                JsonNode.object()
+                        .set(JsonNodeName.with("prop1"), JsonNode.string("value1"))
+                        .set(JsonNodeName.with("prop2"), JsonNode.string("value2")));
+    }
+
+    @Test
+    public void testParseObjectOrderUnimportant() {
+        this.parseAndCheck("{\"prop1\": \"value1\", \"prop2\": \"value2\"}",
+                JsonNode.object()
+                        .set(JsonNodeName.with("prop2"), JsonNode.string("value2"))
+                        .set(JsonNodeName.with("prop1"), JsonNode.string("value1")));
+    }
+
     private void parseAndCheck(final String json, final JsonNode node) {
         assertEquals("Parse result incorrect for " + CharSequences.quoteAndEscape(json),
                 JsonNode.parse(json),

--- a/src/test/java/walkingkooka/tree/json/JsonObjectNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonObjectNodeTest.java
@@ -18,6 +18,7 @@
 
 package walkingkooka.tree.json;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
@@ -52,6 +53,43 @@ public final class JsonObjectNodeTest extends JsonParentNodeTestCase<JsonObjectN
     private final static String VALUE3 = "value3";
 
     @Test
+    @Ignore
+    @Override
+    public void testAppendChild2() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void testRemoveChildFirst() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void testRemoveChildLast() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Test
+    @Override
+    public void testSetDifferentChildren() {
+        final JsonObjectNode parent = JsonNode.object();
+
+        final JsonStringNode child1 = JsonNode.string("a1");
+        final JsonNumberNode child2 = JsonNode.number(2);
+
+        final JsonNode parent1 = this.setChildrenAndCheck(parent, child1, child2);
+
+        final JsonObjectNode child3 = JsonNode.object();
+        final JsonNode parent2 = this.setChildrenAndCheck(parent1, child3);
+
+        this.checkChildCount(parent2, child3);
+    }
+
+    @Test
     public void testSetChildrenSame() {
         final JsonNodeName key1 = this.key1();
         final JsonStringNode value1 = this.value1();
@@ -75,6 +113,33 @@ public final class JsonObjectNodeTest extends JsonParentNodeTestCase<JsonObjectN
         this.getAndCheck(object, key1, VALUE1);
 
         assertSame(object, object.setChildren(Lists.of(JsonNode.string(VALUE1).setName(key1))));
+    }
+
+    @Test
+    public void testSetChildrenSameDifferentOrder() {
+        final JsonNodeName key1 = this.key1();
+        final JsonStringNode value1 = this.value1();
+
+        final JsonNodeName key2 = this.key2();
+        final JsonStringNode value2 = this.value2();
+
+
+        final JsonObjectNode object = JsonNode.object()
+                .set(key1, value1)
+                .set(key2, value2);
+        this.childrenCheck(object);
+        this.getAndCheck(object, key1, VALUE1);
+
+        final JsonObjectNode object2 = JsonNode.object()
+                .set(key2, value2)
+                .set(key1, value1);
+        this.childrenCheck(object);
+        this.getAndCheck(object, key2, VALUE2);
+
+        final List<JsonNode> differentOrder = Lists.array();
+        differentOrder.addAll(object2.children());
+
+        assertSame(object, object.setChildren(differentOrder));
     }
 
     // set and get
@@ -109,6 +174,20 @@ public final class JsonObjectNodeTest extends JsonParentNodeTestCase<JsonObjectN
                 .set(key1, value1);
 
         assertEquals(Optional.empty(), object.get(key2()));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetNullNameFails() {
+        JsonNode.object().set(
+                null,
+                this.value1());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetNullValueFails() {
+        JsonNode.object().set(
+                this.key1(),
+                null);
     }
 
     @Test
@@ -183,7 +262,10 @@ public final class JsonObjectNodeTest extends JsonParentNodeTestCase<JsonObjectN
                 .remove(key1);
         this.childrenCheck(object);
         this.checkChildCount(object, 1);
-        this.getAndCheck(object, key1, VALUE1);
+
+        System.out.println("Test object: key1==" + object.get(key1) + " key2==" + object.get(key2) + " object: " + object.children);
+
+        this.getAndCheck(object, key2, VALUE2);
 
         // verify originals were not mutated.
         this.checkWithoutParent(value1);
@@ -201,6 +283,10 @@ public final class JsonObjectNodeTest extends JsonParentNodeTestCase<JsonObjectN
         final JsonStringNode value2 = this.value2();
 
         final JsonObjectNode empty = JsonNode.object();
+
+        final JsonObjectNode zzz = empty.set(key1, value1)
+                .set(key2, value2)
+                .remove(key1);
 
         final JsonObjectNode object = empty.set(key1, value1)
                 .set(key2, value2)


### PR DESCRIPTION
- JsonArrayNode.setChildren equality checks (now ignores child.index) saves garbage creation/improving performance.
- Improved naming of internal methods.
- Simplified set children, adoption process.
- Completes https://github.com/mP1/walkingkooka/issues/848