### PR TITLE
Hateos

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosDeleteHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosDeleteHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.compare.Range;
+import walkingkooka.test.Fake;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+import java.util.Objects;
+
+/**
+ * A {@link HateosDeleteHandler} where all methods throw {@link UnsupportedOperationException}.
+ */
+public class FakeHateosDeleteHandler<N extends Node<N, ?, ?, ?>> implements HateosDeleteHandler<N>, Fake {
+
+    @Override
+    public void delete(final BigInteger id,
+                       final HateosHandlerContext<N> context) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(context, "context");
+
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteCollection(final Range<BigInteger> ids,
+                                 final HateosHandlerContext<N> context) {
+        Objects.requireNonNull(ids, "ids");
+        Objects.requireNonNull(context, "context");
+
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosGetHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosGetHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.compare.Range;
+import walkingkooka.net.http.server.HttpRequestParameterName;
+import walkingkooka.test.Fake;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A {@link HateosGetHandler} where all methods throw {@link UnsupportedOperationException}.
+ */
+public class FakeHateosGetHandler<N extends Node<N, ?, ?, ?>> implements HateosGetHandler<N>, Fake {
+
+    @Override
+    public Optional<N> get(final BigInteger id,
+                           final Map<HttpRequestParameterName, List<String>> parameters,
+                           final HateosHandlerContext<N> context) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(parameters, "parameters");
+        Objects.requireNonNull(context, "context");
+
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<N> getCollection(final Range<BigInteger> ids,
+                                     final Map<HttpRequestParameterName, List<String>> parameters,
+                                     final HateosHandlerContext<N> context) {
+        Objects.requireNonNull(ids, "ids");
+        Objects.requireNonNull(parameters, "parameters");
+        Objects.requireNonNull(context, "context");
+
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosHandlerContext.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosHandlerContext.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.test.Fake;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+
+public class FakeHateosHandlerContext<N extends Node<N, ?, ?, ?>> implements HateosHandlerContext<N>, Fake {
+
+    @Override
+    public N addLinks(final HateosResourceName name,
+                      final BigInteger id,
+                      final N node) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosPostHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosPostHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.test.Fake;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A {@link HateosPostHandler} where all methods throw {@link UnsupportedOperationException}.
+ */
+public class FakeHateosPostHandler<N extends Node<N, ?, ?, ?>> implements HateosPostHandler<N>, Fake {
+
+    @Override
+    public N post(final Optional<BigInteger> id,
+                  final N resource,
+                  final HateosHandlerContext<N> context) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(resource, "resource");
+        Objects.requireNonNull(context, "context");
+
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosPutHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/FakeHateosPutHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.test.Fake;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+import java.util.Objects;
+
+/**
+ * A {@link HateosPutHandler} where all methods throw {@link UnsupportedOperationException}.
+ */
+public class FakeHateosPutHandler<N extends Node<N, ?, ?, ?>> implements HateosPutHandler<N>, Fake {
+
+    @Override
+    public N put(final BigInteger id,
+                 final N resource,
+                 final HateosHandlerContext<N> context) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(resource, "resource");
+        Objects.requireNonNull(context, "context");
+
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosContentType.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosContentType.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.net.AbsoluteUrl;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.header.MediaType;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.tree.Node;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.tree.xml.XmlNode;
+
+import javax.xml.parsers.DocumentBuilder;
+import java.math.BigInteger;
+import java.util.Collection;
+
+/**
+ * Controls the content type of hateos messages. Ideally this should have been an enum but currently enums do not
+ * support type parameters.
+ */
+public abstract class HateosContentType<N extends Node<N, ?, ?, ?>> {
+
+    /**
+     * Selects JSON formatted bodies.
+     */
+    public final static HateosContentType<JsonNode> JSON = HateosContentTypeJsonNode.instance();
+
+    /**
+     * Selects XML formatted bodies.
+     */
+    public final static HateosContentType<XmlNode> XML = HateosContentTypeXmlNode.instance();
+
+    /**
+     * Package private use constants.
+     */
+    HateosContentType() {
+        super();
+    }
+
+    /**
+     * Returns the {@link MediaType content type}.
+     */
+    public abstract MediaType contentType();
+
+    /**
+     * Parses the text into a {@link Node}
+     */
+    abstract N parse(final DocumentBuilder documentBuilder, final String text);
+
+    /**
+     * Formats the node as text.
+     */
+    abstract String toText(final N node);
+
+    /**
+     * Helper called by {@link HateosHandlerBuilderRouterHateosHandlerContext}.
+     */
+    abstract N addLinks(final BigInteger id,
+                        final N node,
+                        final HttpMethod method,
+                        final AbsoluteUrl base,
+                        final HateosResourceName resourceName,
+                        final Collection<LinkRelation<?>> linkRelations);
+
+    abstract public String toString();
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosContentTypeJsonNode.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosContentTypeJsonNode.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.io.printer.IndentingPrinter;
+import walkingkooka.io.printer.IndentingPrinters;
+import walkingkooka.io.printer.Printers;
+import walkingkooka.net.AbsoluteUrl;
+import walkingkooka.net.UrlPath;
+import walkingkooka.net.UrlPathName;
+import walkingkooka.net.header.Link;
+import walkingkooka.net.header.LinkParameterName;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.header.MediaType;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.text.LineEnding;
+import walkingkooka.tree.json.JsonArrayNode;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.tree.json.JsonNodeName;
+import walkingkooka.tree.json.JsonObjectNode;
+
+import javax.xml.parsers.DocumentBuilder;
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * The {@link HateosContentType} that handles {@link JsonNode}.
+ */
+final class HateosContentTypeJsonNode extends HateosContentType<JsonNode> {
+
+    /**
+     * Singleton
+     */
+    final static HateosContentTypeJsonNode instance() {
+        return new HateosContentTypeJsonNode();
+    }
+
+    /**
+     * Private ctor use singleton.
+     */
+    private HateosContentTypeJsonNode() {
+        super();
+    }
+
+    @Override
+    public MediaType contentType() {
+        return CONTENT_TYPE;
+    }
+
+    private final static MediaType CONTENT_TYPE = MediaType.with("application", "hal+json");
+
+
+    @Override
+    JsonNode parse(final DocumentBuilder documentBuilder,
+                   final String text) {
+        return JsonNode.parse(text);
+    }
+
+    @Override
+    String toText(final JsonNode node) {
+        final StringBuilder b = new StringBuilder();
+        final IndentingPrinter printer = IndentingPrinters.printer(Printers.stringBuilder(b, LineEnding.SYSTEM));
+        node.printJson(printer);
+        return b.toString();
+    }
+
+    /**
+     * The format for hateos urls is base + "/" + resource name + "/" + id + "/" + link relation
+     * <a href="https://en.wikipedia.org/wiki/Hypertext_Application_Language"></a>
+     * <pre>
+     * "_links": {
+     *   "self": {
+     *     "href": "http://example.com/api/book/hal-cookbook"
+     *   }
+     * },
+     * </pre>
+     */
+    @Override
+    JsonNode addLinks(final BigInteger id,
+                      final JsonNode node,
+                      final HttpMethod method,
+                      final AbsoluteUrl base,
+                      final HateosResourceName resourceName,
+                      final Collection<LinkRelation<?>> linkRelations) {
+
+        // base + resource name.
+        final UrlPath pathAndResourceNameAndId = base.path()
+                .append(UrlPathName.with(resourceName.value()))
+                .append(UrlPathName.with(id.toString()));
+
+        JsonArrayNode links = JsonNode.array();
+
+        for (LinkRelation<?> relation : linkRelations) {
+            // TODO add support for title/title* and hreflang
+            final Map<LinkParameterName<?>, Object> parameters = Maps.ordered();
+            parameters.put(LinkParameterName.METHOD, method);
+            parameters.put(LinkParameterName.REL, Lists.of(relation));
+            parameters.put(LinkParameterName.TYPE, CONTENT_TYPE);
+
+            final Link link = Link.with(base.setPath(LinkRelation.SELF == relation ?
+                    pathAndResourceNameAndId :
+                    pathAndResourceNameAndId.append(UrlPathName.with(relation.value().toString()))))
+                    .setParameters(parameters);
+
+            links = links.appendChild(link.toJsonNode());
+        }
+
+        return JsonObjectNode.class.cast(node).set(LINKS, links);
+    }
+
+    /**
+     * The property that receives the actual links.
+     */
+    private final static JsonNodeName LINKS = JsonNodeName.with("_links");
+
+    @Override
+    public String toString() {
+        return "JSON";
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosContentTypeXmlNode.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosContentTypeXmlNode.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.net.AbsoluteUrl;
+import walkingkooka.net.UrlPath;
+import walkingkooka.net.UrlPathName;
+import walkingkooka.net.header.Link;
+import walkingkooka.net.header.LinkParameterName;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.header.MediaType;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.net.http.server.HttpServerException;
+import walkingkooka.tree.xml.XmlDocument;
+import walkingkooka.tree.xml.XmlName;
+import walkingkooka.tree.xml.XmlNode;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+final class HateosContentTypeXmlNode extends HateosContentType<XmlNode> {
+
+    /**
+     * Singleton
+     */
+    final static HateosContentTypeXmlNode instance() {
+        return new HateosContentTypeXmlNode();
+    }
+
+    /**
+     * Private ctor use singleton.
+     */
+    private HateosContentTypeXmlNode() {
+        super();
+    }
+
+    @Override
+    public MediaType contentType() {
+        return CONTENT_TYPE;
+    }
+
+    private final static MediaType CONTENT_TYPE = MediaType.with("application", "hal+xml");
+
+    @Override
+    XmlNode parse(final DocumentBuilder documentBuilder,
+                  final String text) {
+        try {
+            return XmlNode.fromXml(documentBuilder, new StringReader(text));
+        } catch (final Exception cause) {
+            throw new HttpServerException(cause.getMessage(), cause);
+        }
+    }
+
+    @Override
+    String toText(final XmlNode node) {
+        try {
+            final StringWriter writer = new StringWriter();
+            final Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            node.toXml(transformer, writer);
+            writer.flush();
+            return writer.toString();
+        } catch (final TransformerException cause) {
+            throw new HttpServerException(cause.getMessage(), cause);
+        }
+    }
+
+    @Override
+    XmlNode addLinks(final BigInteger id,
+                     final XmlNode node,
+                     final HttpMethod method,
+                     final AbsoluteUrl base,
+                     final HateosResourceName resourceName,
+                     final Collection<LinkRelation<?>> linkRelations) {
+
+        final XmlDocument document = node.document();
+
+        // base + resource name.
+        final UrlPath pathAndResourceNameAndId = base.path()
+                .append(UrlPathName.with(resourceName.value()))
+                .append(UrlPathName.with(id.toString()));
+
+        final List<XmlNode> links = Lists.array();
+
+        for (LinkRelation<?> relation : linkRelations) {
+            // TODO add support for title/title* and hreflang
+            final Map<LinkParameterName<?>, Object> parameters = Maps.ordered();
+            parameters.put(LinkParameterName.METHOD, method);
+            parameters.put(LinkParameterName.REL, Lists.of(relation));
+            parameters.put(LinkParameterName.TYPE, CONTENT_TYPE);
+
+            final Link link = Link.with(base.setPath(LinkRelation.SELF == relation ?
+                    pathAndResourceNameAndId :
+                    pathAndResourceNameAndId.append(UrlPathName.with(relation.value().toString()))))
+                    .setParameters(parameters);
+
+            links.add(link.toXmlNode());
+        }
+
+        return node.appendChild(
+                document.createElement(LINKS)
+                        .setChildren(links));
+    }
+
+    /**
+     * The xml element that receives the actual links.
+     */
+    private final static XmlName LINKS = XmlName.element("links");
+
+    @Override
+    public String toString() {
+        return "XML";
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosDeleteHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosDeleteHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.compare.Range;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+
+/**
+ * Handles DELETE requests for an resource.
+ */
+public interface HateosDeleteHandler<N extends Node<N, ?, ?, ?>> extends HateosHandler<N> {
+
+    /**
+     * Deletes the request resource identified by the ID.
+     */
+    void delete(final BigInteger id,
+                final HateosHandlerContext<N> context);
+
+    /**
+     * Deletes the request entities identified by the range of IDs.
+     */
+    void deleteCollection(final Range<BigInteger> ids,
+                          final HateosHandlerContext<N> context);
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosDeleteHandlerTestCase.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosDeleteHandlerTestCase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.compare.Range;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+
+public abstract class HateosDeleteHandlerTestCase<H extends HateosDeleteHandler<N>, N extends Node<N, ?, ?, ?>> extends HateosHandlerTestCase<H, N> {
+
+    @Test(expected = NullPointerException.class)
+    public void testDeleteNullIdFails() {
+        this.delete(null,
+                this.createContext());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testDeleteNullContextFails() {
+        this.delete(this.id(),
+                null);
+    }
+
+    protected void delete(final BigInteger id,
+                          final HateosHandlerContext<N> context) {
+        this.createHandler().delete(id, context);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testDeleteCollectionNullIdRangeFails() {
+        this.deleteCollection(null,
+                this.createContext());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testDeleteCollectionNullContextFails() {
+        this.deleteCollection(this.collection(),
+                null);
+    }
+
+    protected void deleteCollection(final Range<BigInteger> collection,
+                                    final HateosHandlerContext<N> context) {
+        this.createHandler().deleteCollection(collection, context);
+    }
+
+    abstract protected BigInteger id();
+
+    abstract protected Range<BigInteger> collection();
+
+    abstract protected N resource();
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosGetHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosGetHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.compare.Range;
+import walkingkooka.net.http.server.HttpRequestParameterName;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Handles GET requests for an resource.
+ */
+public interface HateosGetHandler<N extends Node<N, ?, ?, ?>> extends HateosHandler<N> {
+
+    /**
+     * Perform the GET operation.
+     */
+    Optional<N> get(final BigInteger id,
+                    final Map<HttpRequestParameterName, List<String>> parameters,
+                    final HateosHandlerContext<N> context);
+
+    /**
+     * Perform a batch operation on the requested ids.
+     */
+    Optional<N> getCollection(final Range<BigInteger> ids,
+                              final Map<HttpRequestParameterName, List<String>> parameters,
+                              final HateosHandlerContext<N> context);
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosGetHandlerTestCase.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosGetHandlerTestCase.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.compare.Range;
+import walkingkooka.net.http.server.HttpRequestParameterName;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class HateosGetHandlerTestCase<H extends HateosGetHandler<N>, N extends Node<N, ?, ?, ?>> extends HateosHandlerTestCase<H, N> {
+
+    @Test(expected = NullPointerException.class)
+    public void testGetNullIdFails() {
+        this.get(null,
+                this.parameters(),
+                this.createContext());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetNullParametersFails() {
+        this.get(this.id(),
+                null,
+                this.createContext());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetNullContextFails() {
+        this.get(this.id(),
+                this.parameters(),
+                null);
+    }
+
+    protected Optional<N> get(final BigInteger id,
+                              final Map<HttpRequestParameterName, List<String>> parameters,
+                              final HateosHandlerContext<N> context) {
+        return this.createHandler().get(id, parameters, context);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetCollectionNullCollectionFails() {
+        this.getCollection(null,
+                this.parameters(),
+                this.createContext());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetCollectionNullParametCollectionersFails() {
+        this.getCollection(this.collection(),
+                null,
+                this.createContext());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetCollectionNullContextFails() {
+        this.getCollection(this.collection(),
+                this.parameters(),
+                null);
+    }
+
+    protected Optional<N> getCollection(final Range<BigInteger> collection,
+                                        final Map<HttpRequestParameterName, List<String>> parameters,
+                                        final HateosHandlerContext<N> context) {
+        return this.createHandler().getCollection(collection, parameters, context);
+    }
+
+    abstract protected BigInteger id();
+
+    abstract protected Range<BigInteger> collection();
+
+    abstract protected Map<HttpRequestParameterName, List<String>> parameters();
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.tree.Node;
+
+/**
+ * Base class for all hateos handlers.
+ */
+public interface HateosHandler<N extends Node<N, ?, ?, ?>> {
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilder.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilder.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.build.Builder;
+import walkingkooka.build.BuilderException;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.net.AbsoluteUrl;
+import walkingkooka.net.UrlFragment;
+import walkingkooka.net.UrlQueryString;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.net.http.server.HttpRequest;
+import walkingkooka.net.http.server.HttpRequestAttribute;
+import walkingkooka.net.http.server.HttpResponse;
+import walkingkooka.routing.Router;
+import walkingkooka.tree.Node;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+
+/**
+ * A builder which collects all resource and relation mappings producing a {@link Router}.
+ * The {@link Router} assumes that the transport and content-type have already been tested and filtered.
+ */
+public final class HateosHandlerBuilder<N extends Node<N, ?, ?, ?>>
+        extends HateosHandlerBuilder2<N>
+        implements
+        Builder<Router<HttpRequestAttribute<?>, BiConsumer<HttpRequest, HttpResponse>>> {
+
+    /**
+     * Factory that creates a new {@link HateosHandlerBuilder} with the provided path being used when building links.
+     */
+    public static <N extends Node<N, ?, ?, ?>> HateosHandlerBuilder<N> with(final AbsoluteUrl base,
+                                                                            final HateosContentType<N> contentType) {
+        Objects.requireNonNull(base, "base");
+        if (!base.query().equals(UrlQueryString.EMPTY)) {
+            throw new IllegalArgumentException("Base should have no query string/query parameters but was " + base);
+        }
+        if (!base.fragment().equals(UrlFragment.EMPTY)) {
+            throw new IllegalArgumentException("Base should have no fragment but was " + base);
+        }
+
+        Objects.requireNonNull(contentType, "contentType");
+
+        return new HateosHandlerBuilder<N>(base, contentType);
+    }
+
+    /**
+     * Private ctor use factory.
+     */
+    private HateosHandlerBuilder(final AbsoluteUrl base,
+                                 final HateosContentType<N> contentType) {
+        super(base, contentType, Maps.sorted());
+    }
+
+    /**
+     * Registers a new GET handler for the given hateos resource and relation combination.
+     */
+    public HateosHandlerBuilder<N> get(final HateosResourceName name,
+                                       final LinkRelation<?> relation,
+                                       final HateosGetHandler<N> handler) {
+        final HateosHandlerBuilderRouterHandlers<N> handlers = this.getOrCreateHandlers(name, relation);
+        checkHandler(handler, handlers.get, HttpMethod.GET, name, relation);
+        handlers.get = handler;
+
+        return this;
+    }
+
+    /**
+     * Registers a new POST handler for the given hateos resource and relation combination.
+     */
+    public HateosHandlerBuilder<N> post(final HateosResourceName name,
+                                        final LinkRelation<?> relation,
+                                        final HateosPostHandler<N> handler) {
+        final HateosHandlerBuilderRouterHandlers<N> handlers = this.getOrCreateHandlers(name, relation);
+        checkHandler(handler, handlers.post, HttpMethod.POST, name, relation);
+        handlers.post = handler;
+
+        return this;
+    }
+
+    /**
+     * Registers a new PUT handler for the given hateos resource and relation combination.
+     */
+    public HateosHandlerBuilder<N> put(final HateosResourceName name,
+                                       final LinkRelation<?> relation,
+                                       final HateosPutHandler<N> handler) {
+        final HateosHandlerBuilderRouterHandlers<N> handlers = this.getOrCreateHandlers(name, relation);
+        checkHandler(handler, handlers.put, HttpMethod.PUT, name, relation);
+        handlers.put = handler;
+
+        return this;
+    }
+
+    /**
+     * Registers a new handler for the given hateos resource and relation combination.
+     */
+    public HateosHandlerBuilder<N> delete(final HateosResourceName name,
+                                          final LinkRelation<?> relation,
+                                          final HateosDeleteHandler<N> handler) {
+        final HateosHandlerBuilderRouterHandlers<N> handlers = this.getOrCreateHandlers(name, relation);
+        checkHandler(handler, handlers.delete, HttpMethod.DELETE, name, relation);
+        handlers.delete = handler;
+
+        return this;
+    }
+
+    /**
+     * Gets or creates a {@link HateosHandlerBuilderRouterHandlers} for the key.
+     */
+    private HateosHandlerBuilderRouterHandlers<N> getOrCreateHandlers(final HateosResourceName name,
+                                                                      final LinkRelation<?> relation) {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(relation, "relation");
+
+        final HateosHandlerBuilderRouterKey key = HateosHandlerBuilderRouterKey.with(name, relation);
+        HateosHandlerBuilderRouterHandlers<N> value = this.handlers.get(key);
+        if (null == value) {
+            value = HateosHandlerBuilderRouterHandlers.with();
+            this.handlers.put(key, value);
+        }
+
+        return value;
+    }
+
+    /**
+     * Verifies the new handler is not overwriting an existing one.
+     */
+    private <H extends HateosHandler<N>> void checkHandler(final H handler,
+                                                           final H previous,
+                                                           final HttpMethod method,
+                                                           final HateosResourceName resourceName,
+                                                           final LinkRelation<?> relation) {
+        Objects.requireNonNull(handler, "handler");
+
+        if (null != previous && !handler.equals(previous)) {
+            throw new IllegalArgumentException("Attempt to replace " + method + " handler for " + resourceName + " " + relation + "=" + handler);
+        }
+    }
+
+    /**
+     * Builds a {@link Router} that will accept a {@link BiConsumer} with the request and response. These will then
+     * examine the request and route to the appropriate if any handler for the identified resource, id if present and relation if present.
+     */
+    @Override
+    public Router<HttpRequestAttribute<?>, BiConsumer<HttpRequest, HttpResponse>> build() throws BuilderException {
+        final Map<HateosHandlerBuilderRouterKey, HateosHandlerBuilderRouterHandlers<N>> copy = Maps.sorted();
+
+        for (Entry<HateosHandlerBuilderRouterKey, HateosHandlerBuilderRouterHandlers<N>> resourceAndRelationToHandler : this.handlers.entrySet()) {
+            copy.put(resourceAndRelationToHandler.getKey(), resourceAndRelationToHandler.getValue().copy());
+        }
+
+        return HateosHandlerBuilderRouter.with(this.base,
+                this.contentType,
+                copy);
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilder2.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilder2.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.net.AbsoluteUrl;
+import walkingkooka.tree.Node;
+
+import java.util.Map;
+
+/**
+ * Base class for both the builder and router implementation.
+ */
+abstract class HateosHandlerBuilder2<N extends Node<N, ?, ?, ?>> {
+
+    /**
+     * Package private to limit sub classing.
+     */
+    HateosHandlerBuilder2(final AbsoluteUrl base,
+                          final HateosContentType<N> contentType,
+                          final Map<HateosHandlerBuilderRouterKey, HateosHandlerBuilderRouterHandlers<N>> handlers) {
+        super();
+        this.base = base;
+        this.contentType = contentType;
+
+        this.handlers = handlers;
+    }
+
+    /**
+     * The base path where hateos urls live.
+     */
+    final AbsoluteUrl base;
+
+    /**
+     * The content type for all handler processing.
+     */
+    final HateosContentType<N> contentType;
+
+    /**
+     * A map of resource and relations to handlers.
+     */
+    final Map<HateosHandlerBuilderRouterKey, HateosHandlerBuilderRouterHandlers<N>> handlers;
+
+
+    // Object .........................................................................................................
+
+    @Override
+    public final String toString() {
+        return this.base + " " + this.contentType + " " + this.handlers;
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouter.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouter.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.net.AbsoluteUrl;
+import walkingkooka.net.UrlPathName;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.net.http.server.HttpRequest;
+import walkingkooka.net.http.server.HttpRequestAttribute;
+import walkingkooka.net.http.server.HttpRequestAttributes;
+import walkingkooka.net.http.server.HttpResponse;
+import walkingkooka.routing.RouteException;
+import walkingkooka.routing.Router;
+import walkingkooka.tree.Node;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+/**
+ * Router which accepts a request and returns a {@link BiConsumer} that operates on the base {@!link UrlPath}.
+ */
+final class HateosHandlerBuilderRouter<N extends Node<N, ?, ?, ?>>
+        extends HateosHandlerBuilder2<N>
+        implements Router<HttpRequestAttribute<?>, BiConsumer<HttpRequest, HttpResponse>> {
+
+    /**
+     * Factory called by {@link HateosHandlerBuilder#build()}
+     */
+    static <N extends Node<N, ?, ?, ?>> HateosHandlerBuilderRouter<N> with(final AbsoluteUrl base,
+                                                                           final HateosContentType<N> contentType,
+                                                                           final Map<HateosHandlerBuilderRouterKey, HateosHandlerBuilderRouterHandlers<N>> handlers) {
+        return new HateosHandlerBuilderRouter<N>(base,
+                contentType,
+                handlers);
+    }
+
+    /**
+     * Private ctor use factory.
+     */
+    private HateosHandlerBuilderRouter(final AbsoluteUrl base,
+                                       final HateosContentType<N> contentType,
+                                       Map<HateosHandlerBuilderRouterKey, HateosHandlerBuilderRouterHandlers<N>> handlers) {
+        super(base, contentType, handlers);
+
+        final Set<HateosHandlerBuilderRouterKey> nameAndLinkRelations = handlers.keySet();
+
+        this.getContext = HateosHandlerBuilderRouterHateosHandlerContext.with(HttpMethod.GET, contentType, base, nameAndLinkRelations);
+        this.postContext = HateosHandlerBuilderRouterHateosHandlerContext.with(HttpMethod.POST, contentType, base, nameAndLinkRelations);
+        this.putContext = HateosHandlerBuilderRouterHateosHandlerContext.with(HttpMethod.PUT, contentType, base, nameAndLinkRelations);
+        this.deleteContext = HateosHandlerBuilderRouterHateosHandlerContext.with(HttpMethod.DELETE, contentType, base, nameAndLinkRelations);
+    }
+
+    @Override
+    public Optional<BiConsumer<HttpRequest, HttpResponse>> route(final Map<HttpRequestAttribute<?>, Object> parameters) throws RouteException {
+        Objects.requireNonNull(parameters, "parameters");
+
+        return Optional.ofNullable(-1 != consumeBasePath(parameters) ?
+                HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumer.with(this) :
+                null);
+    }
+
+    /**
+     * Attempts to consume the {@link #base} completely returning the index to the {@link HateosResourceName} component within the path or -1.
+     */
+    int consumeBasePath(final Map<HttpRequestAttribute<?>, Object> parameters) {
+        // base path must be matched..................................................................................
+        int pathIndex = 0;
+        for (UrlPathName name : this.base.path()) {
+            if (!name.equals(parameters.get(HttpRequestAttributes.pathComponent(pathIndex)))) {
+                pathIndex = -1;
+                break;
+            }
+            pathIndex++;
+        }
+        return pathIndex;
+    }
+
+    final HateosHandlerBuilderRouterHateosHandlerContext<N> getContext;
+    final HateosHandlerBuilderRouterHateosHandlerContext<N> postContext;
+    final HateosHandlerBuilderRouterHateosHandlerContext<N> putContext;
+    final HateosHandlerBuilderRouterHateosHandlerContext<N> deleteContext;
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHandlers.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHandlers.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.build.tostring.ToStringBuilder;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.tree.Node;
+
+/**
+ * Holds all the handlers for a {@link HateosHandlerBuilderRouterKey}
+ */
+final class HateosHandlerBuilderRouterHandlers<N extends Node<N, ?, ?, ?>> {
+
+    /**
+     * Created by the builder with one for each resource name.
+     */
+    static <N extends Node<N, ?, ?, ?>> HateosHandlerBuilderRouterHandlers<N> with() {
+        return new HateosHandlerBuilderRouterHandlers<>();
+    }
+
+    private HateosHandlerBuilderRouterHandlers() {
+        super();
+    }
+
+    /**
+     * Makes a defensive copy of this handlers. This is necessary when the router is created and the map copied from the builder.
+     */
+    HateosHandlerBuilderRouterHandlers<N> copy() {
+        final HateosHandlerBuilderRouterHandlers<N> handlers = new HateosHandlerBuilderRouterHandlers<>();
+
+        handlers.get = this.get;
+        handlers.post = this.post;
+        handlers.put = this.put;
+        handlers.delete = this.delete;
+
+        return handlers;
+    }
+
+    /**
+     * These handlers will be null to indicate the method is not supported, otherwise the handler is invoked.
+     */
+    HateosGetHandler<N> get;
+    HateosPostHandler<N> post;
+    HateosPutHandler<N> put;
+    HateosDeleteHandler<N> delete;
+
+    @Override
+    public String toString() {
+        final ToStringBuilder b = ToStringBuilder.empty();
+
+        b.label(HttpMethod.GET.toString()).value(this.get);
+        b.label(HttpMethod.POST.toString()).value(this.post);
+        b.label(HttpMethod.PUT.toString()).value(this.put);
+        b.label(HttpMethod.DELETE.toString()).value(this.delete);
+
+        return b.build();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHateosHandlerContext.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHateosHandlerContext.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.net.AbsoluteUrl;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link HateosHandlerContext} that is ued by {@link HateosHandlerBuilderRouter}.
+ */
+final class HateosHandlerBuilderRouterHateosHandlerContext<N extends Node<N, ?, ?, ?>>
+        implements HateosHandlerContext<N> {
+
+    /**
+     * Factory only called by {@link HateosHandlerBuilderRouter}
+     */
+    static <N extends Node<N, ?, ?, ?>> HateosHandlerBuilderRouterHateosHandlerContext<N> with(final HttpMethod method,
+                                                                                               final HateosContentType<N> contentType,
+                                                                                               final AbsoluteUrl base,
+                                                                                               final Set<HateosHandlerBuilderRouterKey> nameAndLinkRelations) {
+        return new HateosHandlerBuilderRouterHateosHandlerContext<>(method, contentType, base, nameAndLinkRelations);
+    }
+
+    /**
+     * Private ctor
+     */
+    private HateosHandlerBuilderRouterHateosHandlerContext(final HttpMethod method,
+                                                           final HateosContentType<N> contentType,
+                                                           final AbsoluteUrl base,
+                                                           final Set<HateosHandlerBuilderRouterKey> nameAndLinkRelations) {
+        super();
+        this.method = method;
+        this.base = base;
+        this.contentType = contentType;
+        this.nameAndLinkRelations = nameAndLinkRelations;
+    }
+
+    /**
+     * Adds links for this node.
+     */
+    @Override
+    public N addLinks(final HateosResourceName name,
+                      final BigInteger id,
+                      final N node) {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(node, "node");
+
+        return this.contentType.addLinks(id,
+                node,
+                this.method,
+                this.base,
+                name,
+                this.linkRelations(name));
+    }
+
+    private List<LinkRelation<?>> linkRelations(final HateosResourceName name) {
+        return this.nameAndLinkRelations.stream()
+                .filter(e -> e.resourceName.equals(name))
+                .map(e -> e.linkRelation)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * The base url of all handlers.
+     */
+    private final AbsoluteUrl base;
+
+    /**
+     * The method used by the request.
+     */
+    private final HttpMethod method;
+
+    /**
+     * The content type for all handler processing.
+     */
+    private final HateosContentType<N> contentType;
+
+    /**
+     * Hateos resource name to link relations.
+     */
+    private final Set<HateosHandlerBuilderRouterKey> nameAndLinkRelations;
+
+    @Override
+    public String toString() {
+        return this.base.toString();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumer.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.net.http.HttpStatusCode;
+import walkingkooka.net.http.server.HttpRequest;
+import walkingkooka.net.http.server.HttpResponse;
+import walkingkooka.tree.Node;
+
+import java.util.function.BiConsumer;
+
+/**
+ * Router which accepts a request and then dispatches after testing the {@link HttpMethod}. This is the product of
+ * {@link HateosHandlerBuilder}.
+ */
+final class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumer<N extends Node<N, ?, ?, ?>> implements BiConsumer<HttpRequest, HttpResponse> {
+
+    /**
+     * Factory called by {@link HateosHandlerBuilder#build()}
+     */
+    static <N extends Node<N, ?, ?, ?>> HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumer<N> with(final HateosHandlerBuilderRouter<N> router) {
+        return new HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumer<N>(router);
+    }
+
+    /**
+     * Private ctor use factory.
+     */
+    private HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumer(final HateosHandlerBuilderRouter<N> router) {
+        super();
+        this.router = router;
+    }
+
+    /**
+     * Tests the method and calls a sub class of {@link HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod}.
+     */
+    @Override
+    public void accept(final HttpRequest request, final HttpResponse response) {
+        do {
+            final HttpMethod httpMethod = request.method();
+            if (httpMethod.equals(HttpMethod.GET)) {
+                HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGet.with(this.router, request, response)
+                        .execute();
+                break;
+            }
+            if (httpMethod.equals(HttpMethod.POST)) {
+                HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPost.with(this.router, request, response)
+                        .execute();
+                break;
+            }
+            if (httpMethod.equals(HttpMethod.PUT)) {
+                HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPut.with(this.router, request, response)
+                        .execute();
+                break;
+            }
+            if (httpMethod.equals(HttpMethod.DELETE)) {
+                HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDelete.with(this.router, request, response)
+                        .execute();
+                break;
+            }
+            methodNotAllowed(httpMethod.value(), response);
+            break;
+        } while (false);
+    }
+
+    static void methodNotAllowed(final String message,
+                                 final HttpResponse response) {
+        response.setStatus(HttpStatusCode.METHOD_NOT_ALLOWED.setMessage(message));
+    }
+
+    final HateosHandlerBuilderRouter<N> router;
+
+    @Override
+    public String toString() {
+        return this.router.toString();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDelete.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDelete.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.compare.Range;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.net.http.HttpStatusCode;
+import walkingkooka.net.http.server.HttpRequest;
+import walkingkooka.net.http.server.HttpResponse;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+
+/**
+ * Router which accepts a request and then dispatches after testing the {@link HttpMethod}. This is the product of
+ * {@link HateosHandlerBuilder}.
+ */
+final class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDelete<N extends Node<N, ?, ?, ?>>
+        extends HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod<N> {
+
+    /**
+     * Factory called by {@link HateosHandlerBuilder#build()}
+     */
+    static <N extends Node<N, ?, ?, ?>> HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDelete<N> with(final HateosHandlerBuilderRouter<N> router,
+                                                                                                                  final HttpRequest request,
+                                                                                                                  final HttpResponse response) {
+        return new HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDelete<N>(router,
+                request,
+                response);
+    }
+
+    /**
+     * Private ctor use factory.
+     */
+    private HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDelete(final HateosHandlerBuilderRouter<N> router,
+                                                                              final HttpRequest request,
+                                                                              final HttpResponse response) {
+        super(router, request, response);
+    }
+
+    @Override
+    void idMissing(final HateosResourceName resourceName, final LinkRelation<?> linkRelation) {
+        this.collection(resourceName, Range.all(), linkRelation);
+    }
+
+    @Override
+    void wildcard(final HateosResourceName resourceName, final LinkRelation<?> linkRelation) {
+        this.collection(resourceName, Range.all(), linkRelation);
+    }
+
+    @Override
+    void id(final HateosResourceName resourceName,
+            final BigInteger id,
+            final LinkRelation<?> linkRelation) {
+        final HateosHandlerBuilderRouterHandlers<N> handlers = this.handlersOrResponseNotFound(resourceName, linkRelation);
+        if (null != handlers) {
+            final HateosDeleteHandler<N> delete = this.handlerOrResponseMethodNot(resourceName, linkRelation, handlers.delete);
+            if (null != delete) {
+                delete.delete(id, this.router.deleteContext);
+                this.setStatusDeleted("resource");
+            }
+        }
+    }
+
+    @Override
+    void collection(final HateosResourceName resourceName,
+                    final Range<BigInteger> ids,
+                    final LinkRelation<?> linkRelation) {
+        final HateosHandlerBuilderRouterHandlers<N> handlers = this.handlersOrResponseNotFound(resourceName, linkRelation);
+        if (null != handlers) {
+            final HateosDeleteHandler<N> delete = this.handlerOrResponseMethodNot(resourceName, linkRelation, handlers.delete);
+            if (null != delete) {
+                delete.deleteCollection(ids, this.router.deleteContext);
+                this.setStatusDeleted("collection");
+            }
+        }
+    }
+
+    private void setStatusDeleted(final String label) {
+        this.setStatus(HttpStatusCode.NO_CONTENT, "Delete " + label + " successful");
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGet.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGet.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.compare.Range;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.net.http.HttpStatusCode;
+import walkingkooka.net.http.server.HttpRequest;
+import walkingkooka.net.http.server.HttpResponse;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+/**
+ * Router which accepts a request and then dispatches after testing the {@link HttpMethod}. This is the product of
+ * {@link HateosHandlerBuilder}.
+ */
+final class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGet<N extends Node<N, ?, ?, ?>>
+        extends HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod<N> {
+
+    /**
+     * Factory called by {@link HateosHandlerBuilder#build()}
+     */
+    static <N extends Node<N, ?, ?, ?>> HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGet<N> with(final HateosHandlerBuilderRouter<N> router,
+                                                                                                               final HttpRequest request,
+                                                                                                               final HttpResponse response) {
+        return new HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGet<N>(router,
+                request,
+                response);
+    }
+
+    /**
+     * Private ctor use factory.
+     */
+    private HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGet(final HateosHandlerBuilderRouter<N> router,
+                                                                           final HttpRequest request,
+                                                                           final HttpResponse response) {
+        super(router, request, response);
+    }
+
+    @Override
+    void idMissing(final HateosResourceName resourceName, final LinkRelation<?> linkRelation) {
+        this.collection(resourceName, Range.all(), linkRelation);
+    }
+
+    @Override
+    void wildcard(final HateosResourceName resourceName, final LinkRelation<?> linkRelation) {
+        this.collection(resourceName, Range.all(), linkRelation);
+    }
+
+    @Override
+    void id(final HateosResourceName resourceName,
+            final BigInteger id,
+            final LinkRelation<?> linkRelation) {
+        final HateosHandlerBuilderRouterHandlers<N> handlers = this.handlersOrResponseNotFound(resourceName, linkRelation);
+        if (null != handlers) {
+            final HateosGetHandler<N> get = this.handlerOrResponseMethodNot(resourceName, linkRelation, handlers.get);
+            if (null != get) {
+                this.setStatusAndBody("Get resource successful",
+                        get.get(id,
+                                this.request.parameters(),
+                                this.router.getContext));
+            }
+        }
+    }
+
+    @Override
+    void collection(final HateosResourceName resourceName,
+                    final Range<BigInteger> ids,
+                    final LinkRelation<?> linkRelation) {
+        final HateosHandlerBuilderRouterHandlers<N> handlers = this.handlersOrResponseNotFound(resourceName, linkRelation);
+        if (null != handlers) {
+            final HateosGetHandler<N> get = this.handlerOrResponseMethodNot(resourceName, linkRelation, handlers.get);
+            if (null != get) {
+                this.setStatusAndBody("Get collection successful",
+                        get.getCollection(ids,
+                                this.request.parameters(),
+                                this.router.getContext));
+            }
+        }
+    }
+
+    final void setStatusAndBody(final String message, final Optional<N> node) {
+        if (node.isPresent()) {
+            this.setStatusAndBody(message, node.get());
+        } else {
+            this.setStatus(HttpStatusCode.NO_CONTENT, "No content available");
+        }
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.collect.map.Maps;
+import walkingkooka.compare.Range;
+import walkingkooka.net.UrlPathName;
+import walkingkooka.net.header.AcceptCharset;
+import walkingkooka.net.header.CharsetName;
+import walkingkooka.net.header.HttpHeaderName;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.header.MediaType;
+import walkingkooka.net.header.MediaTypeParameterName;
+import walkingkooka.net.header.NotAcceptableHeaderException;
+import walkingkooka.net.http.HttpEntity;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.net.http.HttpStatusCode;
+import walkingkooka.net.http.server.HttpRequest;
+import walkingkooka.net.http.server.HttpRequestAttribute;
+import walkingkooka.net.http.server.HttpRequestAttributes;
+import walkingkooka.net.http.server.HttpResponse;
+import walkingkooka.net.http.server.HttpServerException;
+import walkingkooka.text.CharSequences;
+import walkingkooka.tree.Node;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Router which accepts a request and then dispatches after testing the {@link HttpMethod}. This is the product of
+ * {@link HateosHandlerBuilder}.
+ */
+abstract class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod<N extends Node<N, ?, ?, ?>> {
+
+    /**
+     * Package private ctor use factory.
+     */
+    HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod(final HateosHandlerBuilderRouter<N> router,
+                                                                      final HttpRequest request,
+                                                                      final HttpResponse response) {
+        super();
+        this.router = router;
+        this.request = request;
+        this.parameters = request.routingParameters();
+        this.response = response;
+    }
+
+    final void execute() {
+        do {
+            // verify correctly dispatched...
+            int pathIndex = this.router.consumeBasePath(this.parameters);
+            if (-1 == pathIndex) {
+                badRequest("Bad routing.");
+                break;
+            }
+
+            // extract resource name......................................................................................
+            final String resourceNameString = this.pathComponentOrNull(pathIndex);
+            if (null == resourceNameString) {
+                this.badRequest("Resource name missing.");
+                break;
+            }
+
+            HateosResourceName resourceName;
+            try {
+                resourceName = HateosResourceName.with(resourceNameString);
+            } catch (final IllegalArgumentException invalid) {
+                this.badRequest("Invalid resource name " + CharSequences.quoteAndEscape(resourceNameString));
+                break;
+            }
+
+            // id or range ..............................................................................................
+            final String idOrRange = this.pathComponentOrNull(pathIndex + 1);
+            if (CharSequences.isNullOrEmpty(idOrRange)) {
+                this.idMissing(resourceName, pathIndex);
+                break;
+            }
+            if ("*".equals(idOrRange)) {
+                this.wildcard(resourceName, pathIndex);
+                break;
+            }
+
+            final int dash = idOrRange.indexOf('-');
+            if (-1 == dash) {
+                this.id(resourceName, idOrRange, pathIndex);
+            } else {
+                this.collection(resourceName, idOrRange, dash, pathIndex);
+            }
+
+        } while (false);
+    }
+
+    // ID.............................................................................................................
+
+    private void idMissing(final HateosResourceName resourceName,
+                           final int pathIndex) {
+        final LinkRelation<?> linkRelation = this.linkRelationOrDefaultOrResponseBadRequest(pathIndex + 2);
+        if (null != linkRelation) {
+            this.idMissing(resourceName, linkRelation);
+        }
+    }
+
+    abstract void idMissing(final HateosResourceName resourceName,
+                            final LinkRelation<?> linkRelation);
+
+    // WILDCARD.............................................................................................................
+
+    private void wildcard(final HateosResourceName resourceName,
+                          final int pathIndex) {
+        final LinkRelation<?> linkRelation = this.linkRelationOrDefaultOrResponseBadRequest(pathIndex + 2);
+        if (null != linkRelation) {
+            this.wildcard(resourceName, linkRelation);
+        }
+    }
+
+    abstract void wildcard(final HateosResourceName resourceName,
+                           final LinkRelation<?> linkRelation);
+
+    // ID.............................................................................................................
+
+    private void id(final HateosResourceName resourceName,
+                    final String id,
+                    final int pathIndex) {
+        // $resourceName / id
+
+        BigInteger bigIntegerId = null;
+        try {
+            bigIntegerId = new BigInteger(id);
+        } catch (final IllegalArgumentException invalid) {
+            this.badRequest("Invalid id " + CharSequences.quoteAndEscape(id));
+        }
+
+        if (null != bigIntegerId) {
+            final LinkRelation<?> linkRelation = this.linkRelationOrDefaultOrResponseBadRequest(pathIndex + 2);
+            if (null != linkRelation) {
+                this.id(resourceName, bigIntegerId, linkRelation);
+            }
+        }
+    }
+
+    abstract void id(final HateosResourceName resourceName,
+                     final BigInteger id,
+                     final LinkRelation<?> linkRelation);
+
+    // COLLECTION.....................................................................................................
+
+    private void collection(final HateosResourceName resourceName,
+                            final String range,
+                            final int dash,
+                            int pathIndex) {
+        do {
+            if (0 == dash || dash == range.length() - 1) {
+                this.badRequest("Invalid id range " + CharSequences.quoteAndEscape(range));
+                break;
+            }
+
+            BigInteger lower;
+            try {
+                lower = new BigInteger(range.substring(0, dash));
+            } catch (final IllegalArgumentException badRequest) {
+                this.badRequest("Invalid beginning id " + CharSequences.quoteAndEscape(range));
+                break;
+            }
+
+            BigInteger upper;
+            try {
+                upper = new BigInteger(range.substring(dash + 1));
+            } catch (final IllegalArgumentException badRequest) {
+                this.badRequest("Invalid end id " + CharSequences.quoteAndEscape(range));
+                break;
+            }
+
+            Range<BigInteger> rangeOfIds;
+            try {
+                rangeOfIds = Range.greaterThanEquals(lower).and(Range.lessThanEquals(upper));
+            } catch (final IllegalArgumentException invalid) {
+                this.badRequest("Invalid range " + CharSequences.quoteAndEscape(range));
+                break;
+            }
+
+            final LinkRelation<?> linkRelation = this.linkRelationOrDefaultOrResponseBadRequest(pathIndex + 2);
+            if (null == linkRelation) {
+                break;
+            }
+
+            this.collection(resourceName, rangeOfIds, linkRelation);
+        } while (false);
+    }
+
+    abstract void collection(final HateosResourceName resourceName,
+                             final Range<BigInteger> ids,
+                             final LinkRelation<?> linkRelation);
+
+    // HELPERS ......................................................................................................
+
+    /**
+     * If not empty parse the relation otherwise return a default of {@link LinkRelation#SELF}, a null indicates an invalid relation.
+     */
+    private LinkRelation<?> linkRelationOrDefaultOrResponseBadRequest(final int pathIndex) {
+        LinkRelation<?> relation = LinkRelation.SELF;
+
+        final Optional<UrlPathName> relationPath = HttpRequestAttributes.pathComponent(pathIndex)
+                .parameterValue(this.parameters);
+
+        if (relationPath.isPresent()) {
+            final String relationString = relationPath.get().value();
+            if (!CharSequences.isNullOrEmpty(relationString)) {
+                try {
+                    relation = LinkRelation.with(relationString);
+                } catch (final IllegalArgumentException invalid) {
+                    relation = null;
+                    badRequest("Invalid link relation " + CharSequences.quoteAndEscape(relationString));
+                }
+            }
+        }
+
+        return relation;
+    }
+
+    /**
+     * Reads and parses the request body into a {@link Node}
+     */
+    final N resource() {
+        Charset charset = Charset.defaultCharset();
+
+        final Optional<MediaType> contentType = HttpHeaderName.CONTENT_TYPE.headerValue(this.request.headers());
+        if (contentType.isPresent()) {
+            final Optional<CharsetName> possible = MediaTypeParameterName.CHARSET.parameterValue(contentType.get());
+            if (possible.isPresent()) {
+                charset = possible.get().charset().orElse(charset);
+            }
+        }
+
+        try (final StringReader reader = new StringReader(new String(request.body(), charset))) {
+            final StringBuilder text = new StringBuilder();
+            final char[] buffer = new char[4096];
+
+            for (; ; ) {
+                final int fill = reader.read(buffer);
+                if (-1 == fill) {
+                    break;
+                }
+                text.append(buffer, 0, fill);
+            }
+
+            // TODO need a DocumentBuilder factory to support XML
+            return this.router.contentType.parse(null, text.toString());
+        } catch (final IOException cause) {
+            throw new HttpServerException(cause.getMessage(), cause);
+        }
+    }
+
+    /**
+     * Locates the {@link HateosHandlerBuilderRouterHandlers} or writes {@link HttpStatusCode#NOT_FOUND} or {@link HttpStatusCode#METHOD_NOT_ALLOWED}
+     */
+    final HateosHandlerBuilderRouterHandlers<N> handlersOrResponseNotFound(final HateosResourceName resourceName,
+                                                                           final LinkRelation<?> linkRelation) {
+        final HateosHandlerBuilderRouterHandlers<N> handlers = this.router.handlers.get(HateosHandlerBuilderRouterKey.with(resourceName, linkRelation));
+        if (null == handlers) {
+            notFound(resourceName, linkRelation);
+        }
+        return handlers;
+    }
+
+    final <H extends HateosHandler<N>> H handlerOrResponseMethodNot(final HateosResourceName resourceName,
+                                                                    final LinkRelation<?> linkRelation,
+                                                                    final H handler) {
+        if (null == handler) {
+            this.methodNotAllowed(resourceName, linkRelation);
+        }
+        return handler;
+    }
+
+    // error reporting.............................................................................................
+
+    final void badRequestIdRequired() {
+        this.badRequest("Id required");
+    }
+
+    final void badRequestCollectionsUnsupported() {
+        this.badRequest("Collections not supported");
+    }
+
+    final void badRequest(final String message) {
+        this.setStatus(HttpStatusCode.BAD_REQUEST, message);
+    }
+
+    final void methodNotAllowed(final HateosResourceName resourceName,
+                                final LinkRelation<?> linkRelation) {
+        methodNotAllowed(message(resourceName, linkRelation));
+    }
+
+    private void methodNotAllowed(final String message) {
+        this.setStatus(HttpStatusCode.METHOD_NOT_ALLOWED, message);
+    }
+
+    private void notFound(final HateosResourceName resourceName,
+                          final LinkRelation<?> linkRelation) {
+        this.setStatus(HttpStatusCode.NOT_FOUND,
+                this.message(resourceName, linkRelation));
+    }
+
+    private String message(final HateosResourceName resourceName,
+                           final LinkRelation<?> linkRelation) {
+        return "resource: " + resourceName + ", link relation: " + linkRelation;
+    }
+
+    /**
+     * Sets the status to successful and body to the bytes of the encoded text of {@link Node}.
+     */
+    final void setStatusAndBody(final String message, final N node) {
+        this.setStatus(HttpStatusCode.OK, message);
+
+        final AcceptCharset acceptCharset = HttpHeaderName.ACCEPT_CHARSET.headerValueOrFail(this.request.headers());
+        final Optional<Charset> charset = acceptCharset.charset();
+        if (!charset.isPresent()) {
+            throw new NotAcceptableHeaderException("AcceptCharset " + acceptCharset + " doesnt contain supported charset");
+        }
+
+        final HateosContentType<N> hateosContentType = this.router.contentType;
+        final MediaType contentType = hateosContentType.contentType();
+
+        final String content = hateosContentType.toText(node);
+        final byte[] contentBytes = content.getBytes(charset.get());
+
+        final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
+        headers.put(HttpHeaderName.CONTENT_TYPE, contentType.setCharset(CharsetName.with(charset.get().name())));
+        headers.put(HttpHeaderName.CONTENT_LENGTH, Long.valueOf(contentBytes.length));
+
+        this.response.addEntity(HttpEntity.with(headers, contentBytes));
+    }
+
+    final void setStatus(final HttpStatusCode statusCode, final String message) {
+        this.response.setStatus(statusCode.setMessage(message));
+    }
+
+    final HateosHandlerBuilderRouter<N> router;
+    final HttpRequest request;
+
+    /**
+     * Fetches the path component at the path index or returns null.
+     */
+    private String pathComponentOrNull(final int pathIndex) {
+        final Optional<UrlPathName> path = HttpRequestAttributes.pathComponent(pathIndex).parameterValue(this.parameters);
+        return path.isPresent() ?
+                path.get().value() :
+                null;
+    }
+
+    final Map<HttpRequestAttribute<?>, Object> parameters;
+    final HttpResponse response;
+
+    @Override
+    public final String toString() {
+        return this.router.toString();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPost.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPost.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.compare.Range;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.net.http.server.HttpRequest;
+import walkingkooka.net.http.server.HttpResponse;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+/**
+ * Router which accepts a request and then dispatches after testing the {@link HttpMethod}. This is the product of
+ * {@link HateosHandlerBuilder}.
+ */
+final class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPost<N extends Node<N, ?, ?, ?>>
+        extends HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod<N> {
+
+    /**
+     * Factory called by {@link HateosHandlerBuilder#build()}
+     */
+    static <N extends Node<N, ?, ?, ?>> HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPost<N> with(final HateosHandlerBuilderRouter<N> router,
+                                                                                                                final HttpRequest request,
+                                                                                                                final HttpResponse response) {
+        return new HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPost<N>(router,
+                request,
+                response);
+    }
+
+    /**
+     * Private ctor use factory.
+     */
+    private HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPost(final HateosHandlerBuilderRouter<N> router,
+                                                                            final HttpRequest request,
+                                                                            final HttpResponse response) {
+        super(router, request, response);
+    }
+
+    @Override
+    void idMissing(final HateosResourceName resourceName, final LinkRelation<?> linkRelation) {
+        this.id(resourceName, Optional.empty(), linkRelation);
+    }
+
+    @Override
+    void wildcard(final HateosResourceName resourceName, final LinkRelation<?> linkRelation) {
+        this.badRequestCollectionsUnsupported();
+    }
+
+    @Override
+    void id(final HateosResourceName resourceName,
+            final BigInteger id,
+            final LinkRelation<?> linkRelation) {
+        this.id(resourceName, Optional.of(id), linkRelation);
+    }
+
+    private void id(final HateosResourceName resourceName,
+                    final Optional<BigInteger> id,
+                    final LinkRelation<?> linkRelation) {
+        final HateosHandlerBuilderRouterHandlers<N> handlers = this.handlersOrResponseNotFound(resourceName, linkRelation);
+        if (null != handlers) {
+            final HateosPostHandler<N> post = this.handlerOrResponseMethodNot(resourceName, linkRelation, handlers.post);
+            if (null != post) {
+                this.setStatusAndBody("Post resource successful",
+                        post.post(id,
+                                this.resource(),
+                                this.router.postContext));
+            }
+        }
+    }
+
+    @Override
+    void collection(final HateosResourceName resourceName,
+                    final Range<BigInteger> ids,
+                    final LinkRelation<?> linkRelation) {
+        this.badRequestCollectionsUnsupported();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPut.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPut.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.compare.Range;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.http.server.HttpRequest;
+import walkingkooka.net.http.server.HttpResponse;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+
+/**
+ * Handles PUT requests.
+ */
+final class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPut<N extends Node<N, ?, ?, ?>>
+        extends HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod<N> {
+
+    /**
+     * Factory called by {@link HateosHandlerBuilder#build()}
+     */
+    static <N extends Node<N, ?, ?, ?>> HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPut<N> with(final HateosHandlerBuilderRouter<N> router,
+                                                                                                               final HttpRequest request,
+                                                                                                               final HttpResponse response) {
+        return new HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPut<N>(router,
+                request,
+                response);
+    }
+
+    /**
+     * Private ctor use factory.
+     */
+    private HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPut(final HateosHandlerBuilderRouter<N> router,
+                                                                           final HttpRequest request,
+                                                                           final HttpResponse response) {
+        super(router, request, response);
+    }
+
+    @Override
+    void idMissing(final HateosResourceName resourceName, final LinkRelation<?> linkRelation) {
+        this.badRequestIdRequired();
+    }
+
+    @Override
+    void wildcard(final HateosResourceName resourceName, final LinkRelation<?> linkRelation) {
+        this.badRequestCollectionsUnsupported();
+    }
+
+    @Override
+    void id(final HateosResourceName resourceName,
+            final BigInteger id,
+            final LinkRelation<?> linkRelation) {
+        final HateosHandlerBuilderRouterHandlers<N> handlers = this.handlersOrResponseNotFound(resourceName, linkRelation);
+        if (null != handlers) {
+            final HateosPutHandler<N> put = this.handlerOrResponseMethodNot(resourceName, linkRelation, handlers.put);
+            if (null != put) {
+                this.setStatusAndBody("Put resource successful",
+                        put.put(id,
+                                this.resource(),
+                                this.router.putContext));
+            }
+        }
+    }
+
+    @Override
+    void collection(final HateosResourceName resourceName,
+                    final Range<BigInteger> ids,
+                    final LinkRelation<?> linkRelation) {
+        this.badRequestCollectionsUnsupported();
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterKey.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterKey.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.test.HashCodeEqualsDefined;
+
+import java.util.Objects;
+
+/**
+ * Used as a key within a map holding all handlers.
+ */
+final class HateosHandlerBuilderRouterKey implements HashCodeEqualsDefined, Comparable<HateosHandlerBuilderRouterKey> {
+
+    static HateosHandlerBuilderRouterKey with(final HateosResourceName resourceName, final LinkRelation<?> linkRelation) {
+        return new HateosHandlerBuilderRouterKey(resourceName, linkRelation);
+    }
+
+    private HateosHandlerBuilderRouterKey(final HateosResourceName resourceName, final LinkRelation<?> linkRelation) {
+        this.resourceName = resourceName;
+        this.linkRelation = linkRelation;
+    }
+
+    final HateosResourceName resourceName;
+
+    final LinkRelation<?> linkRelation;
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.resourceName, this.linkRelation);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+                other instanceof HateosHandlerBuilderRouterKey && this.equals0((HateosHandlerBuilderRouterKey) other);
+    }
+
+    private boolean equals0(final HateosHandlerBuilderRouterKey other) {
+        return this.compareTo(other) == 0;
+    }
+
+    /**
+     * Dumps the resource name and link relation
+     */
+    @Override
+    public String toString() {
+        return this.resourceName + " " + this.linkRelation;
+    }
+
+    @Override
+    public int compareTo(final HateosHandlerBuilderRouterKey other) {
+        int result = this.resourceName.compareTo(other.resourceName);
+        if (0 == result) {
+            result = this.linkRelation.compareTo(other.linkRelation);
+        }
+        return result;
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerContext.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerContext.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.Context;
+import walkingkooka.net.header.Link;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+
+/**
+ * A {@link Context} that accompanies all handlers and provides a service to retrieve all {@link Link} for an resource.
+ */
+public interface HateosHandlerContext<N extends Node<N, ?, ?, ?>> extends Context {
+
+    /**
+     * Adds links for this node.
+     */
+    N addLinks(final HateosResourceName name,
+               final BigInteger id,
+               final N node);
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerContextTestCase.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerContextTestCase.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.ContextTestCase;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+
+public abstract class HateosHandlerContextTestCase<C extends HateosHandlerContext<N>,
+        N extends Node<N, ?, ?, ?>>
+        extends ContextTestCase<C> {
+
+
+    @Test(expected = NullPointerException.class)
+    public void testAddLinksNullNameFails() {
+        this.addLinksAndCheck(null, this.id(), this.node());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testAddLinksNullIdFails() {
+        this.addLinksAndCheck(this.name(), null, this.node());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testAddLinksNullNullFails() {
+        this.addLinksAndCheck(this.name(), this.id(), null);
+    }
+
+    protected void addLinksAndCheck(final HateosResourceName name,
+                                    final BigInteger id,
+                                    final N node,
+                                    final N expected) {
+        this.addLinksAndCheck(this.createContext(),
+                name,
+                id,
+                node,
+                expected);
+    }
+
+    protected void addLinksAndCheck(final C context,
+                                    final HateosResourceName name,
+                                    final BigInteger id,
+                                    final N node,
+                                    final N expected) {
+    }
+
+    protected N addLinksAndCheck(final HateosResourceName name,
+                                 final BigInteger id,
+                                 final N node) {
+        return this.createContext().addLinks(name,
+                id,
+                node);
+    }
+
+    protected N addLinksAndCheck(final C context,
+                                 final HateosResourceName name,
+                                 final BigInteger id,
+                                 final N node) {
+        return context.addLinks(name,
+                id,
+                node);
+    }
+
+    @Override
+    protected String requiredNameSuffix() {
+        return HateosHandlerContext.class.getSimpleName();
+    }
+
+    protected abstract HateosResourceName name();
+
+    protected abstract BigInteger id();
+
+    protected abstract N node();
+
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerTestCase.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosHandlerTestCase.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.test.ClassTestCase;
+import walkingkooka.tree.Node;
+
+public abstract class HateosHandlerTestCase<H extends HateosHandler<N>, N extends Node<N, ?, ?, ?>> extends ClassTestCase<H> {
+
+    HateosHandlerTestCase() {
+        super();
+    }
+
+    abstract protected H createHandler();
+
+    abstract protected HateosHandlerContext<N> createContext();
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosPostHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosPostHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+/**
+ * Handles POST requests for an resource.
+ */
+public interface HateosPostHandler<N extends Node<N, ?, ?, ?>> extends HateosHandler<N> {
+
+    /**
+     * Processes a post.
+     */
+    N post(final Optional<BigInteger> id,
+           final N resource,
+           final HateosHandlerContext<N> context);
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosPostHandlerTestCase.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosPostHandlerTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+public abstract class HateosPostHandlerTestCase<H extends HateosPostHandler<N>, N extends Node<N, ?, ?, ?>> extends HateosHandlerTestCase<H, N> {
+
+    @Test(expected = NullPointerException.class)
+    public void testNullIdFails() {
+        this.post(null,
+                this.resource(),
+                this.createContext());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullResourceFails() {
+        this.post(this.id(),
+                null,
+                this.createContext());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullContextFails() {
+        this.post(this.id(),
+                this.resource(),
+                null);
+    }
+
+    protected N post(final Optional<BigInteger> id,
+                     final N resource,
+                     final HateosHandlerContext<N> context) {
+        return this.createHandler().post(id, resource, context);
+    }
+
+    abstract protected Optional<BigInteger> id();
+
+    abstract protected N resource();
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosPutHandler.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosPutHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+
+/**
+ * Handles PUT requests for an resource.
+ */
+public interface HateosPutHandler<N extends Node<N, ?, ?, ?>> extends HateosHandler<N> {
+
+    /**
+     * Processes a put or update operation.
+     */
+    N put(final BigInteger id,
+          final N resource,
+          final HateosHandlerContext<N> context);
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosPutHandlerTestCase.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosPutHandlerTestCase.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.tree.Node;
+
+import java.math.BigInteger;
+
+public abstract class HateosPutHandlerTestCase<H extends HateosPutHandler<N>, N extends Node<N, ?, ?, ?>> extends HateosHandlerTestCase<H, N> {
+
+    @Test(expected = NullPointerException.class)
+    public void testNullIdFails() {
+        this.put(null,
+                this.resource(),
+                this.createContext());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullResourceFails() {
+        this.put(this.id(),
+                null,
+                this.createContext());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullContextFails() {
+        this.put(this.id(),
+                this.resource(),
+                null);
+    }
+
+    protected N put(final BigInteger id,
+                    final N resource,
+                    final HateosHandlerContext<N> context) {
+        return this.createHandler().put(id, resource, context);
+    }
+
+    abstract protected BigInteger id();
+
+    abstract protected N resource();
+}

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceName.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceName.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.naming.Name;
+import walkingkooka.predicate.character.CharPredicate;
+import walkingkooka.predicate.character.CharPredicates;
+import walkingkooka.text.CaseSensitivity;
+
+/**
+ * The {@link Name} of an resource
+ */
+public final class HateosResourceName implements Name, Comparable<HateosResourceName> {
+
+    /**
+     * Factory that creates a {@link HateosResourceName}
+     */
+    public static HateosResourceName with(final String name) {
+        CharPredicates.failIfNullOrEmptyOrInitialAndPartFalse(name, "name", INITIAL, PART);
+
+        return new HateosResourceName(name);
+    }
+
+    private final static CharPredicate INITIAL = Character::isJavaIdentifierStart;
+
+    private final static CharPredicate PART = Character::isJavaIdentifierPart;
+
+    /**
+     * Private constructor
+     */
+    private HateosResourceName(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String value() {
+        return this.name;
+    }
+
+    private final String name;
+
+    // Object
+
+    @Override
+    public int hashCode() {
+        return CASE_SENSITIVITY.hash(this.name);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this == other ||
+                other instanceof HateosResourceName && this.equals0((HateosResourceName) other);
+    }
+
+    private boolean equals0(final HateosResourceName other) {
+        return this.compareTo(other) == 0;
+    }
+
+    private final CaseSensitivity CASE_SENSITIVITY = CaseSensitivity.SENSITIVE;
+
+    /**
+     * Dumps the resource name.
+     */
+    @Override
+    public String toString() {
+        return this.name;
+    }
+
+    @Override
+    public int compareTo(final HateosResourceName other) {
+        return CASE_SENSITIVITY.comparator().compare(this.name, other.name);
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosContentTypeJsonNodeTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosContentTypeJsonNodeTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.collect.set.Sets;
+import walkingkooka.net.Url;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.tree.json.JsonNode;
+
+import java.math.BigInteger;
+
+public final class HateosContentTypeJsonNodeTest extends HateosContentTypeTestCase<HateosContentTypeJsonNode, JsonNode> {
+
+    @Test
+    public void testAddLinkSelf() throws Exception {
+        this.addLinksAndCheck(BigInteger.valueOf(123),
+                "{ \"prop1\":\"value1\"}",
+                HttpMethod.GET,
+                Url.parseAbsolute("http://example.com/base"),
+                HateosResourceName.with("entity"),
+                Sets.of(LinkRelation.SELF),
+                "{\n" +
+                        "  \"prop1\": \"value1\",\n" +
+                        "  \"_links\": [{\n" +
+                        "    \"href\": \"http://example.com/base/entity/123\",\n" +
+                        "    \"method\": \"GET\",\n" +
+                        "    \"rel\": \"self\",\n" +
+                        "    \"type\": \"application/hal+json\"\n" +
+                        "  }]\n" +
+                        "}");
+    }
+
+    @Test
+    public void testAddLinkNonSelf() throws Exception {
+        this.addLinksAndCheck(BigInteger.valueOf(123),
+                "{ \"prop1\":\"value1\"}",
+                HttpMethod.GET,
+                Url.parseAbsolute("http://example.com/base"),
+                HateosResourceName.with("entity"),
+                Sets.of(LinkRelation.ITEM),
+                "{\n" +
+                        "  \"prop1\": \"value1\",\n" +
+                        "  \"_links\": [{\n" +
+                        "    \"href\": \"http://example.com/base/entity/123/item\",\n" +
+                        "    \"method\": \"GET\",\n" +
+                        "    \"rel\": \"item\",\n" +
+                        "    \"type\": \"application/hal+json\"\n" +
+                        "  }]\n" +
+                        "}");
+    }
+
+    @Test
+    public void testAddLinkManyRelations() throws Exception {
+        this.addLinksAndCheck(BigInteger.valueOf(123),
+                "{ \"prop1\":\"value1\"}",
+                HttpMethod.GET,
+                Url.parseAbsolute("http://example.com/base"),
+                HateosResourceName.with("entity"),
+                Sets.of(LinkRelation.SELF, LinkRelation.ITEM),
+                "{\n" +
+                        "  \"prop1\": \"value1\",\n" +
+                        "  \"_links\": [{\n" +
+                        "    \"href\": \"http://example.com/base/entity/123/item\",\n" +
+                        "    \"method\": \"GET\",\n" +
+                        "    \"rel\": \"item\",\n" +
+                        "    \"type\": \"application/hal+json\"\n" +
+                        "  }, {\n" +
+                        "    \"href\": \"http://example.com/base/entity/123\",\n" +
+                        "    \"method\": \"GET\",\n" +
+                        "    \"rel\": \"self\",\n" +
+                        "    \"type\": \"application/hal+json\"\n" +
+                        "  }]\n" +
+                        "}");
+    }
+
+    @Override
+    HateosContentTypeJsonNode constant() {
+        return HateosContentTypeJsonNode.instance();
+    }
+
+    @Override
+    JsonNode parse(final String text) {
+        return JsonNode.parse(text);
+    }
+
+    @Override
+    protected Class<HateosContentTypeJsonNode> type() {
+        return HateosContentTypeJsonNode.class;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosContentTypeTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosContentTypeTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.Cast;
+import walkingkooka.test.ClassTestCase;
+import walkingkooka.type.MemberVisibility;
+
+public final class HateosContentTypeTest extends ClassTestCase<HateosContentType<?>> {
+
+    @Override
+    protected Class<HateosContentType<?>> type() {
+        return Cast.to(HateosContentType.class);
+    }
+
+    @Override
+    protected MemberVisibility typeVisibility() {
+        return MemberVisibility.PUBLIC;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosContentTypeTestCase.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosContentTypeTestCase.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.net.AbsoluteUrl;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.test.ClassTestCase;
+import walkingkooka.text.CharSequences;
+import walkingkooka.tree.Node;
+import walkingkooka.type.MemberVisibility;
+
+import java.math.BigInteger;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class HateosContentTypeTestCase<C extends HateosContentType<N>, N extends Node<N, ?, ?, ?>> extends ClassTestCase<C> {
+
+    HateosContentTypeTestCase() {
+        super();
+    }
+
+    final void addLinksAndCheck(final BigInteger id,
+                                final String node,
+                                final HttpMethod method,
+                                final AbsoluteUrl base,
+                                final HateosResourceName resourceName,
+                                final Set<LinkRelation<?>> linkRelations,
+                                final String expected) throws Exception {
+        assertEquals("add links " + id + " " + CharSequences.quoteAndEscape(node) + " " + method + " " + base + " " + linkRelations,
+                this.parse(expected),
+                this.addLinks(id, this.parse(node), method, base, resourceName, linkRelations));
+    }
+
+    final N addLinks(final BigInteger id,
+                     final N node,
+                     final HttpMethod method,
+                     final AbsoluteUrl base,
+                     final HateosResourceName resourceName,
+                     final Set<LinkRelation<?>> linkRelations) {
+        return this.constant().addLinks(id, node, method, base, resourceName, linkRelations);
+    }
+
+    abstract N parse(final String text) throws Exception;
+
+    abstract C constant();
+
+    @Override
+    protected final MemberVisibility typeVisibility() {
+        return MemberVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosContentTypeXmlNodeTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosContentTypeXmlNodeTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.collect.set.Sets;
+import walkingkooka.net.Url;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.tree.xml.XmlNode;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
+import java.math.BigInteger;
+
+public final class HateosContentTypeXmlNodeTest extends HateosContentTypeTestCase<HateosContentTypeXmlNode, XmlNode> {
+
+    @Test
+    public void testAddLinkSelf() throws Exception {
+        this.addLinksAndCheck(BigInteger.valueOf(123),
+                "<entity><value>1</value></entity>",
+                HttpMethod.GET,
+                Url.parseAbsolute("http://example.com/base"),
+                HateosResourceName.with("entity"),
+                Sets.of(LinkRelation.SELF),
+                "<entity><value>1</value><links><link href=\"http://example.com/base/entity/123\" method=\"GET\" rel=\"self\" type=\"application/hal+xml\"/></links></entity>");
+    }
+
+    @Test
+    public void testAddLinkNonSelf() throws Exception {
+        this.addLinksAndCheck(BigInteger.valueOf(123),
+                "<entity><value>1</value></entity>",
+                HttpMethod.GET,
+                Url.parseAbsolute("http://example.com/base"),
+                HateosResourceName.with("entity"),
+                Sets.of(LinkRelation.ITEM),
+                "<entity><value>1</value><links><link href=\"http://example.com/base/entity/123/item\" method=\"GET\" rel=\"item\" type=\"application/hal+xml\"/></links></entity>");
+    }
+
+    @Test
+    public void testAddLinkManyRelations() throws Exception {
+        this.addLinksAndCheck(BigInteger.valueOf(123),
+                "<entity><value>1</value></entity>",
+                HttpMethod.GET,
+                Url.parseAbsolute("http://example.com/base"),
+                HateosResourceName.with("entity"),
+                Sets.of(LinkRelation.SELF, LinkRelation.ITEM),
+                "<entity><value>1</value><links><link href=\"http://example.com/base/entity/123/item\" method=\"GET\" rel=\"item\" type=\"application/hal+xml\"/><link href=\"http://example.com/base/entity/123\" method=\"GET\" rel=\"self\" type=\"application/hal+xml\"/></links></entity>");
+    }
+
+    @Override
+    HateosContentTypeXmlNode constant() {
+        return HateosContentTypeXmlNode.instance();
+    }
+
+    @Override
+    XmlNode parse(final String text) throws Exception {
+        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(false);
+        factory.setValidating(false);
+        factory.setExpandEntityReferences(false);
+        return XmlNode.fromXml(factory.newDocumentBuilder(),
+                new StringReader(text))
+                .element()
+                .get()
+                .normalize();
+    }
+
+    @Override
+    protected Class<HateosContentTypeXmlNode> type() {
+        return HateosContentTypeXmlNode.class;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilder2Test.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilder2Test.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.Cast;
+import walkingkooka.test.ClassTestCase;
+import walkingkooka.type.MemberVisibility;
+
+public final class HateosHandlerBuilder2Test extends ClassTestCase<HateosHandlerBuilder2<?>> {
+    @Override
+    protected Class<HateosHandlerBuilder2<?>> type() {
+        return Cast.to(HateosHandlerBuilder2.class);
+    }
+
+    @Override
+    protected MemberVisibility typeVisibility() {
+        return MemberVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHandlersTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHandlersTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.test.ClassTestCase;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.type.MemberVisibility;
+
+import static org.junit.Assert.assertEquals;
+
+public final class HateosHandlerBuilderRouterHandlersTest extends ClassTestCase<HateosHandlerBuilderRouterHandlers<JsonNode>> {
+
+    @Test
+    public void testCopy() {
+        final HateosHandlerBuilderRouterHandlers<JsonNode> handlers = HateosHandlerBuilderRouterHandlers.with();
+
+        final FakeHateosGetHandler<JsonNode> get = new FakeHateosGetHandler<>();
+        final FakeHateosPostHandler<JsonNode> post = new FakeHateosPostHandler<>();
+        final FakeHateosPutHandler<JsonNode> put = new FakeHateosPutHandler<>();
+        final FakeHateosDeleteHandler<JsonNode> delete = new FakeHateosDeleteHandler<>();
+
+        handlers.get = get;
+        handlers.post = post;
+        handlers.put = put;
+        handlers.delete = delete;
+
+        final HateosHandlerBuilderRouterHandlers<JsonNode> copy = handlers.copy();
+
+        assertEquals("GET", get, copy.get);
+        assertEquals("POST", post, copy.post);
+        assertEquals("PUT", put, copy.put);
+        assertEquals("DELETE", delete, copy.delete);
+    }
+
+    @Test
+    public void testToString() {
+        final HateosHandlerBuilderRouterHandlers<JsonNode> handlers = HateosHandlerBuilderRouterHandlers.with();
+
+        final FakeHateosGetHandler<JsonNode> get = new FakeHateosGetHandler<JsonNode>() {
+            public String toString() {
+                return "G1";
+            }
+
+            ;
+        };
+        final FakeHateosPostHandler<JsonNode> post = new FakeHateosPostHandler<JsonNode>() {
+            public String toString() {
+                return "P2";
+            }
+
+            ;
+        };
+        final FakeHateosPutHandler<JsonNode> put = new FakeHateosPutHandler<JsonNode>() {
+            public String toString() {
+                return "P3";
+            }
+
+            ;
+        };
+        final FakeHateosDeleteHandler<JsonNode> delete = new FakeHateosDeleteHandler<JsonNode>() {
+            public String toString() {
+                return "D4";
+            }
+
+            ;
+        };
+
+        handlers.get = get;
+        handlers.post = post;
+        handlers.put = put;
+        handlers.delete = delete;
+
+        assertEquals("GET=G1 POST=P2 PUT=P3 DELETE=D4", handlers.toString());
+    }
+
+    @Override
+    protected Class<HateosHandlerBuilderRouterHandlers<JsonNode>> type() {
+        return Cast.to(HateosHandlerBuilderRouterHandlers.class);
+    }
+
+    @Override
+    protected MemberVisibility typeVisibility() {
+        return MemberVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHateosHandlerContextTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHateosHandlerContextTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.set.Sets;
+import walkingkooka.net.Url;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.tree.json.JsonNode;
+
+import java.math.BigInteger;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public final class HateosHandlerBuilderRouterHateosHandlerContextTest extends
+        HateosHandlerContextTestCase<HateosHandlerBuilderRouterHateosHandlerContext<JsonNode>, JsonNode> {
+
+    @Test
+    public void testAddLinksSelf() {
+        this.addLinksAndCheck2(this.resourceName1(),
+                "{\"prop1\": \"value1\", \"prop2\": \"value2\"}");
+    }
+
+    @Test
+    public void testAddLinksNoneSelf() {
+        this.addLinksAndCheck2(this.resourceName2(),
+                "{\"prop1\": \"value1\", \"prop2\": \"value2\"}");
+    }
+
+    @Test
+    public void testAddLinksManyLinks() {
+        this.addLinksAndCheck2(this.resourceName3(),
+                "{\"prop1\": \"value1\", \"prop2\": \"value2\"}");
+    }
+
+    private void addLinksAndCheck2(final HateosResourceName resourceName,
+                                   final String expected) {
+        this.addLinksAndCheck(resourceName,
+                BigInteger.valueOf(123),
+                this.node(),
+                JsonNode.parse(expected));
+    }
+
+    @Override
+    protected HateosHandlerBuilderRouterHateosHandlerContext<JsonNode> createContext() {
+        return HateosHandlerBuilderRouterHateosHandlerContext.with(HttpMethod.GET,
+                HateosContentType.JSON,
+                Url.parseAbsolute("http://example.com/api/"),
+                this.nameAndLinkRelations());
+    }
+
+    private Set<HateosHandlerBuilderRouterKey> nameAndLinkRelations() {
+        final Set<HateosHandlerBuilderRouterKey> nameAndLinkRelations = Sets.sorted();
+
+        nameAndLinkRelations.add(HateosHandlerBuilderRouterKey.with(this.resourceName1(), LinkRelation.SELF));
+        nameAndLinkRelations.add(HateosHandlerBuilderRouterKey.with(this.resourceName1(), LinkRelation.ABOUT));
+        nameAndLinkRelations.add(HateosHandlerBuilderRouterKey.with(this.resourceName2(), LinkRelation.SELF));
+        nameAndLinkRelations.add(HateosHandlerBuilderRouterKey.with(this.resourceName2(), LinkRelation.PREV));
+        nameAndLinkRelations.add(HateosHandlerBuilderRouterKey.with(this.resourceName2(), LinkRelation.NEXT));
+
+        return nameAndLinkRelations;
+    }
+
+    private HateosResourceName resourceName1() {
+        return HateosResourceName.with("entity1");
+    }
+
+    private HateosResourceName resourceName2() {
+        return HateosResourceName.with("entity2");
+    }
+
+    private HateosResourceName resourceName3() {
+        return HateosResourceName.with("entity3");
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("http://example.com/api/", this.createContext().toString());
+    }
+
+    @Override
+    protected HateosResourceName name() {
+        return HateosResourceName.with("entity1");
+    }
+
+    @Override
+    protected BigInteger id() {
+        return BigInteger.valueOf(123);
+    }
+
+    @Override
+    protected JsonNode node() {
+        return JsonNode.parse("{\"prop1\": \"value1\", \"prop2\": \"value2\"}");
+    }
+
+    @Override
+    protected Class<HateosHandlerBuilderRouterHateosHandlerContext<JsonNode>> type() {
+        return Cast.to(HateosHandlerBuilderRouterHateosHandlerContext.class);
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDeleteTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDeleteTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.Cast;
+import walkingkooka.tree.json.JsonNode;
+
+public final class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDeleteTest extends
+        HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethodTestCase<HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDelete<JsonNode>> {
+    @Override
+    protected Class<HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDelete<JsonNode>> type() {
+        return Cast.to(HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerDelete.class);
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGetTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGetTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.Cast;
+import walkingkooka.tree.json.JsonNode;
+
+public final class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGetTest extends
+        HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethodTestCase<HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGet<JsonNode>> {
+    @Override
+    protected Class<HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGet<JsonNode>> type() {
+        return Cast.to(HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerGet.class);
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethodTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethodTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.Cast;
+import walkingkooka.test.ClassTestCase;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.type.MemberVisibility;
+
+public final class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethodTest extends
+        ClassTestCase<HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod<JsonNode>> {
+    @Override
+    protected Class<HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod<JsonNode>> type() {
+        return Cast.to(HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod.class);
+    }
+
+    @Override
+    protected MemberVisibility typeVisibility() {
+        return MemberVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethodTestCase.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethodTestCase.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.test.ClassTestCase;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.type.MemberVisibility;
+
+public abstract class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethodTestCase<M extends HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethod<JsonNode>>
+        extends ClassTestCase<M> {
+
+    HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethodTestCase() {
+        super();
+    }
+
+    @Override
+    protected final MemberVisibility typeVisibility() {
+        return MemberVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPostTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPostTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.Cast;
+import walkingkooka.tree.json.JsonNode;
+
+public final class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPostTest extends
+        HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethodTestCase<HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPost<JsonNode>> {
+    @Override
+    protected Class<HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPost<JsonNode>> type() {
+        return Cast.to(HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPost.class);
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPutTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPutTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.Cast;
+import walkingkooka.tree.json.JsonNode;
+
+public final class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPutTest extends
+        HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerMethodTestCase<HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPut<JsonNode>> {
+    @Override
+    protected Class<HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPut<JsonNode>> type() {
+        return Cast.to(HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerPut.class);
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.net.http.HttpStatusCode;
+import walkingkooka.net.http.server.FakeHttpRequest;
+import walkingkooka.net.http.server.HttpResponses;
+import walkingkooka.net.http.server.TestRecordingHttpResponse;
+import walkingkooka.test.ClassTestCase;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.type.MemberVisibility;
+
+public final class HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumerTest extends ClassTestCase<HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumer<JsonNode>> {
+
+    @Test
+    public void testMethodNotSupported() {
+        final FakeHttpRequest request = new FakeHttpRequest() {
+            @Override
+            public HttpMethod method() {
+                return HttpMethod.with("XYZ");
+            }
+
+            @Override
+            public String toString() {
+                return this.method().toString();
+            }
+        };
+        final TestRecordingHttpResponse response = HttpResponses.testRecording();
+        HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumer.with(null)
+                .accept(request, response);
+        response.check(request, HttpStatusCode.METHOD_NOT_ALLOWED.setMessage("XYZ"));
+    }
+
+    @Override
+    protected Class<HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumer<JsonNode>> type() {
+        return Cast.to(HateosHandlerBuilderRouterHttpRequestHttpResponseBiConsumer.class);
+    }
+
+    @Override
+    protected MemberVisibility typeVisibility() {
+        return MemberVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterKeyTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterKeyTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.compare.ComparableTesting;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.test.ClassTestCase;
+import walkingkooka.type.MemberVisibility;
+
+import static org.junit.Assert.assertEquals;
+
+public final class HateosHandlerBuilderRouterKeyTest extends ClassTestCase<HateosHandlerBuilderRouterKey> implements ComparableTesting<HateosHandlerBuilderRouterKey> {
+
+    @Test
+    public void testDifferentResourceName() {
+        this.checkNotEquals(HateosHandlerBuilderRouterKey.with(HateosResourceName.with("different"), this.linkRelation()));
+    }
+
+    @Test
+    public void testDifferentLinkRelation() {
+        this.checkNotEquals(HateosHandlerBuilderRouterKey.with(this.resourceName(), LinkRelation.with("different")));
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("resource1 self", this.createComparable().toString());
+    }
+
+    @Override
+    public HateosHandlerBuilderRouterKey createComparable() {
+        return HateosHandlerBuilderRouterKey.with(this.resourceName(), this.linkRelation());
+    }
+
+    private HateosResourceName resourceName() {
+        return HateosResourceName.with("resource1");
+    }
+
+    private LinkRelation<?> linkRelation() {
+        return LinkRelation.SELF;
+    }
+
+    @Override
+    protected Class<HateosHandlerBuilderRouterKey> type() {
+        return HateosHandlerBuilderRouterKey.class;
+    }
+
+    @Override
+    protected MemberVisibility typeVisibility() {
+        return MemberVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderRouterTest.java
@@ -1,0 +1,1130 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.map.Maps;
+import walkingkooka.compare.Range;
+import walkingkooka.net.RelativeUrl;
+import walkingkooka.net.Url;
+import walkingkooka.net.header.AcceptCharset;
+import walkingkooka.net.header.CharsetName;
+import walkingkooka.net.header.HttpHeaderName;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.http.HttpEntity;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.net.http.HttpProtocolVersion;
+import walkingkooka.net.http.HttpStatus;
+import walkingkooka.net.http.HttpStatusCode;
+import walkingkooka.net.http.HttpTransport;
+import walkingkooka.net.http.server.HttpRequest;
+import walkingkooka.net.http.server.HttpRequestAttribute;
+import walkingkooka.net.http.server.HttpRequestParameterName;
+import walkingkooka.net.http.server.HttpResponse;
+import walkingkooka.net.http.server.HttpResponses;
+import walkingkooka.net.http.server.TestRecordingHttpResponse;
+import walkingkooka.routing.RouterTestCase;
+import walkingkooka.test.Latch;
+import walkingkooka.tree.json.JsonNode;
+
+import java.math.BigInteger;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public final class HateosHandlerBuilderRouterTest extends RouterTestCase<HateosHandlerBuilderRouter<JsonNode>,
+        HttpRequestAttribute<?>,
+        BiConsumer<HttpRequest, HttpResponse>> {
+
+    final static byte[] NO_BODY = null;
+    final static byte[] BODY = "{\"prop1\":\"value1\"}".getBytes(Charset.defaultCharset());
+
+    final static BigInteger ID = BigInteger.valueOf(123);
+    final static BigInteger NO_ID = null;
+    final static Range<BigInteger> ALL = Range.all();
+    final static Range<BigInteger> RANGE = Range.greaterThanEquals(BigInteger.valueOf(123)).and(Range.lessThanEquals(BigInteger.valueOf(456)));
+
+    private final static FakeHateosGetHandler<JsonNode> GET_HANDLER = new FakeHateosGetHandler<>();
+    private final static FakeHateosPostHandler<JsonNode> POST_HANDLER = new FakeHateosPostHandler<>();
+    private final static FakeHateosPutHandler<JsonNode> PUT_HANDLER = new FakeHateosPutHandler<>();
+    private final static FakeHateosDeleteHandler<JsonNode> DELETE_HANDLER = new FakeHateosDeleteHandler<>();
+
+
+    // GET RESOURCE ................................................................................................
+
+    @Test
+    public void testGetInvalidResourceNameBadRequest() {
+        this.routeGetHandleAndCheck((b) -> b.get(this.resourceName1(), this.relation1(), GET_HANDLER),
+                "/api/999/123/self",
+                HttpStatusCode.BAD_REQUEST,
+                "Invalid resource name \"999\"",
+                null);
+    }
+
+    @Test
+    public void testGetWithoutHandlersNotFound() {
+        this.routeGetHandleAndCheck((b) -> b.get(this.resourceName1(), this.relation1(), GET_HANDLER),
+                "/api/resource3/123/xyz",
+                HttpStatusCode.NOT_FOUND,
+                "resource: resource3, link relation: xyz",
+                null);
+    }
+
+    @Test
+    public void testGetInvalidIdBadRequest() {
+        this.routeGetHandleAndCheck((b) -> b.get(this.resourceName1(), this.relation1(), GET_HANDLER),
+                "/api/resource3/abc123/self",
+                HttpStatusCode.BAD_REQUEST,
+                "Invalid id \"abc123\"",
+                null);
+    }
+
+    @Test
+    public void testGetInvalidRangeBeginningBadRequest() {
+        this.routeGetHandleAndCheck((b) -> b.get(this.resourceName1(), this.relation1(), GET_HANDLER),
+                "/api/resource3/-456/self",
+                HttpStatusCode.BAD_REQUEST,
+                "Invalid id range \"-456\"",
+                null);
+    }
+
+    @Test
+    public void testGetInvalidRangeEndBadRequest() {
+        this.routeGetHandleAndCheck((b) -> b.get(this.resourceName1(), this.relation1(), GET_HANDLER),
+                "/api/resource3/123-/self",
+                HttpStatusCode.BAD_REQUEST,
+                "Invalid id range \"123-\"",
+                null);
+    }
+
+    @Test
+    public void testGetInvalidLinkRelationBadRequest() {
+        this.routeGetHandleAndCheck((b) -> b.get(this.resourceName1(), this.relation1(), GET_HANDLER),
+                "/api/resource1/123/999",
+                HttpStatusCode.BAD_REQUEST,
+                "Invalid link relation \"999\"",
+                null);
+    }
+
+    @Test
+    public void testGetIdWithRelationSelf() {
+        final Latch getted = Latch.create();
+
+        this.routeGetHandleAndCheck((b) -> this.addGetHandler(b, "{}", getted),
+                "/api/resource1/123/self?param1=value1",
+                HttpStatusCode.OK,
+                "Get resource successful",
+                "{}");
+
+        assertEquals("Getted ", true, getted.value());
+    }
+
+    @Test
+    public void testGetIdWithoutRelationDefaultsSelf() {
+        final Latch getted = Latch.create();
+
+        this.routeGetHandleAndCheck((b) -> this.addGetHandler(b, "{}", getted),
+                "/api/resource1/123?param1=value1",
+                HttpStatusCode.OK,
+                "Get resource successful",
+                "{}");
+
+        assertEquals("Getted ", true, getted.value());
+    }
+
+    @Test
+    public void testGetIdIgnoresAlternatives() {
+        final Latch getted = Latch.create();
+
+        this.routeGetHandleAndCheck((b) -> {
+                    this.addGetHandler(b, "{}", getted);
+                    b.get(this.resourceName1(), this.relation2(), GET_HANDLER);
+                    b.get(this.resourceName2(), this.relation1(), GET_HANDLER);
+                },
+                "/api/resource1/123/self?param1=value1",
+                HttpStatusCode.OK,
+                "Get resource successful",
+                "{}");
+
+        assertEquals("Getted ", true, getted.value());
+    }
+
+    @Test
+    public void testGetContextAddLinks() {
+        final HateosHandlerBuilder<JsonNode> builder = this.builder();
+        builder.get(this.resourceName1(),
+                this.relation1(),
+                new FakeHateosGetHandler<JsonNode>() {
+                    @Override
+                    public Optional<JsonNode> get(final BigInteger id,
+                                                  final Map<HttpRequestParameterName, List<String>> parameters,
+                                                  final HateosHandlerContext<JsonNode> context) {
+                        return Optional.of(context.addLinks(resourceName1(), id, JsonNode.parse("{\"p1\": \"v1\"}")));
+                    }
+                });
+        builder.get(this.resourceName1(),
+                this.relation2(),
+                GET_HANDLER);
+
+        this.routeHandleAndCheck(builder,
+                HttpMethod.GET,
+                "/api/resource1/123/self",
+                NO_BODY,
+                HttpStatusCode.OK.setMessage("Get resource successful"),
+                this.httpEntity("{\n" +
+                        "  \"p1\": \"v1\",\n" +
+                        "  \"_links\": [{\n" +
+                        "    \"href\": \"http://www.example.com/api/resource1/123/next\",\n" +
+                        "    \"method\": \"GET\",\n" +
+                        "    \"rel\": \"next\",\n" +
+                        "    \"type\": \"application/hal+json\"\n" +
+                        "  }, {\n" +
+                        "    \"href\": \"http://www.example.com/api/resource1/123\",\n" +
+                        "    \"method\": \"GET\",\n" +
+                        "    \"rel\": \"self\",\n" +
+                        "    \"type\": \"application/hal+json\"\n" +
+                        "  }]\n" +
+                        "}"));
+    }
+
+    private void addGetHandler(final HateosHandlerBuilder<JsonNode> builder,
+                               final String reply,
+                               final Latch getted) {
+        builder.get(this.resourceName1(),
+                this.relation1(),
+                new FakeHateosGetHandler<JsonNode>() {
+
+                    @Override
+                    public Optional<JsonNode> get(final BigInteger id,
+                                                  final Map<HttpRequestParameterName, List<String>> parameters,
+                                                  final HateosHandlerContext<JsonNode> context) {
+                        assertEquals("id", ID, id);
+                        assertEquals("parameters",
+                                Lists.of("value1"),
+                                parameters.get(HttpRequestParameterName.with("param1")));
+
+                        getted.set("123 getted");
+                        return Optional.ofNullable(null != reply ?
+                                JsonNode.parse(reply) : null);
+                    }
+                });
+    }
+
+    // GET COLLECTION WITHOUT ID ................................................................................................
+
+    @Test
+    public void testGetCollectionWithoutIdWithoutHandlersNotFound() {
+        this.routeGetHandleAndCheck((b) -> b.get(this.resourceName1(), this.relation1(), GET_HANDLER),
+                "/api/resource3//xyz",
+                HttpStatusCode.NOT_FOUND,
+                "resource: resource3, link relation: xyz",
+                null);
+    }
+
+    @Test
+    public void testGetCollectionWithoutIdWithRelationSelf() {
+        final Latch getted = Latch.create();
+
+        this.routeGetHandleAndCheck((b) -> this.addGetCollectionHandler(b, ALL, "{}", getted),
+                "/api/resource1//self?param1=value1",
+                HttpStatusCode.OK,
+                "Get collection successful",
+                "{}");
+
+        assertEquals("Getted ", true, getted.value());
+    }
+
+    @Test
+    public void testGetCollectionWithoutIdWithoutRelationDefaultsSelf() {
+        final Latch getted = Latch.create();
+
+        this.routeGetHandleAndCheck((b) -> this.addGetCollectionHandler(b, ALL, "{}", getted),
+                "/api/resource1/?param1=value1",
+                HttpStatusCode.OK,
+                "Get collection successful",
+                "{}");
+
+        assertEquals("Getted ", true, getted.value());
+    }
+
+    @Test
+    public void testGetCollectionWithoutIdIgnoresAlternatives() {
+        final Latch getted = Latch.create();
+
+        this.routeGetHandleAndCheck((b) -> {
+                    this.addGetCollectionHandler(b, ALL, "{}", getted);
+                    b.get(this.resourceName1(), this.relation2(), GET_HANDLER);
+                    b.get(this.resourceName2(), this.relation1(), GET_HANDLER);
+                },
+                "/api/resource1//self?param1=value1",
+                HttpStatusCode.OK,
+                "Get collection successful",
+                "{}");
+
+        assertEquals("Getted ", true, getted.value());
+    }
+
+    // GET COLLECTION WILDCARD ................................................................................................
+
+    @Test
+    public void testGetCollectionWildcardWithoutHandlersNotFound() {
+        this.routeGetHandleAndCheck((b) -> b.get(this.resourceName1(), this.relation1(), GET_HANDLER),
+                "/api/resource3/*/xyz",
+                HttpStatusCode.NOT_FOUND,
+                "resource: resource3, link relation: xyz",
+                null);
+    }
+
+    @Test
+    public void testGetCollectionWildcardWithRelationSelf() {
+        final Latch getted = Latch.create();
+
+        this.routeGetHandleAndCheck((b) -> this.addGetCollectionHandler(b, ALL, "{}", getted),
+                "/api/resource1/*/self?param1=value1",
+                HttpStatusCode.OK,
+                "Get collection successful",
+                "{}");
+
+        assertEquals("Getted ", true, getted.value());
+    }
+
+    @Test
+    public void testGetCollectionWildcardWithoutRelationDefaultsSelf() {
+        final Latch getted = Latch.create();
+
+        this.routeGetHandleAndCheck((b) -> this.addGetCollectionHandler(b, ALL, "{}", getted),
+                "/api/resource1/*?param1=value1",
+                HttpStatusCode.OK,
+                "Get collection successful",
+                "{}");
+
+        assertEquals("Getted ", true, getted.value());
+    }
+
+    @Test
+    public void testGetCollectionWildcardIgnoresAlternatives() {
+        final Latch getted = Latch.create();
+
+        this.routeGetHandleAndCheck((b) -> {
+                    this.addGetCollectionHandler(b, ALL, "{}", getted);
+                    b.get(this.resourceName1(), this.relation2(), GET_HANDLER);
+                    b.get(this.resourceName2(), this.relation1(), GET_HANDLER);
+                },
+                "/api/resource1/*/self?param1=value1",
+                HttpStatusCode.OK,
+                "Get collection successful",
+                "{}");
+
+        assertEquals("Getted ", true, getted.value());
+    }
+
+    // GET COLLECTION RANGE ................................................................................................
+
+    @Test
+    public void testGetCollectionRangeWithoutHandlersNotFound() {
+        this.routeGetHandleAndCheck((b) -> b.get(this.resourceName1(), this.relation1(), GET_HANDLER),
+                "/api/resource3/123-456/xyz",
+                HttpStatusCode.NOT_FOUND,
+                "resource: resource3, link relation: xyz",
+                null);
+    }
+
+    @Test
+    public void testGetCollectionRangeWithRelationSelf() {
+        final Latch getted = Latch.create();
+
+        this.routeGetHandleAndCheck((b) -> this.addGetCollectionHandler(b, RANGE, "{}", getted),
+                "/api/resource1/123-456/self?param1=value1",
+                HttpStatusCode.OK,
+                "Get collection successful",
+                "{}");
+
+        assertEquals("Getted ", true, getted.value());
+    }
+
+    @Test
+    public void testGetCollectionRangeWithoutRelationDefaultsSelf() {
+        final Latch getted = Latch.create();
+
+        this.routeGetHandleAndCheck((b) -> this.addGetCollectionHandler(b, RANGE, "{}", getted),
+                "/api/resource1/123-456?param1=value1",
+                HttpStatusCode.OK,
+                "Get collection successful",
+                "{}");
+
+        assertEquals("Getted ", true, getted.value());
+    }
+
+    @Test
+    public void testGetCollectionRangeIgnoresAlternatives() {
+        final Latch getted = Latch.create();
+
+        this.routeGetHandleAndCheck((b) -> {
+                    this.addGetCollectionHandler(b, RANGE, "{}", getted);
+                    b.get(this.resourceName1(), this.relation2(), GET_HANDLER);
+                    b.get(this.resourceName2(), this.relation1(), GET_HANDLER);
+                },
+                "/api/resource1/123-456/self?param1=value1",
+                HttpStatusCode.OK,
+                "Get collection successful",
+                "{}");
+
+        assertEquals("Getted ", true, getted.value());
+    }
+
+    // GET HELPERS.....................................................................................................
+
+    private void addGetCollectionHandler(final HateosHandlerBuilder<JsonNode> builder,
+                                         final Range<BigInteger> ids,
+                                         final String reply,
+                                         final Latch getted) {
+        builder.get(this.resourceName1(),
+                this.relation1(),
+                new FakeHateosGetHandler<JsonNode>() {
+
+                    @Override
+                    public Optional<JsonNode> getCollection(final Range<BigInteger> i,
+                                                            final Map<HttpRequestParameterName, List<String>> parameters,
+                                                            final HateosHandlerContext<JsonNode> context) {
+                        assertEquals("ids", ids, i);
+                        assertEquals("parameters",
+                                Lists.of("value1"),
+                                parameters.get(HttpRequestParameterName.with("param1")));
+
+                        getted.set("123 getted");
+                        return Optional.ofNullable(null != reply ?
+                                JsonNode.parse(reply) : null);
+                    }
+                });
+    }
+
+    private void routeGetHandleAndCheck(final Consumer<HateosHandlerBuilder<JsonNode>> build,
+                                        final String url,
+                                        final HttpStatusCode status,
+                                        final String statusMessage,
+                                        final String body) {
+        this.routeHandleAndCheck(build,
+                HttpMethod.GET,
+                url,
+                NO_BODY,
+                status.setMessage(statusMessage),
+                this.httpEntity(body));
+    }
+
+    // POST RESOURCE ID................................................................................................
+
+    @Test
+    public void testPostIdWithoutHandlersNotFound() {
+        this.routePostHandleAndCheck((b) -> b.post(this.resourceName1(), this.relation1(), POST_HANDLER),
+                "/api/resource3/123/xyz",
+                HttpStatusCode.NOT_FOUND,
+                "resource: resource3, link relation: xyz",
+                null);
+    }
+
+    @Test
+    public void testPostIdWithRelationSelf() {
+        final Latch posted = Latch.create();
+
+        this.routePostHandleAndCheck((b) -> this.addPostHandler(b, ID, "{}", posted),
+                "/api/resource1/123/self?param1=value1",
+                HttpStatusCode.OK,
+                "Post resource successful",
+                "{}");
+
+        assertEquals("Posted ", true, posted.value());
+    }
+
+    @Test
+    public void testPostIdWithoutRelationDefaultsSelf() {
+        final Latch posted = Latch.create();
+
+        this.routePostHandleAndCheck((b) -> this.addPostHandler(b, ID, "{}", posted),
+                "/api/resource1/123?param1=value1",
+                HttpStatusCode.OK,
+                "Post resource successful",
+                "{}");
+
+        assertEquals("Posted ", true, posted.value());
+    }
+
+    @Test
+    public void testPostIdIgnoresAlternatives() {
+        final Latch posted = Latch.create();
+
+        this.routePostHandleAndCheck((b) -> {
+                    this.addPostHandler(b, ID, "{}", posted);
+                    b.post(this.resourceName1(), this.relation2(), POST_HANDLER);
+                    b.post(this.resourceName2(), this.relation1(), POST_HANDLER);
+                },
+                "/api/resource1/123/self?param1=value1",
+                HttpStatusCode.OK,
+                "Post resource successful",
+                "{}");
+
+        assertEquals("Posted ", true, posted.value());
+    }
+
+    // POST RESOURCE WITHOUT ID................................................................................................
+
+    @Test
+    public void testPostWithoutIdWithoutHandlersNotFound() {
+        this.routePostHandleAndCheck((b) -> b.post(this.resourceName1(), this.relation1(), POST_HANDLER),
+                "/api/resource3//xyz",
+                HttpStatusCode.NOT_FOUND,
+                "resource: resource3, link relation: xyz",
+                null);
+    }
+
+    @Test
+    public void testPostWithoutIdWithRelationSelf() {
+        final Latch posted = Latch.create();
+
+        this.routePostHandleAndCheck((b) -> this.addPostHandler(b, NO_ID, "{}", posted),
+                "/api/resource1//self?param1=value1",
+                HttpStatusCode.OK,
+                "Post resource successful",
+                "{}");
+
+        assertEquals("Posted ", true, posted.value());
+    }
+
+    @Test
+    public void testPostWithoutIdWithoutRelationDefaultsSelf() {
+        final Latch posted = Latch.create();
+
+        this.routePostHandleAndCheck((b) -> this.addPostHandler(b, NO_ID, "{}", posted),
+                "/api/resource1/?param1=value1",
+                HttpStatusCode.OK,
+                "Post resource successful",
+                "{}");
+
+        assertEquals("Posted ", true, posted.value());
+    }
+
+    @Test
+    public void testPostWithoutIdIgnoresAlternatives() {
+        final Latch posted = Latch.create();
+
+        this.routePostHandleAndCheck((b) -> {
+                    this.addPostHandler(b, NO_ID, "{}", posted);
+                    b.post(this.resourceName1(), this.relation2(), POST_HANDLER);
+                    b.post(this.resourceName2(), this.relation1(), POST_HANDLER);
+                },
+                "/api/resource1//self?param1=value1",
+                HttpStatusCode.OK,
+                "Post resource successful",
+                "{}");
+
+        assertEquals("Posted ", true, posted.value());
+    }
+
+    // POST RESOURCE WILDCARD................................................................................................
+
+    @Test
+    public void testPostWildcardFails() {
+        this.routePostHandleAndCheck((b) -> b.post(this.resourceName1(), this.relation1(), POST_HANDLER),
+                "/api/resource1/*/self",
+                HttpStatusCode.BAD_REQUEST,
+                "Collections not supported",
+                null);
+    }
+
+    // POST RESOURCE RANGE................................................................................................
+
+    @Test
+    public void testPostRangeWithoutHandlersBadRequest() {
+        this.routePostHandleAndCheck((b) -> b.post(this.resourceName1(), this.relation1(), POST_HANDLER),
+                "/api/resource3/123-456/xyz",
+                HttpStatusCode.BAD_REQUEST,
+                "Collections not supported",
+                null);
+    }
+
+    private void addPostHandler(final HateosHandlerBuilder<JsonNode> builder,
+                                final BigInteger id,
+                                final String reply,
+                                final Latch posted) {
+        builder.post(this.resourceName1(),
+                this.relation1(),
+                new FakeHateosPostHandler<JsonNode>() {
+
+                    @Override
+                    public JsonNode post(final Optional<BigInteger> i,
+                                         final JsonNode post,
+                                         final HateosHandlerContext<JsonNode> context) {
+                        assertEquals("id", Optional.ofNullable(id), i);
+
+                        posted.set("123 posted");
+                        return null != reply ?
+                                JsonNode.parse(reply) :
+                                null;
+                    }
+                });
+    }
+
+    private void routePostHandleAndCheck(final Consumer<HateosHandlerBuilder<JsonNode>> build,
+                                         final String url,
+                                         final HttpStatusCode status,
+                                         final String statusMessage,
+                                         final String body) {
+        this.routeHandleAndCheck(build,
+                HttpMethod.POST,
+                url,
+                BODY,
+                status.setMessage(statusMessage),
+                this.httpEntity(body));
+    }
+
+    // PUT RESOURCE ID................................................................................................
+
+    @Test
+    public void testPutIdWithoutHandlersNotFound() {
+        this.routePutHandleAndCheck((b) -> b.put(this.resourceName1(), this.relation1(), PUT_HANDLER),
+                "/api/resource3/123/xyz",
+                HttpStatusCode.NOT_FOUND,
+                "resource: resource3, link relation: xyz",
+                null);
+    }
+
+    @Test
+    public void testPutIdWithRelationSelf() {
+        final Latch putted = Latch.create();
+
+        this.routePutHandleAndCheck((b) -> this.addPutHandler(b, ID, "{}", putted),
+                "/api/resource1/123/self?param1=value1",
+                HttpStatusCode.OK,
+                "Put resource successful",
+                "{}");
+
+        assertEquals("Putted ", true, putted.value());
+    }
+
+    @Test
+    public void testPutIdWithoutRelationDefaultsSelf() {
+        final Latch putted = Latch.create();
+
+        this.routePutHandleAndCheck((b) -> this.addPutHandler(b, ID, "{}", putted),
+                "/api/resource1/123?param1=value1",
+                HttpStatusCode.OK,
+                "Put resource successful",
+                "{}");
+
+        assertEquals("Putted ", true, putted.value());
+    }
+
+    @Test
+    public void testPutIdIgnoresAlternatives() {
+        final Latch putted = Latch.create();
+
+        this.routePutHandleAndCheck((b) -> {
+                    this.addPutHandler(b, ID, "{}", putted);
+                    b.put(this.resourceName1(), this.relation2(), PUT_HANDLER);
+                    b.put(this.resourceName2(), this.relation1(), PUT_HANDLER);
+                },
+                "/api/resource1/123/self?param1=value1",
+                HttpStatusCode.OK,
+                "Put resource successful",
+                "{}");
+
+        assertEquals("Putted ", true, putted.value());
+    }
+
+    // PUT RESOURCE WILDCARD................................................................................................
+
+    @Test
+    public void testPutWithoutIdBadRequest() {
+        this.routePutHandleAndCheck((b) -> b.put(this.resourceName1(), this.relation1(), PUT_HANDLER),
+                "/api/resource1//self",
+                HttpStatusCode.BAD_REQUEST,
+                "Id required",
+                null);
+    }
+
+    // PUT RESOURCE WILDCARD................................................................................................
+
+    @Test
+    public void testPutWildcardBadRequest() {
+        this.routePutHandleAndCheck((b) -> b.put(this.resourceName1(), this.relation1(), PUT_HANDLER),
+                "/api/resource1/*/self",
+                HttpStatusCode.BAD_REQUEST,
+                "Collections not supported",
+                null);
+    }
+
+    // PUT RESOURCE RANGE................................................................................................
+
+    @Test
+    public void testPutRangeWithoutHandlersNotFound() {
+        this.routePutHandleAndCheck((b) -> b.put(this.resourceName1(), this.relation1(), PUT_HANDLER),
+                "/api/resource3/123-456/xyz",
+                HttpStatusCode.BAD_REQUEST,
+                "Collections not supported",
+                null);
+    }
+
+    private void addPutHandler(final HateosHandlerBuilder<JsonNode> builder,
+                               final BigInteger id,
+                               final String reply,
+                               final Latch putted) {
+        builder.put(this.resourceName1(),
+                this.relation1(),
+                new FakeHateosPutHandler<JsonNode>() {
+
+                    @Override
+                    public JsonNode put(final BigInteger i,
+                                        final JsonNode put,
+                                        final HateosHandlerContext<JsonNode> context) {
+                        assertEquals("id", id, i);
+
+                        putted.set("123 putted");
+                        return null != reply ?
+                                JsonNode.parse(reply) :
+                                null;
+                    }
+                });
+    }
+
+    private void routePutHandleAndCheck(final Consumer<HateosHandlerBuilder<JsonNode>> build,
+                                        final String url,
+                                        final HttpStatusCode status,
+                                        final String statusMessage,
+                                        final String body) {
+        this.routeHandleAndCheck(build,
+                HttpMethod.PUT,
+                url,
+                BODY,
+                status.setMessage(statusMessage),
+                this.httpEntity(body));
+    }
+
+    // DELETE RESOURCE ................................................................................................
+
+    @Test
+    public void testDeleteIdWithoutHandlersNotFound() {
+        this.routeDeleteHandleAndCheck((b) -> b.delete(this.resourceName1(), this.relation1(), DELETE_HANDLER),
+                "/api/resource3/123/xyz",
+                HttpStatusCode.NOT_FOUND,
+                "resource: resource3, link relation: xyz");
+    }
+
+    @Test
+    public void testDeleteIdWithRelationSelf() {
+        final Latch deleted = Latch.create();
+
+        this.routeDeleteHandleAndCheck((b) -> this.addDeleteHandler(b, deleted),
+                "/api/resource1/123/self",
+                HttpStatusCode.NO_CONTENT,
+                "Delete resource successful");
+
+        assertEquals("Deleted ", true, deleted.value());
+    }
+
+
+    @Test
+    public void testDeleteIdWithoutRelationDefaultsSelf() {
+        final Latch deleted = Latch.create();
+
+        this.routeDeleteHandleAndCheck((b) -> this.addDeleteHandler(b, deleted),
+                "/api/resource1/123",
+                HttpStatusCode.NO_CONTENT,
+                "Delete resource successful");
+
+        assertEquals("Deleted ", true, deleted.value());
+    }
+
+    @Test
+    public void testDeleteIdIgnoresAlternatives() {
+        final Latch deleted = Latch.create();
+
+        this.routeDeleteHandleAndCheck((b) -> {
+                    this.addDeleteHandler(b, deleted);
+                    b.delete(this.resourceName1(), this.relation2(), DELETE_HANDLER);
+                    b.delete(this.resourceName2(), this.relation1(), DELETE_HANDLER);
+                },
+                "/api/resource1/123/self",
+                HttpStatusCode.NO_CONTENT,
+                "Delete resource successful");
+
+        assertEquals("Deleted ", true, deleted.value());
+    }
+
+    private void addDeleteHandler(final HateosHandlerBuilder<JsonNode> builder,
+                                  final Latch deleted) {
+        builder.delete(this.resourceName1(),
+                this.relation1(),
+                new FakeHateosDeleteHandler<JsonNode>() {
+                    @Override
+                    public void delete(final BigInteger id, final HateosHandlerContext<JsonNode> context) {
+                        assertEquals("id", ID, id);
+                        deleted.set("123 deleted");
+                    }
+                });
+    }
+
+    private void routeDeleteHandleAndCheck(final Consumer<HateosHandlerBuilder<JsonNode>> build,
+                                           final String url,
+                                           final HttpStatusCode status,
+                                           final String statusMessage) {
+        this.routeHandleAndCheck(build,
+                HttpMethod.DELETE,
+                url,
+                NO_BODY,
+                status.setMessage(statusMessage));
+    }
+
+    // DeleteCollection WithoutId RESOURCE ................................................................................................
+
+    @Test
+    public void testDeleteCollectionWithoutIdWithoutHandlersNotFound() {
+        this.routeDeleteCollectionHandleAndCheck((b) -> b.delete(this.resourceName1(), this.relation1(), DELETE_HANDLER),
+                "/api/resource3//xyz",
+                HttpStatusCode.NOT_FOUND,
+                "resource: resource3, link relation: xyz");
+    }
+
+    @Test
+    public void testDeleteCollectionWithoutIdWithRelationSelf() {
+        final Latch deleted = Latch.create();
+
+        this.routeDeleteCollectionHandleAndCheck((b) -> this.addDeleteCollectionHandler(b, ALL, deleted),
+                "/api/resource1//self",
+                HttpStatusCode.NO_CONTENT,
+                "Delete collection successful");
+
+        assertEquals("Deleted ", true, deleted.value());
+    }
+
+
+    @Test
+    public void testDeleteCollectionWithoutIdWithoutRelationDefaultsSelf() {
+        final Latch deleted = Latch.create();
+
+        this.routeDeleteCollectionHandleAndCheck((b) -> this.addDeleteCollectionHandler(b, ALL, deleted),
+                "/api/resource1/",
+                HttpStatusCode.NO_CONTENT,
+                "Delete collection successful");
+
+        assertEquals("Deleted ", true, deleted.value());
+    }
+
+    @Test
+    public void testDeleteCollectionWithoutIdIgnoresAlternatives() {
+        final Latch deleted = Latch.create();
+
+        this.routeDeleteCollectionHandleAndCheck((b) -> {
+                    this.addDeleteCollectionHandler(b, ALL, deleted);
+                    b.delete(this.resourceName1(), this.relation2(), DELETE_HANDLER);
+                    b.delete(this.resourceName2(), this.relation1(), DELETE_HANDLER);
+                },
+                "/api/resource1//self",
+                HttpStatusCode.NO_CONTENT,
+                "Delete collection successful");
+
+        assertEquals("Deleted ", true, deleted.value());
+    }
+
+    // DeleteCollectionWildcard RESOURCE ................................................................................................
+
+    @Test
+    public void testDeleteCollectionWildcardWithoutHandlersNotFound() {
+        this.routeDeleteCollectionHandleAndCheck((b) -> b.delete(this.resourceName1(), this.relation1(), DELETE_HANDLER),
+                "/api/resource3/*/xyz",
+                HttpStatusCode.NOT_FOUND,
+                "resource: resource3, link relation: xyz");
+    }
+
+    @Test
+    public void testDeleteCollectionWildcardWithRelationSelf() {
+        final Latch deleted = Latch.create();
+
+        this.routeDeleteCollectionHandleAndCheck((b) -> this.addDeleteCollectionHandler(b, ALL, deleted),
+                "/api/resource1/*/self",
+                HttpStatusCode.NO_CONTENT,
+                "Delete collection successful");
+
+        assertEquals("Deleted ", true, deleted.value());
+    }
+
+
+    @Test
+    public void testDeleteCollectionWildcardWithoutRelationDefaultsSelf() {
+        final Latch deleted = Latch.create();
+
+        this.routeDeleteCollectionHandleAndCheck((b) -> this.addDeleteCollectionHandler(b, ALL, deleted),
+                "/api/resource1/*",
+                HttpStatusCode.NO_CONTENT,
+                "Delete collection successful");
+
+        assertEquals("Deleted ", true, deleted.value());
+    }
+
+    @Test
+    public void testDeleteCollectionWildcardIgnoresAlternatives() {
+        final Latch deleted = Latch.create();
+
+        this.routeDeleteCollectionHandleAndCheck((b) -> {
+                    this.addDeleteCollectionHandler(b, ALL, deleted);
+                    b.delete(this.resourceName1(), this.relation2(), DELETE_HANDLER);
+                    b.delete(this.resourceName2(), this.relation1(), DELETE_HANDLER);
+                },
+                "/api/resource1/*/self",
+                HttpStatusCode.NO_CONTENT,
+                "Delete collection successful");
+
+        assertEquals("Deleted ", true, deleted.value());
+    }
+
+    // DeleteCollection Range  ................................................................................................
+
+    @Test
+    public void testDeleteCollectionRangeWithoutHandlersNotFound() {
+        this.routeDeleteCollectionHandleAndCheck(
+                (b) -> b.delete(this.resourceName1(), this.relation1(), DELETE_HANDLER),
+                "/api/resource3/123-456/xyz",
+                HttpStatusCode.NOT_FOUND,
+                "resource: resource3, link relation: xyz");
+    }
+
+    @Test
+    public void testDeleteCollectionRangeWithRelationSelf() {
+        final Latch deleted = Latch.create();
+
+        this.routeDeleteCollectionHandleAndCheck(
+                (b) -> this.addDeleteCollectionHandler(b, RANGE, deleted),
+                "/api/resource1/123-456/self",
+                HttpStatusCode.NO_CONTENT,
+                "Delete collection successful");
+
+        assertEquals("Deleted ", true, deleted.value());
+    }
+
+
+    @Test
+    public void testDeleteCollectionRangeWithoutRelationDefaultsSelf() {
+        final Latch deleted = Latch.create();
+
+        this.routeDeleteCollectionHandleAndCheck(
+                (b) -> this.addDeleteCollectionHandler(b, RANGE, deleted),
+                "/api/resource1/123-456",
+                HttpStatusCode.NO_CONTENT,
+                "Delete collection successful");
+
+        assertEquals("Deleted ", true, deleted.value());
+    }
+
+    @Test
+    public void testDeleteCollectionRangeIgnoresAlternatives() {
+        final Latch deleted = Latch.create();
+
+        this.routeDeleteCollectionHandleAndCheck((b) -> {
+                    this.addDeleteCollectionHandler(b, RANGE, deleted);
+                    b.delete(this.resourceName1(), this.relation2(), DELETE_HANDLER);
+                    b.delete(this.resourceName2(), this.relation1(), DELETE_HANDLER);
+                },
+                "/api/resource1/123-456/self",
+                HttpStatusCode.NO_CONTENT,
+                "Delete collection successful");
+
+        assertEquals("Deleted ", true, deleted.value());
+    }
+
+    // DELETE HELPERS.....................................................................................................
+
+    private void addDeleteCollectionHandler(final HateosHandlerBuilder<JsonNode> builder,
+                                            final Range<BigInteger> range,
+                                            final Latch deleted) {
+        builder.delete(this.resourceName1(),
+                this.relation1(),
+                new FakeHateosDeleteHandler<JsonNode>() {
+                    @Override
+                    public void deleteCollection(final Range<BigInteger> r, final HateosHandlerContext<JsonNode> context) {
+                        assertEquals("range", range, r);
+                        deleted.set("123-456 deleted");
+                    }
+                });
+    }
+
+    private void routeDeleteCollectionHandleAndCheck(final Consumer<HateosHandlerBuilder<JsonNode>> build,
+                                                     final String url,
+                                                     final HttpStatusCode status,
+                                                     final String statusMessage) {
+        this.routeHandleAndCheck(build,
+                HttpMethod.DELETE,
+                url,
+                NO_BODY,
+                status.setMessage(statusMessage));
+    }
+
+    // HELPERS ............................................................................................
+
+    @Override
+    protected HateosHandlerBuilderRouter<JsonNode> createRouter() {
+        final HateosHandlerBuilder<JsonNode> builder = this.builder();
+        builder.get(this.resourceName1(), this.relation1(), new FakeHateosGetHandler<>());
+        return Cast.to(builder.build()); // builder returns interface which is HHBR class.
+    }
+
+    private HateosHandlerBuilder<JsonNode> builder() {
+        return HateosHandlerBuilder.with(
+                Url.parseAbsolute("http://www.example.com/api"),
+                HateosContentType.JSON);
+    }
+
+    private HateosResourceName resourceName1() {
+        return HateosResourceName.with("resource1");
+    }
+
+    private HateosResourceName resourceName2() {
+        return HateosResourceName.with("resource2");
+    }
+
+    private LinkRelation<?> relation1() {
+        return LinkRelation.SELF;
+    }
+
+    private LinkRelation<?> relation2() {
+        return LinkRelation.NEXT;
+    }
+
+    private HttpEntity[] httpEntity(final String body) {
+        HttpEntity[] entities = new HttpEntity[0];
+
+        if (null != body) {
+            final CharsetName charsetName = CharsetName.UTF_8;
+            final byte[] bytes = body.getBytes(charsetName.charset().get());
+
+            final Map<HttpHeaderName<?>, Object> headers = Maps.sorted();
+            headers.put(HttpHeaderName.CONTENT_TYPE, HateosContentType.JSON.contentType().setCharset(charsetName));
+            headers.put(HttpHeaderName.CONTENT_LENGTH, Long.valueOf(body.length()));
+            entities = new HttpEntity[]{HttpEntity.with(headers, bytes)};
+        }
+        return entities;
+    }
+
+    private void routeHandleAndCheck(final Consumer<HateosHandlerBuilder<JsonNode>> build,
+                                     final HttpMethod method,
+                                     final String url,
+                                     final byte[] body,
+                                     final HttpStatus status,
+                                     final HttpEntity... entities) {
+        assertTrue(url + " must start with /api", url.startsWith("/api"));
+
+        final HateosHandlerBuilder<JsonNode> builder = this.builder();
+        build.accept(builder);
+
+        this.routeHandleAndCheck(builder, method, url, body, status, entities);
+    }
+
+    private void routeHandleAndCheck(final HateosHandlerBuilder<JsonNode> builder,
+                                     final HttpMethod method,
+                                     final String url,
+                                     final byte[] body,
+                                     final HttpStatus status,
+                                     final HttpEntity... entities) {
+        assertTrue(url + " must start with /api", url.startsWith("/api"));
+
+        final TestRecordingHttpResponse response = HttpResponses.testRecording();
+
+        final HttpRequest request = this.request(method, url, body);
+        Optional<BiConsumer<HttpRequest, HttpResponse>> handle = builder.build()
+                .route(request.routingParameters());
+        if (handle.isPresent()) {
+            handle.get().accept(request, response);
+        }
+        response.check(request, status, entities);
+    }
+
+
+    private HttpRequest request(final HttpMethod method,
+                                final String url,
+                                final byte[] body) {
+        return new HttpRequest() {
+
+            @Override
+            public HttpTransport transport() {
+                return HttpTransport.UNSECURED;
+            }
+
+            @Override
+            public HttpProtocolVersion protocolVersion() {
+                return HttpProtocolVersion.VERSION_1_0;
+            }
+
+            @Override
+            public HttpMethod method() {
+                return method;
+            }
+
+            @Override
+            public RelativeUrl url() {
+                return RelativeUrl.parse(url);
+            }
+
+            @Override
+            public Map<HttpHeaderName<?>, Object> headers() {
+                return Maps.one(HttpHeaderName.ACCEPT_CHARSET, AcceptCharset.parse("utf8;"));
+            }
+
+            @Override
+            public byte[] body() {
+                return body.clone();
+            }
+
+            @Override
+            public Map<HttpRequestParameterName, List<String>> parameters() {
+                final Map<HttpRequestParameterName, List<String>> parameters = Maps.sorted();
+
+                this.url()
+                        .query()
+                        .parameters()
+                        .entrySet()
+                        .forEach(e -> parameters.put(HttpRequestParameterName.with(e.getKey().value()), e.getValue()));
+
+                return parameters;
+            }
+
+            @Override
+            public List<String> parameterValues(final HttpRequestParameterName parameterName) {
+                final List<String> values = this.parameters().get(parameterName);
+                return null == values ?
+                        Lists.empty() :
+                        values;
+            }
+
+            @Override
+            public String toString() {
+                return this.method() + " " + this.url() + " " + parameters();
+            }
+        };
+    }
+
+    @Override
+    protected Class<HateosHandlerBuilderRouter<JsonNode>> type() {
+        return Cast.to(HateosHandlerBuilderRouter.class);
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosHandlerBuilderTest.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import org.junit.Test;
+import walkingkooka.Cast;
+import walkingkooka.build.BuilderTestCase;
+import walkingkooka.net.AbsoluteUrl;
+import walkingkooka.net.header.LinkRelation;
+import walkingkooka.net.http.server.HttpRequest;
+import walkingkooka.net.http.server.HttpRequestAttribute;
+import walkingkooka.net.http.server.HttpResponse;
+import walkingkooka.routing.Router;
+import walkingkooka.tree.json.JsonNode;
+
+import java.util.function.BiConsumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public final class HateosHandlerBuilderTest extends BuilderTestCase<HateosHandlerBuilder<JsonNode>,
+        Router<HttpRequestAttribute<?>, BiConsumer<HttpRequest, HttpResponse>>> {
+
+    // creation ..........................................................................................
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullFails() {
+        this.createBuilder(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWithQueryStringFails() {
+        this.createBuilder("http://example/api?param1=value1");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWithFragmentFails() {
+        this.createBuilder("http://example/api#fragment-1");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testWithNullContentTypeFails() {
+        this.createBuilder("http://example/api", null);
+    }
+
+    // get ..........................................................................................
+
+    @Test(expected = NullPointerException.class)
+    public void testGetNullResourceNameFails() {
+        this.createBuilder().get(null, LinkRelation.SELF, this.getHandler());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetNullRelationFails() {
+        this.createBuilder().get(this.resourceName1(), null, this.getHandler());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetNullHandlerFails() {
+        this.createBuilder().get(this.resourceName1(), LinkRelation.SELF, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetDuplicateResourceAndRelationFails() {
+        final HateosResourceName resourceName = this.resourceName1();
+        final LinkRelation<?> relation = LinkRelation.SELF;
+
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        builder.get(resourceName, relation, this.getHandler());
+        builder.get(resourceName, relation, this.getHandler());
+    }
+
+    @Test
+    public void testGetRepeatedResourceAndRelationFails() {
+        final HateosResourceName resourceName = this.resourceName1();
+        final LinkRelation<?> relation = LinkRelation.SELF;
+        final HateosGetHandler<JsonNode> handler = this.getHandler();
+
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        builder.get(resourceName, relation, handler);
+        builder.get(resourceName, relation, handler);
+    }
+
+    @Test
+    public void testGet() {
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        final LinkRelation<?> relation = LinkRelation.SELF;
+        assertSame(builder, builder.get(this.resourceName1(), relation, this.getHandler()));
+        assertSame(builder, builder.get(this.resourceName2(), relation, this.getHandler()));
+        assertSame(builder, builder.get(this.resourceName1(), LinkRelation.ITEM, this.getHandler()));
+    }
+
+    private HateosGetHandler<JsonNode> getHandler() {
+        return new FakeHateosGetHandler<JsonNode>() {
+            @Override
+            public String toString() {
+                return "get123";
+            }
+        };
+    }
+
+    // post ..........................................................................................
+
+    @Test(expected = NullPointerException.class)
+    public void testPostNullResourceNameFails() {
+        this.createBuilder().post(null, LinkRelation.SELF, this.postHandler());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testPostNullRelationFails() {
+        this.createBuilder().post(this.resourceName1(), null, this.postHandler());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testPostNullHandlerFails() {
+        this.createBuilder().post(this.resourceName1(), LinkRelation.SELF, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPostDuplicateResourceAndRelationFails() {
+        final HateosResourceName resourceName = this.resourceName1();
+        final LinkRelation<?> relation = LinkRelation.SELF;
+
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        builder.post(resourceName, relation, this.postHandler());
+        builder.post(resourceName, relation, this.postHandler());
+    }
+
+    @Test
+    public void testPostRepeatedResourceAndRelationFails() {
+        final HateosResourceName resourceName = this.resourceName1();
+        final LinkRelation<?> relation = LinkRelation.SELF;
+        final HateosPostHandler<JsonNode> handler = this.postHandler();
+
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        builder.post(resourceName, relation, handler);
+        builder.post(resourceName, relation, handler);
+    }
+
+    @Test
+    public void testPost() {
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        final LinkRelation<?> relation = LinkRelation.SELF;
+        assertSame(builder, builder.post(this.resourceName1(), relation, this.postHandler()));
+        assertSame(builder, builder.post(this.resourceName2(), relation, this.postHandler()));
+        assertSame(builder, builder.post(this.resourceName1(), LinkRelation.ITEM, this.postHandler()));
+    }
+
+    private HateosPostHandler<JsonNode> postHandler() {
+        return new FakeHateosPostHandler<JsonNode>() {
+            @Override
+            public String toString() {
+                return "post234";
+            }
+        };
+    }
+
+    // put ..........................................................................................
+
+    @Test(expected = NullPointerException.class)
+    public void testPutNullResourceNameFails() {
+        this.createBuilder().put(null, LinkRelation.SELF, this.putHandler());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testPutNullRelationFails() {
+        this.createBuilder().put(this.resourceName1(), null, this.putHandler());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testPutNullHandlerFails() {
+        this.createBuilder().put(this.resourceName1(), LinkRelation.SELF, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPutDuplicateResourceAndRelationFails() {
+        final HateosResourceName resourceName = this.resourceName1();
+        final LinkRelation<?> relation = LinkRelation.SELF;
+
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        builder.put(resourceName, relation, this.putHandler());
+        builder.put(resourceName, relation, this.putHandler());
+    }
+
+    @Test
+    public void testPutRepeatedResourceAndRelationFails() {
+        final HateosResourceName resourceName = this.resourceName1();
+        final LinkRelation<?> relation = LinkRelation.SELF;
+        final HateosPutHandler<JsonNode> handler = this.putHandler();
+
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        builder.put(resourceName, relation, handler);
+        builder.put(resourceName, relation, handler);
+    }
+
+    @Test
+    public void testPut() {
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        final LinkRelation<?> relation = LinkRelation.SELF;
+        assertSame(builder, builder.put(this.resourceName1(), relation, this.putHandler()));
+        assertSame(builder, builder.put(this.resourceName2(), relation, this.putHandler()));
+        assertSame(builder, builder.put(this.resourceName1(), LinkRelation.ITEM, this.putHandler()));
+    }
+
+    private HateosPutHandler<JsonNode> putHandler() {
+        return new FakeHateosPutHandler<JsonNode>() {
+            @Override
+            public String toString() {
+                return "put345";
+            }
+        };
+    }
+    // delete ..........................................................................................
+
+    @Test(expected = NullPointerException.class)
+    public void testDeleteNullResourceNameFails() {
+        this.createBuilder().delete(null, LinkRelation.SELF, this.deleteHandler());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testDeleteNullRelationFails() {
+        this.createBuilder().delete(this.resourceName1(), null, this.deleteHandler());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testDeleteNullHandlerFails() {
+        this.createBuilder().delete(this.resourceName1(), LinkRelation.SELF, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteDuplicateResourceAndRelationFails() {
+        final HateosResourceName resourceName = this.resourceName1();
+        final LinkRelation<?> relation = LinkRelation.SELF;
+
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        builder.delete(resourceName, relation, this.deleteHandler());
+        builder.delete(resourceName, relation, this.deleteHandler());
+    }
+
+    @Test
+    public void testDeleteRepeatedResourceAndRelationFails() {
+        final HateosResourceName resourceName = this.resourceName1();
+        final LinkRelation<?> relation = LinkRelation.SELF;
+        final HateosDeleteHandler<JsonNode> handler = this.deleteHandler();
+
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        builder.delete(resourceName, relation, handler);
+        builder.delete(resourceName, relation, handler);
+    }
+
+    @Test
+    public void testDelete() {
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        final LinkRelation<?> relation = LinkRelation.SELF;
+        assertSame(builder, builder.delete(this.resourceName1(), relation, this.deleteHandler()));
+        assertSame(builder, builder.delete(this.resourceName2(), relation, this.deleteHandler()));
+        assertSame(builder, builder.delete(this.resourceName1(), LinkRelation.ITEM, this.deleteHandler()));
+    }
+
+    private HateosDeleteHandler<JsonNode> deleteHandler() {
+        return new FakeHateosDeleteHandler<JsonNode>() {
+            @Override
+            public String toString() {
+                return "delete456";
+            }
+        };
+    }
+
+    // toString....................................................................................................
+
+    @Test
+    public void testToString() {
+        final HateosHandlerBuilder<JsonNode> builder = this.createBuilder();
+        builder.get(this.resourceName1(), LinkRelation.SELF, this.getHandler());
+        builder.post(this.resourceName1(), LinkRelation.SELF, this.postHandler());
+        builder.put(this.resourceName1(), LinkRelation.SELF, this.putHandler());
+        builder.delete(this.resourceName1(), LinkRelation.SELF, this.deleteHandler());
+        assertEquals("http://example.com/api JSON {resource1 self=GET=get123 POST=post234 PUT=put345 DELETE=delete456}",
+                builder.toString());
+    }
+
+    // helpers ..........................................................................................
+
+    private HateosResourceName resourceName1() {
+        return HateosResourceName.with("resource1");
+    }
+
+    private HateosResourceName resourceName2() {
+        return HateosResourceName.with("resource2");
+    }
+
+    // helpers ..........................................................................................
+
+    @Override
+    protected HateosHandlerBuilder<JsonNode> createBuilder() {
+        return this.createBuilder("http://example.com/api");
+    }
+
+    private HateosHandlerBuilder<JsonNode> createBuilder(final String url) {
+        return this.createBuilder(url, this.contentType());
+    }
+
+    private HateosHandlerBuilder<JsonNode> createBuilder(final String url, final HateosContentType<JsonNode> contentType) {
+        return HateosHandlerBuilder.with(AbsoluteUrl.parse(url), contentType);
+    }
+
+    private HateosContentType<JsonNode> contentType() {
+        return HateosContentType.JSON;
+    }
+
+    @Override
+    protected Class<HateosHandlerBuilder> type() {
+        return Cast.to(HateosHandlerBuilder.class);
+    }
+
+    @Override
+    protected Class<Router<HttpRequestAttribute<?>, BiConsumer<HttpRequest, HttpResponse>>> builderProductType() {
+        return Cast.to(Router.class);
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceNameTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceNameTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.net.http.server.hateos;
+
+import walkingkooka.naming.NameTestCase;
+import walkingkooka.text.CaseSensitivity;
+
+public final class HateosResourceNameTest extends NameTestCase<HateosResourceName, HateosResourceName> {
+
+    @Override
+    protected HateosResourceName createName(final String name) {
+        return HateosResourceName.with(name);
+    }
+
+    @Override
+    protected CaseSensitivity caseSensitivity() {
+        return CaseSensitivity.SENSITIVE;
+    }
+
+    @Override
+    protected String nameText() {
+        return "australia";
+    }
+
+    @Override
+    protected String differentNameText() {
+        return "different";
+    }
+
+    @Override
+    protected String nameTextLess() {
+        return "albania";
+    }
+
+    @Override
+    protected Class<HateosResourceName> type() {
+        return HateosResourceName.class;
+    }
+}


### PR DESCRIPTION
- Multiple handler interfaces, one each for GET, POST, PUT, DELETE.
- HateosHandlerContext provides support for adding links by name for nodes.
- Support for JSON and XML.
- test cases for each handler.