### PR TITLE
HttpRequest.cookies removed.

### DIFF
--- a/src/main/java/walkingkooka/net/header/ClientCookie.java
+++ b/src/main/java/walkingkooka/net/header/ClientCookie.java
@@ -31,6 +31,11 @@ import java.util.Objects;
 final public class ClientCookie extends Cookie {
 
     /**
+     * A constant list of no cookies.
+     */
+    public final static List<ClientCookie> NO_COOKIES = Lists.empty();
+
+    /**
      * Converts a {@link javax.servlet.http.Cookie} into a {@link Cookie}.
      */
     public static ClientCookie from(final javax.servlet.http.Cookie cookie) {

--- a/src/main/java/walkingkooka/net/header/CookieName.java
+++ b/src/main/java/walkingkooka/net/header/CookieName.java
@@ -66,7 +66,9 @@ final public class CookieName extends HeaderNameValue
      */
     @Override
     public Optional<ClientCookie> parameterValue(final HttpRequest request) {
-        return request.cookies().stream()
+        return HttpHeaderName.COOKIE.headerValue(request.headers())
+                .orElse(ClientCookie.NO_COOKIES)
+                .stream()
                 .filter(c -> c.name().equals(this))
                 .findFirst();
     }

--- a/src/main/java/walkingkooka/net/http/server/FakeHttpRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/FakeHttpRequest.java
@@ -19,7 +19,6 @@
 package walkingkooka.net.http.server;
 
 import walkingkooka.net.RelativeUrl;
-import walkingkooka.net.header.ClientCookie;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.http.HttpMethod;
 import walkingkooka.net.http.HttpProtocolVersion;
@@ -53,11 +52,6 @@ public class FakeHttpRequest implements HttpRequest, Fake {
 
     @Override
     public Map<HttpHeaderName<?>, Object> headers() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<ClientCookie> cookies() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/net/http/server/HeaderScopeHttpRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/HeaderScopeHttpRequest.java
@@ -19,7 +19,6 @@
 package walkingkooka.net.http.server;
 
 import walkingkooka.net.RelativeUrl;
-import walkingkooka.net.header.ClientCookie;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.header.HttpHeaderScope;
 import walkingkooka.net.http.HttpMethod;
@@ -72,11 +71,6 @@ final class HeaderScopeHttpRequest implements HttpRequest {
     }
 
     private final HeaderScopeHttpRequestHeadersMap headers;
-
-    @Override
-    public List<ClientCookie> cookies() {
-        return this.request.cookies();
-    }
 
     @Override
     public Map<HttpRequestParameterName, List<String>> parameters() {

--- a/src/main/java/walkingkooka/net/http/server/HttpRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpRequest.java
@@ -18,10 +18,8 @@
 
 package walkingkooka.net.http.server;
 
-import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.net.RelativeUrl;
-import walkingkooka.net.header.ClientCookie;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.http.HasHeaders;
 import walkingkooka.net.http.HttpMethod;
@@ -40,11 +38,6 @@ public interface HttpRequest extends HasHeaders {
      * An empty {@link Map} with no headers.
      */
     Map<HttpHeaderName<?>, Object> NO_HEADERS = Maps.empty();
-
-    /**
-     * An empty {@link List} with no cookies.
-     */
-    List<ClientCookie> NO_COOKIES = Lists.empty();
 
     /**
      * An empty {@link Map} with no parameters.
@@ -70,11 +63,6 @@ public interface HttpRequest extends HasHeaders {
      * Returns the {@link HttpMethod method} used to make the request.
      */
     HttpMethod method();
-
-    /**
-     * Returns all cookies that appear in the request.
-     */
-    List<ClientCookie> cookies();
 
     /**
      * Returns a {@link Map} of parameters which may be taken from the query string or post data etc, depending on the method.

--- a/src/main/java/walkingkooka/net/http/server/HttpServletRequestHttpRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpServletRequestHttpRequest.java
@@ -21,19 +21,15 @@ package walkingkooka.net.http.server;
 import walkingkooka.build.tostring.ToStringBuilder;
 import walkingkooka.build.tostring.ToStringBuilderOption;
 import walkingkooka.net.RelativeUrl;
-import walkingkooka.net.header.ClientCookie;
-import walkingkooka.net.header.Cookie;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.http.HttpMethod;
 import walkingkooka.net.http.HttpProtocolVersion;
 import walkingkooka.net.http.HttpTransport;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * An adapter that presents a {@link HttpRequest} from a {@link HttpServletRequest}.
@@ -97,21 +93,6 @@ final class HttpServletRequestHttpRequest implements HttpRequest {
     }
 
     private HttpServletRequestHttpRequestHeadersMap headers;
-
-    /**
-     * Lazily creates the list of {@link ClientCookie}.
-     */
-    @Override
-    public List<ClientCookie> cookies() {
-        if (null == this.cookies) {
-            this.cookies = Arrays.stream(this.request.getCookies())
-                    .map(Cookie::clientFrom)
-                    .collect(Collectors.toList());
-        }
-        return this.cookies;
-    }
-
-    private List<ClientCookie> cookies;
 
     @Override
     public Map<HttpRequestParameterName, List<String>> parameters() {

--- a/src/main/java/walkingkooka/net/http/server/RouterHttpRequestParametersMap.java
+++ b/src/main/java/walkingkooka/net/http/server/RouterHttpRequestParametersMap.java
@@ -107,15 +107,23 @@ final class RouterHttpRequestParametersMap extends AbstractMap<HttpRequestAttrib
 
     @Override
     public int size() {
-        return HttpRequestAttributes.size() +
-                this.cookies().size() +
-                this.headers().size() +
-                this.pathNames().length +
-                this.parameters().size();
+        if(-1 == this.size) {
+            this.size = HttpRequestAttributes.size() +
+                    this.cookieCount() +
+                    this.headers().size() +
+                    this.pathNames().length +
+                    this.parameters().size();
+        }
+        return this.size;
     }
 
-    private List<ClientCookie> cookies() {
-        return this.request.cookies();
+    /**
+     * Caches the number of parameter values.
+     */
+    private int size = -1;
+
+    private int cookieCount() {
+        return HttpHeaderName.COOKIE.headerValue(this.headers()).orElse(ClientCookie.NO_COOKIES).size();
     }
 
     private Map<HttpHeaderName<?>, Object> headers() {

--- a/src/main/java/walkingkooka/net/http/server/RouterHttpRequestParametersMapEntrySet.java
+++ b/src/main/java/walkingkooka/net/http/server/RouterHttpRequestParametersMapEntrySet.java
@@ -20,6 +20,8 @@ package walkingkooka.net.http.server;
 
 import walkingkooka.Cast;
 import walkingkooka.collect.iterator.Iterators;
+import walkingkooka.net.header.ClientCookie;
+import walkingkooka.net.header.HttpHeaderName;
 
 import java.util.AbstractSet;
 import java.util.Iterator;
@@ -57,7 +59,7 @@ final class RouterHttpRequestParametersMapEntrySet extends AbstractSet<Entry<Htt
         // url query string parameters are ignored...
         final Iterator<Entry<HttpRequestAttribute<?>, Object>> pathNames = RouterHttpRequestParametersMapPathComponentEntryIterator.with(map.pathNames());
         final Iterator<Entry<HttpRequestAttribute<?>, Object>> headers = RouterHttpRequestParametersMapHttpHeaderEntryIterator.with(request.headers().entrySet().iterator());
-        final Iterator<Entry<HttpRequestAttribute<?>, Object>> cookies = RouterHttpRequestParametersMapCookiesEntryIterator.with(request.cookies());
+        final Iterator<Entry<HttpRequestAttribute<?>, Object>> cookies = RouterHttpRequestParametersMapCookiesEntryIterator.with(HttpHeaderName.COOKIE.headerValue(request.headers()).orElse(ClientCookie.NO_COOKIES));
         final Iterator<Entry<HttpRequestAttribute<?>, Object>> parameters = Cast.to(request.parameters().entrySet().iterator());
 
         return Iterators.chain(attributes, Iterators.chain(pathNames, Iterators.chain(headers, Iterators.chain(cookies, parameters))));

--- a/src/test/java/walkingkooka/net/header/CookieNameTest.java
+++ b/src/test/java/walkingkooka/net/header/CookieNameTest.java
@@ -20,11 +20,12 @@ package walkingkooka.net.header;
 
 
 import org.junit.Test;
+import walkingkooka.collect.map.Maps;
 import walkingkooka.naming.NameTestCase;
 import walkingkooka.net.http.server.FakeHttpRequest;
 import walkingkooka.text.CaseSensitivity;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -142,9 +143,10 @@ final public class CookieNameTest extends NameTestCase<CookieName, CookieName> {
         final CookieName name = CookieName.with("cookie123");
         assertEquals(Optional.of(Cookie.client(name, "value123")),
                 name.parameterValue(new FakeHttpRequest() {
+
                     @Override
-                    public List<ClientCookie> cookies() {
-                        return Cookie.parseClientHeader("a=b;cookie123=value123;x=y");
+                    public Map<HttpHeaderName<?>, Object> headers() {
+                        return Maps.one(HttpHeaderName.COOKIE, Cookie.parseClientHeader("a=b;cookie123=value123;x=y"));
                     }
                 }));
     }

--- a/src/test/java/walkingkooka/net/http/server/HeaderScopeHttpRequestTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HeaderScopeHttpRequestTest.java
@@ -22,8 +22,6 @@ import org.junit.Test;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.net.RelativeUrl;
 import walkingkooka.net.Url;
-import walkingkooka.net.header.ClientCookie;
-import walkingkooka.net.header.Cookie;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.header.NotAcceptableHeaderException;
 import walkingkooka.net.http.HttpMethod;
@@ -46,7 +44,6 @@ public final class HeaderScopeHttpRequestTest extends HttpRequestTestCase<Header
     private final static HttpHeaderName<Long> HEADER = HttpHeaderName.CONTENT_LENGTH;
     private final static Long HEADER_VALUE = 123L;
     private final static Map<HttpHeaderName<?>, Object> HEADERS = Maps.one(HEADER, HEADER_VALUE);
-    private final static List<ClientCookie> COOKIES = Cookie.parseClientHeader("cookie123=value456");
     private final static Map<HttpRequestParameterName, List<String>> PARAMETERS = Maps.fake();
     private final static String TOSTRING = HeaderScopeHttpRequestTest.class.getSimpleName() + ".toString";
 
@@ -130,11 +127,6 @@ public final class HeaderScopeHttpRequestTest extends HttpRequestTestCase<Header
     }
 
     @Test
-    public void testCookies() {
-        assertSame(COOKIES, this.createRequest().cookies());
-    }
-
-    @Test
     public void testParameters() {
         assertSame(PARAMETERS, this.createRequest().parameters());
     }
@@ -170,11 +162,6 @@ public final class HeaderScopeHttpRequestTest extends HttpRequestTestCase<Header
             @Override
             public Map<HttpHeaderName<?>, Object> headers() {
                 return HEADERS;
-            }
-
-            @Override
-            public List<ClientCookie> cookies() {
-                return COOKIES;
             }
 
             @Override

--- a/src/test/java/walkingkooka/net/http/server/HttpServletRequestHttpRequestTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HttpServletRequestHttpRequestTest.java
@@ -23,7 +23,6 @@ import walkingkooka.collect.enumeration.Enumerations;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.net.Url;
-import walkingkooka.net.header.ClientCookie;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.http.HttpMethod;
 import walkingkooka.net.http.HttpProtocolVersion;
@@ -96,12 +95,6 @@ public final class HttpServletRequestHttpRequestTest extends HttpRequestTestCase
 
         assertEquals(headers,
                 this.createRequest().headers());
-    }
-
-    @Test
-    public void testCookies() {
-        assertEquals(ClientCookie.parseHeader("cookie123=cookievalue456"),
-                this.createRequest().cookies());
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/http/server/RouterHttpRequestParametersMapTest.java
+++ b/src/test/java/walkingkooka/net/http/server/RouterHttpRequestParametersMapTest.java
@@ -122,7 +122,6 @@ public final class RouterHttpRequestParametersMapTest extends MapTestCase<Router
                 this.url(),
                 this.protocolVersion(),
                 this.headers(),
-                this.cookies(),
                 this.parameters());
     }
 
@@ -143,7 +142,10 @@ public final class RouterHttpRequestParametersMapTest extends MapTestCase<Router
     }
 
     private Map<HttpHeaderName<?>, Object> headers() {
-        return Maps.one(HttpHeaderName.CONNECTION, "Close");
+        final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
+        headers.put(HttpHeaderName.CONNECTION, "Close");
+        headers.put(HttpHeaderName.COOKIE, this.cookies());
+        return headers;
     }
 
     private List<ClientCookie> cookies() {
@@ -159,7 +161,6 @@ public final class RouterHttpRequestParametersMapTest extends MapTestCase<Router
                                                      final RelativeUrl url,
                                                      final HttpProtocolVersion protocolVersion,
                                                      final Map<HttpHeaderName<?>, Object> headers,
-                                                     final List<ClientCookie> cookies,
                                                      final Map<HttpRequestParameterName, List<String>> parameters) {
         return RouterHttpRequestParametersMap.with(new FakeHttpRequest() {
 
@@ -189,18 +190,13 @@ public final class RouterHttpRequestParametersMapTest extends MapTestCase<Router
             }
 
             @Override
-            public List<ClientCookie> cookies() {
-                return cookies;
-            }
-
-            @Override
             public Map<HttpRequestParameterName, List<String>> parameters() {
                 return parameters;
             }
 
             @Override
             public String toString() {
-                return transport + " " + method + " " + url + " " + protocolVersion + " " + headers + " " + cookies + " " + parameters;
+                return transport + " " + method + " " + url + " " + protocolVersion + " " + headers + " " + parameters;
             }
         });
     }


### PR DESCRIPTION
- Client cookies must be read using HttpHeaderName.COOKIE.