### PR TITLE
AcceptCharset

### DIFF
--- a/src/main/java/walkingkooka/net/header/AcceptCharset.java
+++ b/src/main/java/walkingkooka/net/header/AcceptCharset.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.header;
+
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Charset"></a>
+ * <pre>
+ * Accept-Charset: <charset>
+ *
+ * // Multiple types, weighted with the quality value syntax:
+ * Accept-Charset: utf-8, iso-8859-1;q=0.5
+ * </pre>
+ */
+public final class AcceptCharset extends HeaderValue2<List<CharsetHeaderValue>> {
+
+    /**
+     * Parses a header value that contains one or more charsets.
+     */
+    public static AcceptCharset parse(final String text) {
+        return AcceptCharsetHeaderParser.parseAcceptCharset(text);
+    }
+
+    /**
+     * Factory that creates a new {@link AcceptCharset}
+     */
+    public static AcceptCharset with(final List<CharsetHeaderValue> values) {
+        Objects.requireNonNull(values, "values");
+
+        return new AcceptCharset(values.stream()
+                .map(v -> Objects.requireNonNull(v, "values includes null"))
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Private ctor use factory. Only called directly by factory or {@link AcceptCharsetHeaderParser}
+     */
+    AcceptCharset(final List<CharsetHeaderValue> values) {
+        super(values);
+    }
+
+    /**
+     * Finds the first system supported {@link Charset}. This assumes the {@link CharsetHeaderValue} have already been
+     * sorted by q factors, thus order implies importance.
+     */
+    public Optional<Charset> charset() {
+        return this.value().stream()
+                .map(chv -> chv.value().charset())
+                .filter(c -> c.isPresent())
+                .map(c -> c.get())
+                .findFirst();
+    }
+
+    @Override
+    public String toHeaderText() {
+        return HeaderValue.toHeaderTextList(value, SEPARATOR);
+    }
+
+    private final static String SEPARATOR = HeaderValue.SEPARATOR.string().concat(" ");
+
+
+    @Override
+    public boolean isWildcard() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultipart() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequest() {
+        return true;
+    }
+
+    @Override
+    public boolean isResponse() {
+        return false;
+    }
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof AcceptCharset;
+    }
+}

--- a/src/main/java/walkingkooka/net/header/AcceptCharsetHeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/AcceptCharsetHeaderParser.java
@@ -33,16 +33,16 @@ import java.util.List;
  * Accept-Charset: utf-8, iso-8859-1;q=0.5
  * </pre>
  */
-final class CharsetHeaderValueListHeaderParser extends HeaderParserWithParameters<CharsetHeaderValue, CharsetHeaderValueParameterName<?>> {
+final class AcceptCharsetHeaderParser extends HeaderParserWithParameters<CharsetHeaderValue, CharsetHeaderValueParameterName<?>> {
 
-    static List<CharsetHeaderValue> parseCharsetHeaderValueList(final String text) {
-        final CharsetHeaderValueListHeaderParser parser = new CharsetHeaderValueListHeaderParser(text);
+    static AcceptCharset parseAcceptCharset(final String text) {
+        final AcceptCharsetHeaderParser parser = new AcceptCharsetHeaderParser(text);
         parser.parse();
         parser.charsets.sort(HasQFactorWeight.qFactorDescendingComparator());
-        return Lists.readOnly(parser.charsets);
+        return new AcceptCharset(Lists.readOnly(parser.charsets));
     }
 
-    private CharsetHeaderValueListHeaderParser(final String text) {
+    private AcceptCharsetHeaderParser(final String text) {
         super(text);
     }
 

--- a/src/main/java/walkingkooka/net/header/AcceptCharsetHeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/header/AcceptCharsetHeaderValueConverter.java
@@ -21,44 +21,40 @@ package walkingkooka.net.header;
 
 import walkingkooka.naming.Name;
 
-import java.util.List;
-
 /**
- * A {@link HeaderValueConverter} that parses a content header value into a {@link List<CharsetHeaderValue>}.
+ * A {@link HeaderValueConverter} that parses a content header value into a {@link AcceptCharset}.
  */
-final class CharsetHeaderValueListHeaderValueConverter extends HeaderValueConverter2<List<CharsetHeaderValue>> {
+final class AcceptCharsetHeaderValueConverter extends HeaderValueConverter2<AcceptCharset> {
 
     /**
      * Singleton
      */
-    final static CharsetHeaderValueListHeaderValueConverter INSTANCE = new CharsetHeaderValueListHeaderValueConverter();
+    final static AcceptCharsetHeaderValueConverter INSTANCE = new AcceptCharsetHeaderValueConverter();
 
     /**
      * Private ctor use singleton.
      */
-    private CharsetHeaderValueListHeaderValueConverter() {
+    private AcceptCharsetHeaderValueConverter() {
         super();
     }
 
     @Override
-    List<CharsetHeaderValue> parse0(final String text, final Name name) {
-        return CharsetHeaderValue.parse(text);
+    AcceptCharset parse0(final String text, final Name name) {
+        return AcceptCharset.parse(text);
     }
 
     @Override
     void check0(final Object value, final Name name) {
-        this.checkListOfType(value, CharsetHeaderValue.class, name);
+        this.checkType(value, AcceptCharset.class, name);
     }
 
     @Override
-    String toText0(final List<CharsetHeaderValue> value, final Name name) {
-        return HeaderValue.toHeaderTextList(value, SEPARATOR);
+    String toText0(final AcceptCharset value, final Name name) {
+        return value.toHeaderText();
     }
-
-    private final static String SEPARATOR = HeaderValue.SEPARATOR.string().concat(" ");
 
     @Override
     public String toString() {
-        return this.toStringListOf(CharsetHeaderValue.class);
+        return this.toStringType(AcceptCharset.class);
     }
 }

--- a/src/main/java/walkingkooka/net/header/CharsetHeaderValue.java
+++ b/src/main/java/walkingkooka/net/header/CharsetHeaderValue.java
@@ -21,7 +21,6 @@ package walkingkooka.net.header;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.net.HasQFactorWeight;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -59,13 +58,6 @@ final public class CharsetHeaderValue extends HeaderValueWithParameters2<Charset
         CONSTANTS.put(charsetName, charsetHeaderValue);
 
         return charsetHeaderValue;
-    }
-
-    /**
-     * Creates a {@link List} of {@link CharsetHeaderValue}.
-     */
-    public static List<CharsetHeaderValue> parse(final String text) {
-        return CharsetHeaderValueListHeaderParser.parseCharsetHeaderValueList(text);
     }
 
     /**

--- a/src/main/java/walkingkooka/net/header/CharsetHeaderValueParameterName.java
+++ b/src/main/java/walkingkooka/net/header/CharsetHeaderValueParameterName.java
@@ -33,9 +33,9 @@ final public class CharsetHeaderValueParameterName<V> extends HeaderParameterNam
     final static HeaderParameterNameConstants<CharsetHeaderValueParameterName<?>> CONSTANTS = HeaderParameterNameConstants.empty(
             CharsetHeaderValueParameterName::new,
             HeaderValueConverter.quotedUnquotedString(
-                    CharsetHeaderValueListHeaderParser.QUOTED_PARAMETER_VALUE,
+                    AcceptCharsetHeaderParser.QUOTED_PARAMETER_VALUE,
                     false,
-                    CharsetHeaderValueListHeaderParser.UNQUOTED_PARAMETER_VALUE));
+                    AcceptCharsetHeaderParser.UNQUOTED_PARAMETER_VALUE));
 
     /**
      * The q factor weight parameter.

--- a/src/main/java/walkingkooka/net/header/HeaderValueConverter.java
+++ b/src/main/java/walkingkooka/net/header/HeaderValueConverter.java
@@ -46,17 +46,17 @@ abstract class HeaderValueConverter<T> {
     }
 
     /**
+     * {@see AcceptCharsetHeaderValueConverter}
+     */
+    static HeaderValueConverter<AcceptCharset> acceptCharset() {
+        return AcceptCharsetHeaderValueConverter.INSTANCE;
+    }
+
+    /**
      * {@see CacheControlDirectiveListHeaderValueConverter}
      */
     static HeaderValueConverter<List<CacheControlDirective<?>>> cacheControlDirectiveList() {
         return CacheControlDirectiveListHeaderValueConverter.INSTANCE;
-    }
-
-    /**
-     * {@see CharsetHeaderValueListHeaderValueConverter}
-     */
-    static HeaderValueConverter<List<CharsetHeaderValue>> charsetHeaderValueList() {
-        return CharsetHeaderValueListHeaderValueConverter.INSTANCE;
     }
 
     /**

--- a/src/main/java/walkingkooka/net/header/HttpHeaderName.java
+++ b/src/main/java/walkingkooka/net/header/HttpHeaderName.java
@@ -63,6 +63,15 @@ final public class HttpHeaderName<T> extends HeaderName2<T>
         return registerConstant(header, scope, HeaderValueConverter.absoluteUrl());
     }
 
+    /**
+     * Creates and adds a new {@link HttpHeaderName} to the cache being built that handles {@link List<CharsetHeaderValue>} header values.
+     */
+    private static HttpHeaderName<AcceptCharset> registerAcceptCharsetConstant(final String header,
+                                                                               final HttpHeaderNameScope scope) {
+        return registerConstant(header,
+                scope,
+                HeaderValueConverter.acceptCharset());
+    }
 
     /**
      * Creates and adds a new {@link HttpHeaderName} to the cache being built that handles {@link List<CharsetHeaderValue>} header values.
@@ -72,14 +81,6 @@ final public class HttpHeaderName<T> extends HeaderName2<T>
         return registerConstant(header,
                 scope,
                 HeaderValueConverter.cacheControlDirectiveList());
-    }
-
-    /**
-     * Creates and adds a new {@link HttpHeaderName} to the cache being built that handles {@link List<CharsetHeaderValue>} header values.
-     */
-    private static HttpHeaderName<List<CharsetHeaderValue>> registerCharsetHeaderValueListConstant(final String header,
-                                                                                                   final HttpHeaderNameScope scope) {
-        return registerConstant(header, scope, HeaderValueConverter.charsetHeaderValueList());
     }
 
     /**
@@ -310,7 +311,7 @@ final public class HttpHeaderName<T> extends HeaderName2<T>
      * Accept-Charset: utf-8, iso-8859-1;q=0.5
      * </pre>
      */
-    public final static HttpHeaderName<List<CharsetHeaderValue>> ACCEPT_CHARSET = registerCharsetHeaderValueListConstant("Accept-Charset",
+    public final static HttpHeaderName<AcceptCharset> ACCEPT_CHARSET = registerAcceptCharsetConstant("Accept-Charset",
             HttpHeaderNameScope.REQUEST);
 
     /**

--- a/src/test/java/walkingkooka/net/header/AcceptCharsetHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptCharsetHeaderParserTest.java
@@ -22,11 +22,10 @@ import org.junit.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 
-import java.util.List;
 import java.util.Map;
 
-public final class CharsetHeaderValueListHeaderParserTest extends HeaderParserWithParametersTestCase<CharsetHeaderValueListHeaderParser,
-        List<CharsetHeaderValue>> {
+public final class AcceptCharsetHeaderParserTest extends HeaderParserWithParametersTestCase<AcceptCharsetHeaderParser,
+        AcceptCharset> {
 
     // parse ...................................................................................................
 
@@ -436,8 +435,8 @@ public final class CharsetHeaderValueListHeaderParserTest extends HeaderParserWi
     // helpers...................................................................................................
 
     @Override
-    List<CharsetHeaderValue> parse(final String text) {
-        return CharsetHeaderValueListHeaderParser.parseCharsetHeaderValueList(text);
+    AcceptCharset parse(final String text) {
+        return AcceptCharsetHeaderParser.parseAcceptCharset(text);
     }
 
     private void parseAndCheck(final String headerValue, final String charset) {
@@ -467,7 +466,7 @@ public final class CharsetHeaderValueListHeaderParserTest extends HeaderParserWi
     }
 
     private void parseAndCheck(final String headerValue, final CharsetHeaderValue... values) {
-        this.parseAndCheck(headerValue, Lists.of(values));
+        this.parseAndCheck(headerValue, AcceptCharset.with(Lists.of(values)));
     }
 
     private CharsetHeaderValue charsetHeaderValue(final String charset) {
@@ -502,11 +501,11 @@ public final class CharsetHeaderValueListHeaderParserTest extends HeaderParserWi
 
     @Override
     String valueLabel() {
-        return CharsetHeaderValueListHeaderParser.CHARSET;
+        return AcceptCharsetHeaderParser.CHARSET;
     }
 
     @Override
-    protected Class<CharsetHeaderValueListHeaderParser> type() {
-        return CharsetHeaderValueListHeaderParser.class;
+    protected Class<AcceptCharsetHeaderParser> type() {
+        return AcceptCharsetHeaderParser.class;
     }
 }

--- a/src/test/java/walkingkooka/net/header/AcceptCharsetHeaderValueConverterTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptCharsetHeaderValueConverterTest.java
@@ -23,23 +23,22 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.net.email.EmailAddress;
 
 import java.nio.charset.Charset;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-public final class CharsetHeaderValueListHeaderValueConverterTest extends
-        HeaderValueConverterTestCase<CharsetHeaderValueListHeaderValueConverter,
-                List<CharsetHeaderValue>> {
+public final class AcceptCharsetHeaderValueConverterTest extends
+        HeaderValueConverterTestCase<AcceptCharsetHeaderValueConverter,
+                AcceptCharset> {
     @Override
     protected String requiredPrefix() {
-        return CharsetHeaderValue.class.getSimpleName() + List.class.getSimpleName();
+        return AcceptCharset.class.getSimpleName();
     }
 
     @Test
     public void testContentType() {
         final String charset = Charset.forName("utf8").name();
-        this.parseAndToTextAndCheck(charset,
-                Lists.of(CharsetHeaderValue.with(CharsetName.with(charset))));
+        this.parseAndToTextAndCheck2(charset,
+                CharsetHeaderValue.with(CharsetName.with(charset)));
     }
 
     @Test
@@ -49,13 +48,17 @@ public final class CharsetHeaderValueListHeaderValueConverterTest extends
         assertEquals("charsetName must have no charset",
                 CharsetName.NO_CHARSET,
                 charsetName.charset());
-        this.parseAndToTextAndCheck(charset,
-                Lists.of(CharsetHeaderValue.with(CharsetName.with(charset))));
+        this.parseAndToTextAndCheck2(charset,
+                CharsetHeaderValue.with(CharsetName.with(charset)));
+    }
+
+    private void parseAndToTextAndCheck2(final String text, final CharsetHeaderValue...values) {
+        this.parseAndToTextAndCheck(text, AcceptCharset.with(Lists.of(values)));
     }
 
     @Override
-    CharsetHeaderValueListHeaderValueConverter converter() {
-        return CharsetHeaderValueListHeaderValueConverter.INSTANCE;
+    AcceptCharsetHeaderValueConverter converter() {
+        return AcceptCharsetHeaderValueConverter.INSTANCE;
     }
 
     @Override
@@ -69,22 +72,22 @@ public final class CharsetHeaderValueListHeaderValueConverterTest extends
     }
 
     @Override
-    List<CharsetHeaderValue> value() {
-        return Lists.of(CharsetHeaderValue.with(CharsetName.UTF_8));
+    AcceptCharset value() {
+        return AcceptCharset.with(Lists.of(CharsetHeaderValue.with(CharsetName.UTF_8)));
     }
 
     @Override
     String valueType() {
-        return this.listValueType(CharsetHeaderValue.class);
+        return this.valueType(AcceptCharset.class);
     }
 
     @Override
     String converterToString() {
-        return "List<CharsetHeaderValue>";
+        return AcceptCharset.class.getSimpleName();
     }
 
     @Override
-    protected Class<CharsetHeaderValueListHeaderValueConverter> type() {
-        return CharsetHeaderValueListHeaderValueConverter.class;
+    protected Class<AcceptCharsetHeaderValueConverter> type() {
+        return AcceptCharsetHeaderValueConverter.class;
     }
 }

--- a/src/test/java/walkingkooka/net/header/AcceptCharsetTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptCharsetTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.header;
+
+import org.junit.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.type.MemberVisibility;
+
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+public final class AcceptCharsetTest extends HeaderValue2TestCase<AcceptCharset, List<CharsetHeaderValue>>{
+
+    // charset...................................................................................................
+
+    @Test
+    public void testCharset() {
+        this.charsetAndCheck(this.createHeaderValue(), CharsetName.UTF_8.charset());
+    }
+
+    @Test
+    public void testCharset2() {
+        this.charsetAndCheck(
+                this.createHeaderValue(CharsetHeaderValue.with(CharsetName.UTF_8)),
+                CharsetName.UTF_8.charset());
+    }
+
+    @Test
+    public void testCharsetWithout() {
+        this.charsetAndCheck(
+                this.createHeaderValue(CharsetHeaderValue.with(CharsetName.with("X-custom"))));
+    }
+
+    private void charsetAndCheck(final AcceptCharset acceptCharset, final Charset charset) {
+        this.charsetAndCheck(acceptCharset, Optional.of(charset));
+    }
+
+    private void charsetAndCheck(final AcceptCharset acceptCharset) {
+        this.charsetAndCheck(acceptCharset, Optional.empty());
+    }
+
+    private void charsetAndCheck(final AcceptCharset acceptCharset, final Optional<Charset> expected) {
+        assertEquals(acceptCharset + " .charset()",
+                expected,
+                acceptCharset.charset());
+    }
+
+    // helpers.......................................................................................................
+
+    @Override
+    AcceptCharset createHeaderValue(final List<CharsetHeaderValue> value) {
+        return AcceptCharset.with(value);
+    }
+
+    private AcceptCharset createHeaderValue(final CharsetHeaderValue...value) {
+        return this.createHeaderValue(Lists.of(value));
+    }
+
+        @Override
+    List<CharsetHeaderValue> value() {
+        return Lists.of(CharsetHeaderValue.with(CharsetName.with("X-custom")),
+                CharsetHeaderValue.with(CharsetName.UTF_8),
+                CharsetHeaderValue.with(CharsetName.UTF_16));
+    }
+
+    @Override
+    List<CharsetHeaderValue> differentValue() {
+        return Lists.of(CharsetHeaderValue.with(CharsetName.UTF_16));
+    }
+
+    @Override
+    protected boolean isMultipart() {
+        return false;
+    }
+
+    @Override
+    protected boolean isRequest() {
+        return true;
+    }
+
+    @Override
+    protected boolean isResponse() {
+        return false;
+    }
+
+    @Override
+    protected Class<AcceptCharset> type() {
+        return AcceptCharset.class;
+    }
+
+    @Override
+    protected MemberVisibility typeVisibility() {
+        return MemberVisibility.PUBLIC;
+    }
+}

--- a/src/test/java/walkingkooka/net/header/CharsetHeaderValueParameterNameTest.java
+++ b/src/test/java/walkingkooka/net/header/CharsetHeaderValueParameterNameTest.java
@@ -21,6 +21,7 @@ package walkingkooka.net.header;
 
 import org.junit.Test;
 import walkingkooka.Cast;
+import walkingkooka.collect.map.Maps;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -78,7 +79,8 @@ final public class CharsetHeaderValueParameterNameTest extends HeaderParameterNa
     }
 
     private CharsetHeaderValue charsetHeaderValue() {
-        return CharsetHeaderValue.parse("utf-8; q=0.5").get(0);
+        return CharsetHeaderValue.with(CharsetName.UTF_8)
+                .setParameters(Maps.one(CharsetHeaderValueParameterName.Q_FACTOR, 0.5f));
     }
 
     // toValue...........................................................................................

--- a/src/test/java/walkingkooka/net/http/HttpEntityTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpEntityTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.compare.Range;
-import walkingkooka.net.header.CharsetHeaderValue;
 import walkingkooka.net.header.CharsetName;
 import walkingkooka.net.header.HeaderValueException;
 import walkingkooka.net.header.HttpHeaderName;
@@ -33,7 +32,6 @@ import walkingkooka.test.HashCodeEqualsDefinedTesting;
 import walkingkooka.type.MemberVisibility;
 
 import java.nio.charset.Charset;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -222,44 +220,24 @@ public final class HttpEntityTest extends ClassTestCase<HttpEntity>
     @Test(expected = NullPointerException.class)
     public void testTextContentTypeNullFails() {
         HttpEntity.text(null,
-                this.acceptCharset(),
-                this.text());
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testTextAcceptCharsetNullFails() {
-        HttpEntity.text(this.contentType(),
-                null,
                 this.text());
     }
 
     @Test(expected = NullPointerException.class)
     public void testTextBodyNullFails() {
         HttpEntity.text(this.contentType(),
-                this.acceptCharset(),
                 null);
     }
 
     @Test(expected = HeaderValueException.class)
     public void testTextContentTypeMissingCharsetFails() {
         HttpEntity.text(MediaType.TEXT_PLAIN,
-                this.acceptCharset(),
                 this.text());
     }
 
     @Test(expected = NotAcceptableHeaderException.class)
     public void testTextContentTypeUnsupportedCharsetFails() {
-        final Charset utf8 = Charset.forName("utf8");
-
-        final Charset unsupported = Charset.availableCharsets()
-                .values()
-                .stream()
-                .filter(c -> !utf8.contains(c))
-                .findFirst()
-                .get();
-
-        HttpEntity.text(this.contentType(CharsetName.with(unsupported.name())),
-                this.acceptCharset(),
+        HttpEntity.text(this.contentType(CharsetName.with("unsupported")),
                 this.text());
     }
 
@@ -273,7 +251,7 @@ public final class HttpEntityTest extends ClassTestCase<HttpEntity>
         headers.put(HttpHeaderName.CONTENT_LENGTH, Long.valueOf(body.length));
         headers.put(HttpHeaderName.CONTENT_TYPE, contentType);
 
-        this.check(HttpEntity.text(contentType, this.acceptCharset(), text),
+        this.check(HttpEntity.text(contentType, text),
                 headers,
                 body);
     }
@@ -284,10 +262,6 @@ public final class HttpEntityTest extends ClassTestCase<HttpEntity>
 
     private MediaType contentType(final CharsetName charsetName) {
         return MediaType.TEXT_PLAIN.setCharset(charsetName);
-    }
-
-    private List<CharsetHeaderValue> acceptCharset() {
-        return CharsetHeaderValue.parse("utf-8;");
     }
 
     private String text() {


### PR DESCRIPTION
- CharsetHeaderValue.parse removed.
- HttpEntity.text(MediaType, String) removed List<CharsetHeaderValue>.
- HttpHeaderName.ACCEPT_CHAR type=AcceptCharset
- CharsetHeaderValueListHeaderParser and CharsetHeaderValueListHeaderValueConverter value now AcceptCharset.