### PR TITLE
Url parsing improvements.

### DIFF
--- a/src/main/java/walkingkooka/net/RelativeUrl.java
+++ b/src/main/java/walkingkooka/net/RelativeUrl.java
@@ -18,6 +18,8 @@
 
 package walkingkooka.net;
 
+import walkingkooka.text.CharSequences;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Objects;
@@ -38,7 +40,12 @@ public final class RelativeUrl extends Url {
     private static RelativeUrl parseRelative0(final String url) {
         Objects.requireNonNull(url, "url");
 
+        if(url.contains("://")) {
+            throw new IllegalArgumentException("Relative url contains protocol=" + CharSequences.quote(url));
+        }
+
         try {
+            // protocol added but will be ignored when other components are picked.
             return parseRelative1(new URL("http://example" + url));
         } catch (final MalformedURLException cause) {
             throw new IllegalArgumentException(cause.getMessage(), cause);

--- a/src/main/java/walkingkooka/net/UrlPath.java
+++ b/src/main/java/walkingkooka/net/UrlPath.java
@@ -114,10 +114,6 @@ public final class UrlPath implements Path<UrlPath, UrlPathName>, Comparable<Url
     public UrlPath append(final UrlPathName name) {
         Objects.requireNonNull(name, "name");
 
-        if (UrlPathName.ROOT.equals(name)) {
-            throw new IllegalArgumentException(UrlPath.CANNOT_APPEND_ROOT_NAME);
-        }
-
         final StringBuilder path = new StringBuilder();
         if (false == this.isRoot()) {
             path.append(this.path);

--- a/src/test/java/walkingkooka/net/AbsoluteUrlTest.java
+++ b/src/test/java/walkingkooka/net/AbsoluteUrlTest.java
@@ -281,6 +281,18 @@ public final class AbsoluteUrlTest extends UrlTestCase<AbsoluteUrl> implements S
     }
 
     @Test
+    public void testParseSchemeHostSlash() {
+        final AbsoluteUrl url = AbsoluteUrl.parse("https://example.com/");
+        this.checkScheme(url, UrlScheme.HTTPS);
+        this.checkCredentialsAbsent(url);
+        this.checkHost(url, HostAddress.with("example.com"));
+        this.checkPortAbsent(url);
+        this.checkPath(url, UrlPath.parse("/"));
+        this.checkQueryString(url, UrlQueryString.EMPTY);
+        this.checkFragment(url, UrlFragment.EMPTY);
+    }
+
+    @Test
     public void testParseSchemeHostPort() {
         final AbsoluteUrl url = AbsoluteUrl.parse("http://example.com:789");
         this.checkScheme(url, UrlScheme.HTTP);
@@ -293,6 +305,18 @@ public final class AbsoluteUrlTest extends UrlTestCase<AbsoluteUrl> implements S
     }
 
     @Test
+    public void testParseSchemeHostPortSlash() {
+        final AbsoluteUrl url = AbsoluteUrl.parse("http://example.com:789/");
+        this.checkScheme(url, UrlScheme.HTTP);
+        this.checkCredentialsAbsent(url);
+        this.checkHost(url, HostAddress.with("example.com"));
+        this.checkPort(url, IpPort.with(789));
+        this.checkPath(url, UrlPath.parse("/"));
+        this.checkQueryString(url, UrlQueryString.EMPTY);
+        this.checkFragment(url, UrlFragment.EMPTY);
+    }
+
+    @Test
     public void testParseSchemeCredentialsHost() {
         final AbsoluteUrl url = AbsoluteUrl.parse("http://abc:def@example.com");
         this.checkScheme(url, UrlScheme.HTTP);
@@ -300,6 +324,30 @@ public final class AbsoluteUrlTest extends UrlTestCase<AbsoluteUrl> implements S
         this.checkHost(url, HostAddress.with("example.com"));
         this.checkPortAbsent(url);
         this.checkPath(url, UrlPath.EMPTY);
+        this.checkQueryString(url, UrlQueryString.EMPTY);
+        this.checkFragment(url, UrlFragment.EMPTY);
+    }
+
+    @Test
+    public void testParseSchemeHostPath() {
+        final AbsoluteUrl url = AbsoluteUrl.parse("http://example.com/path/to/file");
+        this.checkScheme(url, UrlScheme.HTTP);
+        this.checkCredentialsAbsent(url);
+        this.checkHost(url, HostAddress.with("example.com"));
+        this.checkPortAbsent(url);
+        this.checkPath(url, UrlPath.parse("/path/to/file"));
+        this.checkQueryString(url, UrlQueryString.EMPTY);
+        this.checkFragment(url, UrlFragment.EMPTY);
+    }
+
+    @Test
+    public void testParseSchemeHostPathEndsSlash() {
+        final AbsoluteUrl url = AbsoluteUrl.parse("http://example.com/path/to/file/");
+        this.checkScheme(url, UrlScheme.HTTP);
+        this.checkCredentialsAbsent(url);
+        this.checkHost(url, HostAddress.with("example.com"));
+        this.checkPortAbsent(url);
+        this.checkPath(url, UrlPath.parse("/path/to/file/"));
         this.checkQueryString(url, UrlQueryString.EMPTY);
         this.checkFragment(url, UrlFragment.EMPTY);
     }

--- a/src/test/java/walkingkooka/net/RelativeUrlTest.java
+++ b/src/test/java/walkingkooka/net/RelativeUrlTest.java
@@ -34,6 +34,11 @@ public final class RelativeUrlTest extends UrlTestCase<RelativeUrl> implements S
         RelativeUrl.parse(null);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseAbsoluteUrlFails() {
+        RelativeUrl.parse("http://example.com");
+    }
+
     @Test
     public void testParseEmptyPath() {
         final RelativeUrl url = RelativeUrl.parse("");
@@ -46,6 +51,14 @@ public final class RelativeUrlTest extends UrlTestCase<RelativeUrl> implements S
     public void testParseSlash() {
         final RelativeUrl url = RelativeUrl.parse("/");
         this.checkPath(url, UrlPath.parse("/"));
+        this.checkQueryString(url, UrlQueryString.EMPTY);
+        this.checkFragment(url, UrlFragment.EMPTY);
+    }
+
+    @Test
+    public void testParsePathEndingSlash() {
+        final RelativeUrl url = RelativeUrl.parse("/path/file/");
+        this.checkPath(url, UrlPath.parse("/path/file/"));
         this.checkQueryString(url, UrlQueryString.EMPTY);
         this.checkFragment(url, UrlFragment.EMPTY);
     }

--- a/src/test/java/walkingkooka/net/UrlPathTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathTest.java
@@ -46,16 +46,31 @@ public final class UrlPathTest extends PathTestCase<UrlPath, UrlPathName> implem
     }
 
     @Test
+    public void testParseWithoutLeadingSlash() {
+        final UrlPath path = UrlPath.parse("without-leading-slash");
+        this.checkValue(path, "/without-leading-slash");
+    }
+
+    @Test
+    public void testParseWithoutLeadingSlash2() {
+        final UrlPath path = UrlPath.parse("without/leading/slash");
+        this.checkValue(path, "/without/leading/slash");
+        this.checkParent(path, "/without/leading");
+    }
+
+    @Test
     public void testParseDeoesntNormalize() {
         final UrlPath path = UrlPath.parse("/a1/removed/../x/y");
         this.checkValue(path, "/a1/removed/../x/y");
         this.checkParent(path, "/a1/removed/../x");
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testAppendEmptyName() {
+    @Test
+    public void testAppendSlash() {
         final UrlPath path = UrlPath.parse("/path");
-        path.append(UrlPathName.ROOT);
+        final UrlPath pathSlash = path.append(UrlPathName.ROOT);
+        this.checkValue(pathSlash, "/path/");
+        this.checkParent(pathSlash, "/path");
     }
 
     @Test
@@ -67,6 +82,12 @@ public final class UrlPathTest extends PathTestCase<UrlPath, UrlPathName> implem
     @Test
     public void testAppendToEmptyPath() {
         final UrlPath path = UrlPath.parse("/path");
+        assertEquals(path, UrlPath.EMPTY.append(path));
+    }
+
+    @Test
+    public void testAppendToEmptyPath2() {
+        final UrlPath path = UrlPath.parse("/");
         assertEquals(path, UrlPath.EMPTY.append(path));
     }
 


### PR DESCRIPTION
- RelativeUrl parsing will fail if a protocol (absolute url) is given.
- UrlPath handles missing leading slash.