### PR TITLE
HasJsonNodeTesting.assertEquals order fix.

### DIFF
--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeTesting.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeTesting.java
@@ -28,7 +28,7 @@ public interface HasJsonNodeTesting<H extends HasJsonNode> {
 
     default void toJsonNodeAndCheck(final HasJsonNode has, final JsonNode json) {
         assertEquals("toJsonNode doesnt match=" + has,
-                has.toJsonNode(),
-                json);
+                json,
+                has.toJsonNode());
     }
 }


### PR DESCRIPTION
- previously expected was rhs, corrected now lhs.