### PR TITLE
HeaderValueConverterTestCase decreased visibility of abstract methods.

### DIFF
--- a/src/test/java/walkingkooka/net/header/AbsoluteUrlHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/AbsoluteUrlHeaderValueConverterTest.java
@@ -37,27 +37,27 @@ public final class AbsoluteUrlHeaderValueConverterTest extends
     }
 
     @Override
-    protected AbsoluteUrlHeaderValueConverter converter() {
+    AbsoluteUrlHeaderValueConverter converter() {
         return AbsoluteUrlHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<AbsoluteUrl> name() {
+    HttpHeaderName<AbsoluteUrl> name() {
         return HttpHeaderName.REFERER;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "/relative/url/must/fail";
     }
 
     @Override
-    protected AbsoluteUrl value() {
+    AbsoluteUrl value() {
         return AbsoluteUrl.parse(URL);
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return AbsoluteUrl.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/CacheControlDirectiveExtensionHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/CacheControlDirectiveExtensionHeaderValueConverterTest.java
@@ -67,22 +67,22 @@ public final class CacheControlDirectiveExtensionHeaderValueConverterTest extend
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return ",";
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "CacheControlDirectiveExtension";
     }
 
     @Override
-    protected CacheControlDirectiveExtensionHeaderValueConverter converter() {
+    CacheControlDirectiveExtensionHeaderValueConverter converter() {
         return CacheControlDirectiveExtensionHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected Name name() {
+    Name name() {
         return CacheControlDirectiveName.with("extension");
     }
 

--- a/src/test/java/walkingkooka/net/header/CacheControlDirectiveListHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/CacheControlDirectiveListHeaderValueConverterTest.java
@@ -43,31 +43,32 @@ public final class CacheControlDirectiveListHeaderValueConverterTest extends
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "extension=\"abc";
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "List<CacheControlDirective>";
     }
 
     @Override
-    protected CacheControlDirectiveListHeaderValueConverter converter() {
+    CacheControlDirectiveListHeaderValueConverter converter() {
         return CacheControlDirectiveListHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected Name name() {
+    Name name() {
         return HttpHeaderName.CACHE_CONTROL;
     }
 
     @Override
-    protected List<CacheControlDirective<?>> value() {
+    List<CacheControlDirective<?>> value() {
         return Lists.of(CacheControlDirective.NO_CACHE, CacheControlDirective.NO_STORE);
     }
 
-    @Override protected Class<CacheControlDirectiveListHeaderValueConverter> type() {
+    @Override
+    protected Class<CacheControlDirectiveListHeaderValueConverter> type() {
         return CacheControlDirectiveListHeaderValueConverter.class;
     }
 }

--- a/src/test/java/walkingkooka/net/header/CharsetHeaderValueListHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/CharsetHeaderValueListHeaderValueConverterTest.java
@@ -54,27 +54,27 @@ public final class CharsetHeaderValueListHeaderValueConverterTest extends
     }
 
     @Override
-    protected CharsetHeaderValueListHeaderValueConverter converter() {
+    CharsetHeaderValueListHeaderValueConverter converter() {
         return CharsetHeaderValueListHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<EmailAddress> name() {
+    HttpHeaderName<EmailAddress> name() {
         return HttpHeaderName.FROM;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "\0";
     }
 
     @Override
-    protected List<CharsetHeaderValue> value() {
+    List<CharsetHeaderValue> value() {
         return Lists.of(CharsetHeaderValue.with(CharsetName.UTF_8));
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "List<CharsetHeaderValue>";
     }
 

--- a/src/test/java/walkingkooka/net/header/CharsetNameHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/CharsetNameHeaderValueConverterTest.java
@@ -51,27 +51,27 @@ public final class CharsetNameHeaderValueConverterTest extends
     }
 
     @Override
-    protected CharsetNameHeaderValueConverter converter() {
+    CharsetNameHeaderValueConverter converter() {
         return CharsetNameHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<EmailAddress> name() {
+    HttpHeaderName<EmailAddress> name() {
         return HttpHeaderName.FROM;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "\0";
     }
 
     @Override
-    protected CharsetName value() {
+    CharsetName value() {
         return CharsetName.with("utf-8");
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return CharsetName.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/ClientCookieListHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/ClientCookieListHeaderValueConverterTest.java
@@ -58,27 +58,27 @@ public final class ClientCookieListHeaderValueConverterTest extends
     }
 
     @Override
-    protected ClientCookieListHeaderValueConverter converter() {
+    ClientCookieListHeaderValueConverter converter() {
         return ClientCookieListHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<List<ClientCookie>> name() {
+    HttpHeaderName<List<ClientCookie>> name() {
         return HttpHeaderName.COOKIE;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "";
     }
 
     @Override
-    protected List<ClientCookie> value() {
+    List<ClientCookie> value() {
         return ClientCookie.parseHeader("cookie1=value1; cookie2=value2;");
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "List<ClientCookie>";
     }
 

--- a/src/test/java/walkingkooka/net/header/ContentDispositionFileNameEncodedHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentDispositionFileNameEncodedHeaderValueConverterTest.java
@@ -34,27 +34,27 @@ public final class ContentDispositionFileNameEncodedHeaderValueConverterTest ext
     }
 
     @Override
-    protected ContentDispositionFileNameEncodedHeaderValueConverter converter() {
+    ContentDispositionFileNameEncodedHeaderValueConverter converter() {
         return ContentDispositionFileNameEncodedHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected ContentDispositionParameterName name() {
+    ContentDispositionParameterName name() {
         return ContentDispositionParameterName.FILENAME;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "utf-8'";
     }
 
     @Override
-    protected ContentDispositionFileName value() {
+    ContentDispositionFileName value() {
         return ContentDispositionFileName.encoded(EncodedText.with(CharsetName.UTF_8, EncodedText.NO_LANGUAGE, "abc 123"));
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return ContentDispositionFileNameEncoded.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/ContentDispositionFileNameNotEncodedHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentDispositionFileNameNotEncodedHeaderValueConverterTest.java
@@ -34,27 +34,27 @@ public final class ContentDispositionFileNameNotEncodedHeaderValueConverterTest 
     }
 
     @Override
-    protected ContentDispositionFileNameNotEncodedHeaderValueConverter converter() {
+    ContentDispositionFileNameNotEncodedHeaderValueConverter converter() {
         return ContentDispositionFileNameNotEncodedHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected ContentDispositionParameterName name() {
+    ContentDispositionParameterName name() {
         return ContentDispositionParameterName.FILENAME;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "\0";
     }
 
     @Override
-    protected ContentDispositionFileName value() {
+    ContentDispositionFileName value() {
         return ContentDispositionFileName.notEncoded("readme.txt");
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return ContentDispositionFileNameNotEncoded.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/ContentDispositionHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentDispositionHeaderValueConverterTest.java
@@ -35,27 +35,27 @@ public final class ContentDispositionHeaderValueConverterTest extends
     }
 
     @Override
-    protected ContentDispositionHeaderValueConverter converter() {
+    ContentDispositionHeaderValueConverter converter() {
         return ContentDispositionHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<EmailAddress> name() {
+    HttpHeaderName<EmailAddress> name() {
         return HttpHeaderName.FROM;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "\0";
     }
 
     @Override
-    protected ContentDisposition value() {
+    ContentDisposition value() {
         return ContentDispositionType.ATTACHMENT.setFilename(ContentDispositionFileName.notEncoded("readme.txt"));
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return ContentDisposition.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/ContentRangeHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentRangeHeaderValueConverterTest.java
@@ -55,27 +55,27 @@ public final class ContentRangeHeaderValueConverterTest extends
     }
 
     @Override
-    protected ContentRangeHeaderValueConverter converter() {
+    ContentRangeHeaderValueConverter converter() {
         return ContentRangeHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<ContentRange> name() {
+    HttpHeaderName<ContentRange> name() {
         return HttpHeaderName.CONTENT_RANGE;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "http://example.com";
     }
 
     @Override
-    protected ContentRange value() {
+    ContentRange value() {
         return ContentRange.parse(TEXT);
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return ContentRange.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/ETagHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/ETagHeaderValueConverterTest.java
@@ -39,27 +39,27 @@ public final class ETagHeaderValueConverterTest extends
     }
 
     @Override
-    protected ETagHeaderValueConverter converter() {
+    ETagHeaderValueConverter converter() {
         return ETagHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<ETag> name() {
+    HttpHeaderName<ETag> name() {
         return HttpHeaderName.E_TAG;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "I/";
     }
 
     @Override
-    protected ETag value() {
+    ETag value() {
         return ETag.with("01234567890", ETagValidator.WEAK);
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return ETag.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/ETagListHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/ETagListHeaderValueConverterTest.java
@@ -58,27 +58,27 @@ public final class ETagListHeaderValueConverterTest extends
     }
 
     @Override
-    protected ETagListHeaderValueConverter converter() {
+    ETagListHeaderValueConverter converter() {
         return ETagListHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<List<ETag>> name() {
+    HttpHeaderName<List<ETag>> name() {
         return HttpHeaderName.IF_MATCH;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "I/";
     }
 
     @Override
-    protected List<ETag> value() {
+    List<ETag> value() {
         return ETag.parseList("\"1\",\"2\"");
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "List<ETag>";
     }
 

--- a/src/test/java/walkingkooka/net/header/EmailAddressHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/EmailAddressHeaderValueConverterTest.java
@@ -36,27 +36,27 @@ public final class EmailAddressHeaderValueConverterTest extends
     }
 
     @Override
-    protected EmailAddressHeaderValueConverter converter() {
+    EmailAddressHeaderValueConverter converter() {
         return EmailAddressHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<EmailAddress> name() {
+    HttpHeaderName<EmailAddress> name() {
         return HttpHeaderName.FROM;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "/relative/url/must/fail";
     }
 
     @Override
-    protected EmailAddress value() {
+    EmailAddress value() {
         return EmailAddress.with("user@example.com");
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return EmailAddress.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/EncodedTextHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/EncodedTextHeaderValueConverterTest.java
@@ -35,27 +35,27 @@ public final class EncodedTextHeaderValueConverterTest extends
     }
 
     @Override
-    protected EncodedTextHeaderValueConverter converter() {
+    EncodedTextHeaderValueConverter converter() {
         return EncodedTextHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected ContentDispositionParameterName name() {
+    ContentDispositionParameterName name() {
         return ContentDispositionParameterName.FILENAME;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "utf-8'";
     }
 
     @Override
-    protected EncodedText value() {
+    EncodedText value() {
         return EncodedText.with(CharsetName.UTF_8, EncodedText.NO_LANGUAGE, "abc 123");
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return EncodedText.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/HeaderValueConverterTestCase.java
+++ b/src/test/java/walkingkooka/net/header/HeaderValueConverterTestCase.java
@@ -44,7 +44,7 @@ public abstract class HeaderValueConverterTestCase<C extends HeaderValueConverte
         this.converter().parse(this.invalidHeaderValue(), this.name());
     }
 
-    abstract protected String invalidHeaderValue();
+    abstract String invalidHeaderValue();
 
     @Test(expected = NullPointerException.class)
     public void testCheckNullFails() {
@@ -82,58 +82,59 @@ public abstract class HeaderValueConverterTestCase<C extends HeaderValueConverte
         assertEquals(this.converterToString(), this.converter().toString());
     }
 
-    protected abstract String converterToString();
+    abstract String converterToString();
 
-    protected abstract C converter();
+    abstract C converter();
 
-    protected final T parse(final String value) {
+    final T parse(final String value) {
         return this.converter().parse(value, this.name());
     }
 
-    protected final void parseAndToTextAndCheck(final String text, final T value) {
+    final void parseAndToTextAndCheck(final String text, final T value) {
         this.parseAndCheck(text, value);
         this.toTextAndCheck(value, text);
     }
 
-    protected final void parseAndCheck(final String value, final T expected) {
+    final void parseAndCheck(final String value, final T expected) {
         this.parseAndCheck(value, this.name(), expected);
     }
 
-    protected abstract Name name();
+    abstract Name name();
 
-    protected final void parseAndCheck(final String value, final Name name, final T expected) {
+    final void parseAndCheck(final String value, final Name name, final T expected) {
         this.parseAndCheck(this.converter(), value, name, expected);
     }
 
-    protected final void parseAndCheck(final C converter, final String value, final T expected) {
+    final void parseAndCheck(final C converter, final String value, final T expected) {
         this.parseAndCheck(converter, value, this.name(), expected);
     }
 
-    protected final void parseAndCheck(final C converter, final String value, final Name name, final T expected) {
+    final void parseAndCheck(final C converter, final String value, final Name name, final T expected) {
         assertEquals(converter + " " + name + " of " + CharSequences.quoteIfChars(value), expected, converter.parse(value, name));
     }
 
-    protected final void check(final Object value) {
+    final void check(final Object value) {
         this.converter().check(value);
     }
 
-    protected final void toTextAndCheck(final T value, final String expected) {
+    final void toTextAndCheck(final T value, final String expected) {
         this.toTextAndCheck(value, this.name(), expected);
     }
 
-    protected final void toTextAndCheck(final T value, final Name name, final String expected) {
+    final void toTextAndCheck(final T value, final Name name, final String expected) {
         this.toTextAndCheck(this.converter(), value, name, expected);
     }
 
-    protected final void toTextAndCheck(final C converter, final T value, final String expected) {
+    final void toTextAndCheck(final C converter, final T value, final String expected) {
         this.toTextAndCheck(converter, value, this.name(), expected);
     }
 
-    protected final void toTextAndCheck(final C converter, final T value, final Name name, final String expected) {
+    final void toTextAndCheck(final C converter, final T value, final Name name, final String expected) {
         assertEquals(converter + " " + name + " of " + CharSequences.quoteIfChars(value), expected, converter.toText(value, name));
     }
 
-    protected abstract T value();
+    abstract T value();
+
 
     @Override
     protected final MemberVisibility typeVisibility() {

--- a/src/test/java/walkingkooka/net/header/HttpHeaderNameListHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/HttpHeaderNameListHeaderValueConverterTest.java
@@ -83,27 +83,27 @@ public final class HttpHeaderNameListHeaderValueConverterTest extends
     }
 
     @Override
-    protected HttpHeaderNameListHeaderValueConverter converter() {
+    HttpHeaderNameListHeaderValueConverter converter() {
         return HttpHeaderNameListHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<List<HttpHeaderName<?>>> name() {
+    HttpHeaderName<List<HttpHeaderName<?>>> name() {
         return HttpHeaderName.TRAILER;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "   ";
     }
 
     @Override
-    protected List<HttpHeaderName<?>> value() {
+    List<HttpHeaderName<?>> value() {
         return Lists.of(HttpHeaderName.ACCEPT, HttpHeaderName.ACCEPT_LANGUAGE);
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "List<HttpHeaderName>";
     }
 

--- a/src/test/java/walkingkooka/net/header/HttpMethodHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/HttpMethodHeaderValueConverterTest.java
@@ -45,27 +45,27 @@ public final class HttpMethodHeaderValueConverterTest extends
     }
 
     @Override
-    protected HttpMethodHeaderValueConverter converter() {
+    HttpMethodHeaderValueConverter converter() {
         return HttpMethodHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected LinkParameterName<HttpMethod> name() {
+    LinkParameterName<HttpMethod> name() {
         return LinkParameterName.METHOD;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "/relative/url/must/fail";
     }
 
     @Override
-    protected HttpMethod value() {
+    HttpMethod value() {
         return HttpMethod.GET;
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return HttpMethod.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/HttpMethodListHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/HttpMethodListHeaderValueConverterTest.java
@@ -80,27 +80,27 @@ public final class HttpMethodListHeaderValueConverterTest extends
     }
 
     @Override
-    protected HttpMethodListHeaderValueConverter converter() {
+    HttpMethodListHeaderValueConverter converter() {
         return HttpMethodListHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<List<HttpMethod>> name() {
+    HttpHeaderName<List<HttpMethod>> name() {
         return HttpHeaderName.ALLOW;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "/relative/url/must/fail";
     }
 
     @Override
-    protected List<HttpMethod> value() {
+    List<HttpMethod> value() {
         return Lists.of(HttpMethod.GET, HttpMethod.POST);
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "List<HttpMethod>";
     }
 

--- a/src/test/java/walkingkooka/net/header/IfRangeHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/IfRangeHeaderValueConverterTest.java
@@ -37,22 +37,22 @@ public final class IfRangeHeaderValueConverterTest extends
     }
 
     @Override
-    protected IfRangeHeaderValueConverter converter() {
+    IfRangeHeaderValueConverter converter() {
         return IfRangeHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<IfRange<?>> name() {
+    HttpHeaderName<IfRange<?>> name() {
         return HttpHeaderName.IF_RANGE;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "///";
     }
 
     @Override
-    protected IfRange<?> value() {
+    IfRange<?> value() {
         return IfRange.with(this.etag());
     }
 
@@ -60,12 +60,8 @@ public final class IfRangeHeaderValueConverterTest extends
         return ETag.with("abc123", ETagValidator.WEAK);
     }
 
-    private LocalDateTime lastModified() {
-        return LocalDateTime.of(2000, 12, 31, 6, 28, 29);
-    }
-
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "IfRange";
     }
 

--- a/src/test/java/walkingkooka/net/header/LanguageTagHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/LanguageTagHeaderValueConverterTest.java
@@ -37,27 +37,27 @@ public final class LanguageTagHeaderValueConverterTest extends
     }
 
     @Override
-    protected LanguageTagHeaderValueConverter converter() {
+    LanguageTagHeaderValueConverter converter() {
         return LanguageTagHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<LanguageTag> name() {
+    HttpHeaderName<LanguageTag> name() {
         return HttpHeaderName.CONTENT_LANGUAGE;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "invalid!!!";
     }
 
     @Override
-    protected LanguageTag value() {
+    LanguageTag value() {
         return LanguageTag.parse("en; q=0.5");
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return LanguageTag.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/LanguageTagListHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/LanguageTagListHeaderValueConverterTest.java
@@ -61,27 +61,27 @@ public final class LanguageTagListHeaderValueConverterTest extends
     }
 
     @Override
-    protected LanguageTagListHeaderValueConverter converter() {
+    LanguageTagListHeaderValueConverter converter() {
         return LanguageTagListHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<List<LanguageTag>> name() {
+    HttpHeaderName<List<LanguageTag>> name() {
         return HttpHeaderName.ACCEPT_LANGUAGE;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "invalid!!!";
     }
 
     @Override
-    protected List<LanguageTag> value() {
+    List<LanguageTag> value() {
         return LanguageTag.parseList(TEXT);
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "List<LanguageTag>";
     }
 

--- a/src/test/java/walkingkooka/net/header/LanguageTagNameHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/LanguageTagNameHeaderValueConverterTest.java
@@ -34,27 +34,27 @@ public final class LanguageTagNameHeaderValueConverterTest extends
     }
 
     @Override
-    protected LanguageTagNameHeaderValueConverter converter() {
+    LanguageTagNameHeaderValueConverter converter() {
         return LanguageTagNameHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected LinkParameterName<LanguageTagName> name() {
+    LinkParameterName<LanguageTagName> name() {
         return LinkParameterName.HREFLANG;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "invalid!!!";
     }
 
     @Override
-    protected LanguageTagName value() {
+    LanguageTagName value() {
         return LanguageTagName.with("en");
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return LanguageTagName.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/LinkHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/LinkHeaderValueConverterTest.java
@@ -72,29 +72,29 @@ public final class LinkHeaderValueConverterTest extends
     }
 
     @Override
-    protected LinkHeaderValueConverter converter() {
+    LinkHeaderValueConverter converter() {
         return LinkHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<List<Link>> name() {
+    HttpHeaderName<List<Link>> name() {
         return HttpHeaderName.LINK;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "forgot surrounding lt gt";
     }
 
     @Override
-    protected List<Link> value() {
+    List<Link> value() {
         return Lists.of(
                 Link.with(Url.parse("/file")),
                 Link.with(Url.parse("http://example.com")));
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "List<Link>";
     }
 

--- a/src/test/java/walkingkooka/net/header/LinkRelationHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/LinkRelationHeaderValueConverterTest.java
@@ -59,27 +59,27 @@ public final class LinkRelationHeaderValueConverterTest extends
     }
 
     @Override
-    protected LinkRelationHeaderValueConverter converter() {
+    LinkRelationHeaderValueConverter converter() {
         return LinkRelationHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected LinkParameterName<List<LinkRelation<?>>> name() {
+    LinkParameterName<List<LinkRelation<?>>> name() {
         return LinkParameterName.REL;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "\r";
     }
 
     @Override
-    protected List<LinkRelation<?>> value() {
+    List<LinkRelation<?>> value() {
         return Lists.of(LinkRelation.with("abc123"), LinkRelation.with("http://example.com"));
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "List<LinkRelation>";
     }
 

--- a/src/test/java/walkingkooka/net/header/LocalDateTimeHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/LocalDateTimeHeaderValueConverterTest.java
@@ -44,27 +44,27 @@ public final class LocalDateTimeHeaderValueConverterTest extends
     }
 
     @Override
-    protected LocalDateTimeHeaderValueConverter converter() {
+    LocalDateTimeHeaderValueConverter converter() {
         return LocalDateTimeHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName name() {
+    HttpHeaderName name() {
         return HttpHeaderName.DATE;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "abc";
     }
 
     @Override
-    protected LocalDateTime value() {
+    LocalDateTime value() {
         return VALUE;
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return LocalDateTime.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/LongHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/LongHeaderValueConverterTest.java
@@ -37,27 +37,27 @@ public final class LongHeaderValueConverterTest extends
     }
 
     @Override
-    protected LongHeaderValueConverter converter() {
+    LongHeaderValueConverter converter() {
         return LongHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<Long> name() {
+    HttpHeaderName<Long> name() {
         return HttpHeaderName.CONTENT_LENGTH;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "abc";
     }
 
     @Override
-    protected Long value() {
+    Long value() {
         return VALUE;
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return Long.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/MediaTypeBoundaryHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeBoundaryHeaderValueConverterTest.java
@@ -56,27 +56,27 @@ public final class MediaTypeBoundaryHeaderValueConverterTest extends
     }
 
     @Override
-    protected MediaTypeBoundaryHeaderValueConverter converter() {
+    MediaTypeBoundaryHeaderValueConverter converter() {
         return MediaTypeBoundaryHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected MediaTypeParameterName<MediaTypeBoundary> name() {
+    MediaTypeParameterName<MediaTypeBoundary> name() {
         return MediaTypeParameterName.BOUNDARY;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected MediaTypeBoundary value() {
+    MediaTypeBoundary value() {
         return MediaTypeBoundary.with(TEXT);
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return MediaTypeBoundary.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/MediaTypeHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeHeaderValueConverterTest.java
@@ -37,27 +37,27 @@ public final class MediaTypeHeaderValueConverterTest extends
     }
 
     @Override
-    protected MediaTypeHeaderValueConverter converter() {
+    MediaTypeHeaderValueConverter converter() {
         return MediaTypeHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<MediaType> name() {
+    HttpHeaderName<MediaType> name() {
         return HttpHeaderName.CONTENT_TYPE;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "invalid!!!";
     }
 
     @Override
-    protected MediaType value() {
+    MediaType value() {
         return MediaType.parse("type1/sub1;p1=v1");
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return MediaType.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/MediaTypeListHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeListHeaderValueConverterTest.java
@@ -59,27 +59,27 @@ public final class MediaTypeListHeaderValueConverterTest extends
     }
 
     @Override
-    protected MediaTypeListHeaderValueConverter converter() {
+    MediaTypeListHeaderValueConverter converter() {
         return MediaTypeListHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<List<MediaType>> name() {
+    HttpHeaderName<List<MediaType>> name() {
         return HttpHeaderName.ACCEPT;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "invalid!!!";
     }
 
     @Override
-    protected List<MediaType> value() {
+    List<MediaType> value() {
         return MediaType.parseList("type1/sub1;p1=v1,type2/sub2;p2=v2");
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "List<MediaType>";
     }
 

--- a/src/test/java/walkingkooka/net/header/OffsetDateTimeHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/OffsetDateTimeHeaderValueConverterTest.java
@@ -79,22 +79,22 @@ public final class OffsetDateTimeHeaderValueConverterTest extends
     }
 
     @Override
-    protected OffsetDateTimeHeaderValueConverter converter() {
+    OffsetDateTimeHeaderValueConverter converter() {
         return OffsetDateTimeHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected ContentDispositionParameterName<OffsetDateTime> name() {
+    ContentDispositionParameterName<OffsetDateTime> name() {
         return ContentDispositionParameterName.CREATION_DATE;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "abc";
     }
 
     @Override
-    protected OffsetDateTime value() {
+    OffsetDateTime value() {
         return OffsetDateTime.of(2000,
                 12,
                 31,
@@ -106,7 +106,7 @@ public final class OffsetDateTimeHeaderValueConverterTest extends
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return OffsetDateTime.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/QWeightHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/QWeightHeaderValueConverterTest.java
@@ -54,27 +54,27 @@ public final class QWeightHeaderValueConverterTest extends
     }
 
     @Override
-    protected QWeightHeaderValueConverter converter() {
+    QWeightHeaderValueConverter converter() {
         return QWeightHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected TokenHeaderValueParameterName name() {
+    TokenHeaderValueParameterName name() {
         return TokenHeaderValueParameterName.Q;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "abc";
     }
 
     @Override
-    protected Float value() {
+    Float value() {
         return 0.25f;
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "QWeight";
     }
 

--- a/src/test/java/walkingkooka/net/header/QuotedStringHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/QuotedStringHeaderValueConverterTest.java
@@ -108,7 +108,7 @@ public final class QuotedStringHeaderValueConverterTest extends StringHeaderValu
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "123";
     }
 

--- a/src/test/java/walkingkooka/net/header/QuotedUnquotedStringHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/QuotedUnquotedStringHeaderValueConverterTest.java
@@ -45,29 +45,29 @@ public final class QuotedUnquotedStringHeaderValueConverterTest extends
     }
 
     @Override
-    protected QuotedUnquotedStringHeaderValueConverter converter() {
+    QuotedUnquotedStringHeaderValueConverter converter() {
         return QuotedUnquotedStringHeaderValueConverter.with(CharPredicates.asciiPrintable(),
                 true,
                 CharPredicates.digit());
     }
 
     @Override
-    protected TokenHeaderValueParameterName name() {
+    TokenHeaderValueParameterName name() {
         return TokenHeaderValueParameterName.Q;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "\0";
     }
 
     @Override
-    protected String value() {
+    String value() {
         return "123";
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "String";
     }
 

--- a/src/test/java/walkingkooka/net/header/RangeHeaderValueHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/RangeHeaderValueHeaderValueConverterTest.java
@@ -49,27 +49,27 @@ public final class RangeHeaderValueHeaderValueConverterTest extends
     }
 
     @Override
-    protected RangeHeaderValueHeaderValueConverter converter() {
+    RangeHeaderValueHeaderValueConverter converter() {
         return RangeHeaderValueHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<RangeHeaderValue> name() {
+    HttpHeaderName<RangeHeaderValue> name() {
         return HttpHeaderName.RANGE;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "http://example.com";
     }
 
     @Override
-    protected RangeHeaderValue value() {
+    RangeHeaderValue value() {
         return RangeHeaderValue.parse(TEXT);
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return RangeHeaderValue.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/RangeHeaderValueUnitHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/RangeHeaderValueUnitHeaderValueConverterTest.java
@@ -45,27 +45,27 @@ public final class RangeHeaderValueUnitHeaderValueConverterTest extends
     }
 
     @Override
-    protected RangeHeaderValueUnitHeaderValueConverter converter() {
+    RangeHeaderValueUnitHeaderValueConverter converter() {
         return RangeHeaderValueUnitHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<RangeHeaderValueUnit> name() {
+    HttpHeaderName<RangeHeaderValueUnit> name() {
         return HttpHeaderName.ACCEPT_RANGES;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "http://example.com";
     }
 
     @Override
-    protected RangeHeaderValueUnit value() {
+    RangeHeaderValueUnit value() {
         return RangeHeaderValueUnit.parse(TEXT);
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return RangeHeaderValueUnit.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/RelativeUrlHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/RelativeUrlHeaderValueConverterTest.java
@@ -36,27 +36,27 @@ public final class RelativeUrlHeaderValueConverterTest extends
     }
 
     @Override
-    protected RelativeUrlHeaderValueConverter converter() {
+    RelativeUrlHeaderValueConverter converter() {
         return RelativeUrlHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<RelativeUrl> name() {
+    HttpHeaderName<RelativeUrl> name() {
         return HttpHeaderName.CONTENT_LOCATION;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "http://example.com";
     }
 
     @Override
-    protected RelativeUrl value() {
+    RelativeUrl value() {
         return RelativeUrl.parse("/file?p1=v1");
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return RelativeUrl.class.getSimpleName();
     }
 

--- a/src/test/java/walkingkooka/net/header/ServerCookieHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/ServerCookieHeaderValueConverterTest.java
@@ -40,22 +40,22 @@ public final class ServerCookieHeaderValueConverterTest extends
     }
 
     @Override
-    protected HttpHeaderName<ServerCookie> name() {
+    HttpHeaderName<ServerCookie> name() {
         return HttpHeaderName.SET_COOKIE;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "///";
     }
 
     @Override
-    protected ServerCookie value() {
+    ServerCookie value() {
         return Cookie.parseServerHeader("cookie1=value1;secure;");
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "ServerCookie";
     }
 

--- a/src/test/java/walkingkooka/net/header/StringHeaderValueConverterTestCase.java
+++ b/src/test/java/walkingkooka/net/header/StringHeaderValueConverterTestCase.java
@@ -30,17 +30,17 @@ public abstract class StringHeaderValueConverterTestCase<C extends StringHeaderV
     final static String TEXT = "abc123";
 
     @Override
-    protected final HttpHeaderName<String> name() {
+    final HttpHeaderName<String> name() {
         return HttpHeaderName.SERVER;
     }
 
     @Override
-    protected String value() {
+    String value() {
         return TEXT;
     }
 
     @Override
-    protected final String converterToString() {
+    final String converterToString() {
         return this.charPredicate().toString();
     }
 

--- a/src/test/java/walkingkooka/net/header/TokenHeaderValueHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/TokenHeaderValueHeaderValueConverterTest.java
@@ -66,27 +66,27 @@ public final class TokenHeaderValueHeaderValueConverterTest extends
     }
 
     @Override
-    protected TokenHeaderValueHeaderValueConverter converter() {
+    TokenHeaderValueHeaderValueConverter converter() {
         return TokenHeaderValueHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<TokenHeaderValue> name() {
+    HttpHeaderName<TokenHeaderValue> name() {
         return null;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "/////";
     }
 
     @Override
-    protected TokenHeaderValue value() {
+    TokenHeaderValue value() {
         return this.en();
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "TokenHeaderValue";
     }
 

--- a/src/test/java/walkingkooka/net/header/TokenHeaderValueListHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/TokenHeaderValueListHeaderValueConverterTest.java
@@ -108,27 +108,27 @@ public final class TokenHeaderValueListHeaderValueConverterTest extends
     }
 
     @Override
-    protected TokenHeaderValueListHeaderValueConverter converter() {
+    TokenHeaderValueListHeaderValueConverter converter() {
         return TokenHeaderValueListHeaderValueConverter.INSTANCE;
     }
 
     @Override
-    protected HttpHeaderName<List<TokenHeaderValue>> name() {
+    HttpHeaderName<List<TokenHeaderValue>> name() {
         return HttpHeaderName.ACCEPT_ENCODING;
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "/////";
     }
 
     @Override
-    protected List<TokenHeaderValue> value() {
+    List<TokenHeaderValue> value() {
         return Lists.of(this.en(), this.en_AU());
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return "List<TokenHeaderValue>";
     }
 

--- a/src/test/java/walkingkooka/net/header/UnquotedStringHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/UnquotedStringHeaderValueConverterTest.java
@@ -43,7 +43,7 @@ public final class UnquotedStringHeaderValueConverterTest extends StringHeaderVa
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "123";
     }
 

--- a/src/test/java/walkingkooka/net/header/UrlHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/UrlHeaderValueConverterTest.java
@@ -61,7 +61,7 @@ public final class UrlHeaderValueConverterTest extends
     }
 
     @Override
-    protected String invalidHeaderValue() {
+    String invalidHeaderValue() {
         return "\\";
     }
 
@@ -71,7 +71,7 @@ public final class UrlHeaderValueConverterTest extends
     }
 
     @Override
-    protected String converterToString() {
+    String converterToString() {
         return Url.class.getSimpleName();
     }
 


### PR DESCRIPTION
- Previously many abstract methods were protected they are now package private.