### PR TITLE
NameTesting2 additional name tests.

### DIFF
--- a/src/main/java/walkingkooka/naming/NameTesting2.java
+++ b/src/main/java/walkingkooka/naming/NameTesting2.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.naming;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.InvalidCharacterException;
+import walkingkooka.test.HashCodeEqualsDefined;
+import walkingkooka.text.CharSequences;
+import walkingkooka.type.MemberVisibility;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Base class for testing a {@link Name} with mostly helpers to assert construction failure.
+ */
+public interface NameTesting2<N extends Name, C extends Comparable<C> & HashCodeEqualsDefined> extends NameTesting<N, C>{
+
+    /**
+     * All upper case ascii letters
+     */
+    final static String ASCII_UPPERCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    /**
+     * All lower case ascii letters
+     */
+    final static String ASCII_LOWERCASE = "abcdefghijklmnopqrstuvwxyz";
+
+    /**
+     * All ascii letters
+     */
+    final static String ASCII_LETTERS = ASCII_UPPERCASE + ASCII_LOWERCASE;
+
+    /**
+     * The digits 0 .. 9
+     */
+    final static String ASCII_DIGITS = "09123456789";
+
+    /**
+     * All ascii letters and digits
+     */
+    final static String ASCII_LETTERS_DIGITS = ASCII_LETTERS + ASCII_DIGITS;
+
+    /**
+     * Space or tab
+     */
+    final static String SPACE_HTAB = " \t";
+
+    /**
+     * Space, tab, CR and NL.
+     */
+    final static String WHITESPACE = SPACE_HTAB + "\r\n";
+
+    /**
+     * All ascii characters
+     */
+    final static String ASCII = IntStream.rangeClosed(0, 127)
+            .mapToObj(c -> String.valueOf((char)c))
+            .collect(Collectors.joining(""));
+
+    /**
+     * All control characters between 0 and 31 including tab, CR and NL.
+     */
+    final static String CONTROL = IntStream.rangeClosed(0, 31)
+            .mapToObj(i -> String.valueOf((char)i))
+            .collect(Collectors.joining(""));
+
+
+    /**
+     * All ascii characters from space (32) to 127.
+     */
+    final static String ASCII_NON_CONTROL = IntStream.rangeClosed(32, 127)
+            .mapToObj(i -> String.valueOf((char)i))
+            .collect(Collectors.joining(""));
+
+    /**
+     * <a href="https://tools.ietf.org/html/rfc2045#page-5"></a>
+     * <pre>
+     * token := 1*<any (US-ASCII) CHAR except SPACE, CTLs,
+     *                  or tspecials>
+     *
+     *      tspecials :=  "(" / ")" / "<" / ">" / "@" /
+     *                    "," / ";" / ":" / "\" / <">
+     *                    "/" / "[" / "]" / "?" / "="
+     *                    ; Must be in quoted-string,
+     *                    ; to use within parameter values
+     * </pre>
+     */
+    final static String RFC2045_TSPECIAL = "()<>@,;:\\\"/[]?=";
+
+    /**
+     * <a href="https://tools.ietf.org/html/rfc2045#page-5"></a>
+     * <pre>
+     * token := 1*<any (US-ASCII) CHAR except SPACE, CTLs,
+     *                  or tspecials>
+     *
+     *      tspecials :=  "(" / ")" / "<" / ">" / "@" /
+     *                    "," / ";" / ":" / "\" / <">
+     *                    "/" / "[" / "]" / "?" / "="
+     *                    ; Must be in quoted-string,
+     *                    ; to use within parameter values
+     * </pre>
+     */
+    final static String RFC2045 = subtract(ASCII,
+            CONTROL + WHITESPACE + RFC2045_TSPECIAL);
+
+    /**
+     * All characters above 127 and 255.
+     */
+    final static String BYTE_NON_ASCII = IntStream.rangeClosed(128, 255)
+            .mapToObj(i -> String.valueOf((char)i))
+            .collect(Collectors.joining(""));
+
+    /**
+     * Subtracts all subtract characters from text.
+     */
+    static String subtract(final String text,
+                           final String subtract) {
+        final StringBuilder b = new StringBuilder();
+        b.append(text);
+
+        for(char c : subtract.toCharArray()) {
+            final int i = b.indexOf(String.valueOf(c));
+            if(-1 != i) {
+                b.deleteCharAt(i);
+            }
+        }
+
+        return b.toString();
+    }
+
+    @Test
+    default void testNaming() {
+        this.checkNaming(Name.class);
+    }
+
+    void checkNaming(Class<?>... name);
+
+    @Test
+    default void testPublicClass() {
+        assertEquals(MemberVisibility.PUBLIC, this.typeVisibility(), "Visibility of name");
+    }
+
+    @Test
+    default void testNullFails() {
+        assertThrows(NullPointerException.class, () -> {
+            this.createName(null);
+        });
+    }
+
+    @Test
+    default void testEmptyFails() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            this.createName("");
+        });
+    }
+
+    @Test
+    default void testWith() {
+        this.createNameAndCheck(this.nameText());
+    }
+
+    // invalid / valid characters.........................................................................
+
+    @Test
+    default void testNameInvalidCharFails() {
+        final int min = this.minLength();
+        final int max = Math.min(this.maxLength(), 99);
+
+        for (int i = min; i <= max; i++) {
+            final char[] chars = new char[i];
+
+            // fill with valid characters except for last with invalid.
+            final int last = i -1;
+            for(int j = 0; j < last; j++){
+                final String s = this.possibleValidChars(j);
+                chars[j] = this.possibleValidChars(j)
+                        .charAt(0);
+            }
+
+            final String invalid = this.possibleInvalidChars(last);
+            for(char c : invalid.toCharArray()) {
+                chars[last] = c;
+                final String text = new String(chars);
+
+                final InvalidCharacterException expected = assertThrows(InvalidCharacterException.class, () -> {
+                    this.createName(text);
+                });
+                assertEquals(last,
+                        expected.position(),
+                        () -> "Incorrect position reported " + CharSequences.quoteAndEscape(text));
+            }
+        }
+    }
+
+    /**
+     * Try all combinations of valid characters in all positions between min and max lengths.
+     */
+    @Test
+    default void testNameValidChars() {
+        final int min = this.minLength();
+        final int max = Math.min(this.maxLength(), 99);
+
+        final int longest = IntStream.rangeClosed(0, max)
+                .map(i -> this.possibleValidChars(i).length())
+                .max()
+                .getAsInt();
+
+        for (int i = min; i <= max; i++) {
+            final char[] chars = new char[i];
+
+            for(int j = 0; j < longest; j++) {
+
+                for(int k = 0; k < i; k++){
+                    final String possible = this.possibleValidChars(k);
+                    chars[k] = possible.charAt(j % (possible.length() -1));
+                }
+                this.createName(new String(chars));
+            }
+        }
+    }
+
+    @Test
+    default void testNameMaxLength() {
+        final int max = this.maxLength();
+        if (max != Integer.MAX_VALUE) {
+            final String chars = IntStream.rangeClosed(0, max + 1)
+                    .mapToObj(i -> String.valueOf(this.possibleValidChars(i).charAt(0)))
+                    .collect(Collectors.joining(""));
+            assertThrows(IllegalArgumentException.class, () -> {
+                this.createName(chars);
+            });
+        }
+    }
+
+    /**
+     * A positive value at least equal or greater than 1.
+     */
+    int minLength();
+
+    /**
+     * Returns the max length or {@link Integer#MAX_VALUE} if one does not exist.
+     */
+    int maxLength();
+
+    String possibleValidChars(final int position);
+
+    String possibleInvalidChars(final int position);
+}

--- a/src/main/java/walkingkooka/net/UrlPathName.java
+++ b/src/main/java/walkingkooka/net/UrlPathName.java
@@ -51,12 +51,9 @@ public final class UrlPathName extends NetName implements Comparable<UrlPathName
                 with0(name);
     }
 
+
     private static UrlPathName with0(final String name) {
-        final char separator = UrlPath.SEPARATOR.character();
-        final int index = name.indexOf(separator);
-        if(-1 != index) {
-            throw new IllegalArgumentException("Name contains path separator char \'" + separator + "\'=" + name);
-        }
+        CharSequences.failIfNullOrEmpty(name, "name");
 
         final int length = name.length();
         if(length > MAXIMUM_LENGTH) {

--- a/src/main/java/walkingkooka/net/header/CookieName.java
+++ b/src/main/java/walkingkooka/net/header/CookieName.java
@@ -39,8 +39,8 @@ final public class CookieName extends HeaderNameValue
      * It also must not contain a separator character like the following: ( ) < > @ , ; : \ " /  [ ] ? = { }.
      */
     private final static CharPredicate PREDICATE = CharPredicates.builder()//
-            .or(CharPredicates.ascii())//
-            .andNot(CharPredicates.any("()<>@,;:\\\"/[]?={})"))
+            .or(CharPredicates.asciiPrintable())//
+            .andNot(CharPredicates.rfc2045TokenSpecial())
             .toString("cookie name")//
             .build();
 

--- a/src/main/java/walkingkooka/net/header/HeaderNameTestCase.java
+++ b/src/main/java/walkingkooka/net/header/HeaderNameTestCase.java
@@ -19,7 +19,7 @@
 package walkingkooka.net.header;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.test.HashCodeEqualsDefined;
 import walkingkooka.text.CharSequences;
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class HeaderNameTestCase<N extends HeaderName<?>, C extends Comparable<C> & HashCodeEqualsDefined>
         extends ClassTestCase<N>
-        implements NameTesting<N, C> {
+        implements NameTesting2<N, C> {
 
     // parameterValue...........................................................................................
 

--- a/src/main/java/walkingkooka/net/header/LanguageTagName.java
+++ b/src/main/java/walkingkooka/net/header/LanguageTagName.java
@@ -18,8 +18,9 @@
 
 package walkingkooka.net.header;
 
+import walkingkooka.predicate.character.CharPredicate;
+import walkingkooka.predicate.character.CharPredicates;
 import walkingkooka.text.CaseSensitivity;
-import walkingkooka.text.CharSequences;
 
 import java.util.Locale;
 import java.util.Map;
@@ -44,12 +45,14 @@ public abstract class LanguageTagName extends HeaderNameValue implements Compara
      * Factory that creates a new {@link LanguageTagName}
      */
     public static LanguageTagName with(final String value) {
-        CharSequences.failIfNullOrEmpty(value, "value");
+        CharPredicates.failIfNullOrEmptyOrFalse(value, "value", PREDICATE);
 
         return HeaderValue.WILDCARD.string().equals(value) ?
                 WILDCARD :
                 LanguageTagNameNonWildcard.nonWildcard(value);
     }
+
+    private final static CharPredicate PREDICATE = CharPredicates.asciiPrintable();
 
     /**
      * Package private to limit sub classing.

--- a/src/main/java/walkingkooka/net/header/LanguageTagNameNonWildcard.java
+++ b/src/main/java/walkingkooka/net/header/LanguageTagNameNonWildcard.java
@@ -19,6 +19,8 @@
 package walkingkooka.net.header;
 
 import walkingkooka.collect.map.Maps;
+import walkingkooka.predicate.character.CharPredicate;
+import walkingkooka.predicate.character.CharPredicates;
 import walkingkooka.text.CharSequences;
 
 import java.util.Locale;
@@ -54,16 +56,25 @@ final class LanguageTagNameNonWildcard extends LanguageTagName {
         final LanguageTagNameNonWildcard constant = CONSTANTS.get(value);
         return null != constant ?
                 constant :
-                new LanguageTagNameNonWildcard(value, Optional.of(locale(value)));
+                nonWildcard0(value);
     }
 
-    private static Locale locale(final String value) {
+    /**
+     * Only allow printable ascii language tag names.
+     */
+    private static LanguageTagNameNonWildcard nonWildcard0(final String value) {
+        CharPredicates.failIfNullOrEmptyOrFalse(value, "language tag", PREDICATE);
+
         final Locale locale = Locale.forLanguageTag(value);
         if (locale.toString().isEmpty()) {
             throw new IllegalArgumentException("Invalid language tag " + CharSequences.quoteAndEscape(value));
         }
-        return locale;
+        return new LanguageTagNameNonWildcard(value, Optional.of(locale));
     }
+
+    private final static CharPredicate PREDICATE = CharPredicates.range('A', 'Z')
+            .or(CharPredicates.range('a', 'z'))
+            .or(CharPredicates.is('_'));
 
     /**
      * Private ctor use factory

--- a/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceName.java
+++ b/src/main/java/walkingkooka/net/http/server/hateos/HateosResourceName.java
@@ -37,9 +37,9 @@ public final class HateosResourceName implements Name, Comparable<HateosResource
         return new HateosResourceName(name);
     }
 
-    private final static CharPredicate INITIAL = Character::isJavaIdentifierStart;
+    private final static CharPredicate INITIAL = CharPredicates.letter();
 
-    private final static CharPredicate PART = Character::isJavaIdentifierPart;
+    private final static CharPredicate PART = CharPredicates.letterOrDigit().or(CharPredicates.any("-"));
 
     /**
      * Private constructor

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierName.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierName.java
@@ -51,9 +51,9 @@ final public class EbnfIdentifierName implements Name,
      * </pre>
      */
     final static CharPredicate PART = CharPredicateBuilder.empty()
+            .or(INITIAL)
             .any("0123456789")
             .any("_")
-            .or(INITIAL)
             .build();
 
     /**

--- a/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLabelName.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetLabelName.java
@@ -20,14 +20,10 @@ package walkingkooka.text.cursor.parser.spreadsheet;
 
 import walkingkooka.Cast;
 import walkingkooka.naming.Name;
-import walkingkooka.predicate.Predicates;
 import walkingkooka.predicate.character.CharPredicate;
 import walkingkooka.predicate.character.CharPredicates;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.CharSequences;
-
-import java.util.Objects;
-import java.util.function.Predicate;
 
 /**
  * A label or {@link Name} is a name to a cell reference, range and so on.
@@ -48,23 +44,18 @@ final public class SpreadsheetLabelName extends SpreadsheetExpressionReference i
 
     final static CharPredicate PART = INITIAL.or(DIGIT.or(CharPredicates.is('_')));
 
-    final static Predicate<CharSequence> PREDICATE = Predicates.initialAndPart(INITIAL, PART);
-
     final static int MAX_LENGTH = 255;
 
     /**
      * Factory that creates a {@link SpreadsheetLabelName}
      */
     public static SpreadsheetLabelName with(final String name) {
-        Objects.requireNonNull(name, "name");
+        CharPredicates.failIfNullOrEmptyOrInitialAndPartFalse(name, "name", INITIAL, PART);
 
         if (!isAcceptableLength(name)) {
             throw new IllegalArgumentException("Label length " + name.length() + " is greater than allowed " + MAX_LENGTH);
         }
 
-        if (!PREDICATE.test(name)) {
-            throw new IllegalArgumentException("Label contains invalid character(s)=" + CharSequences.quote(name));
-        }
         if (isCellReference(name)) {
             throw new IllegalArgumentException("Label is a valid cell reference=" + CharSequences.quote(name));
         }

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNodeName.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNodeName.java
@@ -20,7 +20,8 @@ package walkingkooka.tree.expression;
 
 import walkingkooka.Cast;
 import walkingkooka.naming.Name;
-import walkingkooka.text.CharSequences;
+import walkingkooka.predicate.character.CharPredicate;
+import walkingkooka.predicate.character.CharPredicates;
 
 /**
  * The name of an expression node.
@@ -29,9 +30,15 @@ public final class ExpressionNodeName implements Name,
         Comparable<ExpressionNodeName> {
 
     public static ExpressionNodeName with(final String name) {
-        CharSequences.failIfNullOrEmpty(name, "name");
+        CharPredicates.failIfNullOrEmptyOrInitialAndPartFalse(name,
+                "name",
+                INITIAL,
+                PART);
         return new ExpressionNodeName(name);
     }
+
+    private final static CharPredicate INITIAL = CharPredicates.letter();
+    private final static CharPredicate PART = CharPredicates.letterOrDigit().or(CharPredicates.any("-"));
 
     static ExpressionNodeName fromClass(final Class<? extends ExpressionNode> klass) {
         final String name = klass.getSimpleName();

--- a/src/main/java/walkingkooka/tree/pojo/PojoName.java
+++ b/src/main/java/walkingkooka/tree/pojo/PojoName.java
@@ -18,10 +18,10 @@ package walkingkooka.tree.pojo;
 
 import walkingkooka.Cast;
 import walkingkooka.naming.Name;
-import walkingkooka.predicate.Predicates;
+import walkingkooka.predicate.character.CharPredicate;
+import walkingkooka.predicate.character.CharPredicateBuilder;
+import walkingkooka.predicate.character.CharPredicates;
 import walkingkooka.text.CharSequences;
-
-import java.util.function.Predicate;
 
 /**
  * Holds the name of a node within the tree. The name will be either a field/property name or an index.
@@ -49,12 +49,20 @@ public final class PojoName implements Name,
     }
 
     static PojoName property(final String name) {
-        Predicates.failIfNullOrFalse(name, NAME_PREDICATE, "Name is invalid property name %s");
+        CharPredicates.failIfNullOrEmptyOrInitialAndPartFalse(name, "name", INITIAL, PART);
 
         return new PojoName(name, -1);
     }
 
-    private final static Predicate<CharSequence> NAME_PREDICATE = Predicates.javaIdentifier();
+    private final static CharPredicate INITIAL = CharPredicateBuilder.empty()
+            .or(Character::isJavaIdentifierStart)
+            .andNot(CharPredicates.asciiControl()) // necessary because nul is also valid java identifier
+            .build();
+    private final static CharPredicate PART = CharPredicateBuilder.empty()
+            .or(Character::isJavaIdentifierPart)
+            .any("-")
+            .andNot(CharPredicates.asciiControl()) // necessary because nul is also valid java identifier
+            .build();
 
     private PojoName(final int index){
         this(String.valueOf(index), index);

--- a/src/main/java/walkingkooka/tree/search/SearchNodeAttributeName.java
+++ b/src/main/java/walkingkooka/tree/search/SearchNodeAttributeName.java
@@ -19,15 +19,12 @@
 package walkingkooka.tree.search;
 
 import walkingkooka.Cast;
+import walkingkooka.InvalidCharacterException;
 import walkingkooka.naming.Name;
-import walkingkooka.predicate.Predicates;
 import walkingkooka.predicate.character.CharPredicate;
 import walkingkooka.predicate.character.CharPredicates;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.CharSequences;
-import walkingkooka.text.Whitespace;
-
-import java.util.function.Predicate;
 
 /**
  * The attributeName of an attribute for a node.
@@ -43,14 +40,12 @@ public final class SearchNodeAttributeName implements Name,
 
     final static CharPredicate PART = INITIAL.or(DIGIT.or(CharPredicates.is('-')).or(CharPredicates.is('.')));
 
-    final static Predicate<CharSequence> PREDICATE = Predicates.initialAndPart(INITIAL, PART);
-
     public static SearchNodeAttributeName with(final String name) {
-        Whitespace.failIfNullOrEmptyOrWhitespace(name, "attributeName");
-        Predicates.failIfNullOrFalse(name, PREDICATE, "Name contains an invalid character=%s");
+        CharPredicates.failIfNullOrEmptyOrInitialAndPartFalse(name, "name", INITIAL, PART);
 
-        if(-1 != CharSequences.indexOf(name, "..")) {
-            throw new IllegalArgumentException("Name cannot contain \"..\" =" + CharSequences.quoteAndEscape(name));
+        final int index = CharSequences.indexOf(name, "..");
+        if(-1 != index) {
+            throw new InvalidCharacterException(name, index);
         }
 
         return new SearchNodeAttributeName(name);

--- a/src/main/java/walkingkooka/tree/search/SearchNodeName.java
+++ b/src/main/java/walkingkooka/tree/search/SearchNodeName.java
@@ -20,7 +20,9 @@ package walkingkooka.tree.search;
 
 import walkingkooka.Cast;
 import walkingkooka.naming.Name;
-import walkingkooka.text.CharSequences;
+import walkingkooka.predicate.character.CharPredicate;
+import walkingkooka.predicate.character.CharPredicateBuilder;
+import walkingkooka.predicate.character.CharPredicates;
 
 /**
  * The name of a search node.
@@ -29,9 +31,19 @@ public final class SearchNodeName implements Name,
         Comparable<SearchNodeName> {
 
     public static SearchNodeName with(final String name) {
-        CharSequences.failIfNullOrEmpty(name, "attributeName");
+        CharPredicates.failIfNullOrEmptyOrInitialAndPartFalse(name, "attributeName", INITIAL, PART);
         return new SearchNodeName(name);
     }
+
+    private final static CharPredicate INITIAL = CharPredicateBuilder.empty()
+            .or(Character::isJavaIdentifierStart)
+            .andNot(CharPredicates.asciiControl()) // necessary because nul is also valid java identifier
+            .build();
+    private final static CharPredicate PART = CharPredicateBuilder.empty()
+            .or(Character::isJavaIdentifierPart)
+            .any("-")
+            .andNot(CharPredicates.asciiControl()) // necessary because nul is also valid java identifier
+            .build();
 
     static SearchNodeName fromClass(final Class<? extends SearchNode> klass) {
         final String name = klass.getSimpleName();

--- a/src/main/java/walkingkooka/tree/xml/XmlProcessingInstruction.java
+++ b/src/main/java/walkingkooka/tree/xml/XmlProcessingInstruction.java
@@ -110,7 +110,7 @@ final public class XmlProcessingInstruction extends XmlLeafNode implements Value
         return SEARCH_NODE_NAME;
     }
 
-    private final static SearchNodeName SEARCH_NODE_NAME = SearchNodeName.with("Processing Instruction");
+    private final static SearchNodeName SEARCH_NODE_NAME = SearchNodeName.with("ProcessingInstruction");
 
     // Object ...........................................................................................
 

--- a/src/test/java/walkingkooka/net/UrlPathNameTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathNameTest.java
@@ -47,13 +47,6 @@ public final class UrlPathNameTest extends ClassTestCase<UrlPathName>
     }
 
     @Test
-    public void testIncludesSeparatorFails() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            UrlPathName.with("abc" + UrlPath.SEPARATOR.character() + "xyz");
-        });
-    }
-
-    @Test
     public void testTooLongFails() {
         final char[] chars = new char[UrlPathName.MAXIMUM_LENGTH + 1];
         Arrays.fill(chars, 'x');

--- a/src/test/java/walkingkooka/net/UrlSchemeTest.java
+++ b/src/test/java/walkingkooka/net/UrlSchemeTest.java
@@ -20,7 +20,7 @@ package walkingkooka.net;
 
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.test.SerializationTesting;
 import walkingkooka.text.CaseSensitivity;
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class UrlSchemeTest extends ClassTestCase<UrlScheme>
-        implements NameTesting<UrlScheme, UrlScheme>, SerializationTesting<UrlScheme> {
+        implements NameTesting2<UrlScheme, UrlScheme>, SerializationTesting<UrlScheme> {
 
     @Override
     public void testNaming() {
@@ -51,20 +51,6 @@ public final class UrlSchemeTest extends ClassTestCase<UrlScheme>
     @Test
     public void testHttpsUpperCaseUnimportantConstants() {
         assertSame(UrlScheme.HTTPS, UrlScheme.with("HTTPS"));
-    }
-
-    @Test
-    public void testInvalidFirstCharFails() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            this.createName("1http");
-        });
-    }
-
-    @Test
-    public void testInvalidCharFails() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            this.createName("ab\u100cd");
-        });
     }
 
     @Test
@@ -134,6 +120,28 @@ public final class UrlSchemeTest extends ClassTestCase<UrlScheme>
     @Override
     public String nameTextLess() {
         return "http";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return 0 == position ?
+                ASCII_LETTERS :
+                ASCII_LETTERS_DIGITS + "+-.";
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + BYTE_NON_ASCII;
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/CacheControlDirectiveNameTest.java
+++ b/src/test/java/walkingkooka/net/header/CacheControlDirectiveNameTest.java
@@ -22,6 +22,7 @@ package walkingkooka.net.header;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.set.Sets;
+import walkingkooka.naming.NameTesting2;
 
 import java.util.Optional;
 import java.util.Set;
@@ -31,7 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class CacheControlDirectiveNameTest extends HeaderName2TestCase<CacheControlDirectiveName<?>,
-        CacheControlDirectiveName<?>> {
+        CacheControlDirectiveName<?>>
+        implements NameTesting2<CacheControlDirectiveName<?>, CacheControlDirectiveName<?>> {
 
     @Test
     public void testWithControlCharacterFails() {
@@ -240,6 +242,28 @@ final public class CacheControlDirectiveNameTest extends HeaderName2TestCase<Cac
     @Override
     public String nameTextLess() {
         return CacheControlDirectiveName.NO_CACHE.value();
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return 0 == position ?
+                ASCII_LETTERS_DIGITS :
+                RFC2045;
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + BYTE_NON_ASCII;
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/CharsetNameTest.java
+++ b/src/test/java/walkingkooka/net/header/CharsetNameTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.compare.Comparators;
 import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.type.MemberVisibility;
@@ -36,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class CharsetNameTest extends ClassTestCase<CharsetName>
-        implements NameTesting<CharsetName, CharsetName> {
+        implements NameTesting2<CharsetName, CharsetName> {
 
     @Test
     public void testWithEmptyFails() {
@@ -206,6 +207,28 @@ public final class CharsetNameTest extends ClassTestCase<CharsetName>
     @Override
     public String nameTextLess() {
         return "UTF-16";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return 0 == position ?
+                ASCII_LETTERS_DIGITS :
+                ASCII_LETTERS_DIGITS +  "-+.:_";
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + BYTE_NON_ASCII;
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/ContentDispositionTypeTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentDispositionTypeTest.java
@@ -22,7 +22,7 @@ package walkingkooka.net.header;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.map.Maps;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.type.MemberVisibility;
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class ContentDispositionTypeTest extends ClassTestCase<ContentDispositionType>
-        implements NameTesting<ContentDispositionType, ContentDispositionType> {
+        implements NameTesting2<ContentDispositionType, ContentDispositionType> {
 
     @Override
     public void testNaming() {
@@ -161,6 +161,26 @@ final public class ContentDispositionTypeTest extends ClassTestCase<ContentDispo
     @Override
     public String nameTextLess() {
         return "attachment";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return RFC2045;
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + RFC2045_TSPECIAL + BYTE_NON_ASCII;
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/CookieNameTest.java
+++ b/src/test/java/walkingkooka/net/header/CookieNameTest.java
@@ -21,7 +21,7 @@ package walkingkooka.net.header;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.map.Maps;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.net.http.server.FakeHttpRequest;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
@@ -34,7 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
-final public class CookieNameTest extends ClassTestCase<CookieName> implements NameTesting<CookieName, CookieName> {
+final public class CookieNameTest extends ClassTestCase<CookieName>
+        implements NameTesting2<CookieName, CookieName> {
 
     /**
      * A <cookie-name> can be any US-ASCII characters except control characters (CTLs), spaces, or tabs.
@@ -147,20 +148,6 @@ final public class CookieNameTest extends ClassTestCase<CookieName> implements N
     }
 
     @Test
-    public void testBraceOpenFails() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            CookieName.with("cookie{");
-        });
-    }
-
-    @Test
-    public void testBraceCloseFails() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            CookieName.with("cookie}");
-        });
-    }
-
-    @Test
     public void testIncludesDigits() {
         this.createNameAndCheck("cookie123");
     }
@@ -226,6 +213,26 @@ final public class CookieNameTest extends ClassTestCase<CookieName> implements N
     @Override
     public String nameTextLess() {
         return "abc";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return NameTesting2.subtract(ASCII_NON_CONTROL, RFC2045_TSPECIAL);
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + RFC2045_TSPECIAL;
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/HeaderParameterNameTestCase.java
+++ b/src/test/java/walkingkooka/net/header/HeaderParameterNameTestCase.java
@@ -76,4 +76,24 @@ public abstract class HeaderParameterNameTestCase<N extends HeaderParameterName<
     public final String nameTextLess() {
         return "param-1";
     }
+
+    @Override
+    public final int minLength() {
+        return 1;
+    }
+
+    @Override
+    public final int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public final String possibleValidChars(final int position) {
+        return RFC2045;
+    }
+
+    @Override
+    public final String possibleInvalidChars(final int position) {
+        return CONTROL + BYTE_NON_ASCII + WHITESPACE;
+    }
 }

--- a/src/test/java/walkingkooka/net/header/HttpHeaderNameTest.java
+++ b/src/test/java/walkingkooka/net/header/HttpHeaderNameTest.java
@@ -24,6 +24,7 @@ import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.collect.set.Sets;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.net.http.server.FakeHttpRequest;
 import walkingkooka.test.ConstantsTesting;
 import walkingkooka.text.CaseSensitivity;
@@ -42,7 +43,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class HttpHeaderNameTest extends HeaderName2TestCase<HttpHeaderName<?>, HttpHeaderName<?>>
-        implements ConstantsTesting<HttpHeaderName<?>> {
+        implements ConstantsTesting<HttpHeaderName<?>>,
+        NameTesting2<HttpHeaderName<?>, HttpHeaderName<?>> {
 
     @Test
     public void testControlCharacterFails() {
@@ -407,6 +409,26 @@ final public class HttpHeaderNameTest extends HeaderName2TestCase<HttpHeaderName
     @Override
     public String nameTextLess() {
         return HttpHeaderName.ACCEPT.value();
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return NameTesting2.subtract(ASCII_NON_CONTROL, ":. ");
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + BYTE_NON_ASCII + ":.";
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/LanguageTagNameNonWildcardTest.java
+++ b/src/test/java/walkingkooka/net/header/LanguageTagNameNonWildcardTest.java
@@ -18,6 +18,7 @@
 
 package walkingkooka.net.header;
 
+import walkingkooka.naming.NameTesting2;
 import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
@@ -26,7 +27,8 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class LanguageTagNameNonWildcardTest extends LanguageTagNameTestCase<LanguageTagNameNonWildcard> {
+public final class LanguageTagNameNonWildcardTest extends LanguageTagNameTestCase<LanguageTagNameNonWildcard>
+        implements NameTesting2<LanguageTagNameNonWildcard, LanguageTagName> {
 
     private final static String VALUE = "en";
     private final static Optional<Locale> LOCALE = Optional.of(Locale.forLanguageTag("en"));
@@ -96,6 +98,26 @@ public final class LanguageTagNameNonWildcardTest extends LanguageTagNameTestCas
     @Override
     public String nameTextLess() {
         return "de";
+    }
+
+    @Override
+    public int minLength() {
+        return 2;
+    }
+
+    @Override
+    public int maxLength() {
+        return 7;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return ASCII_LETTERS + "_";
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + WHITESPACE;
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/LanguageTagNameTestCase.java
+++ b/src/test/java/walkingkooka/net/header/LanguageTagNameTestCase.java
@@ -48,7 +48,7 @@ public abstract class LanguageTagNameTestCase<L extends LanguageTagName> extends
 
     @Override
     public void testPublicClass() {
-        throw new UnsupportedOperationException();
+        // ignore
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceNameTest.java
+++ b/src/test/java/walkingkooka/net/http/server/hateos/HateosResourceNameTest.java
@@ -18,13 +18,13 @@
 
 package walkingkooka.net.http.server.hateos;
 
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.type.MemberVisibility;
 
 public final class HateosResourceNameTest extends ClassTestCase<HateosResourceName>
-        implements NameTesting<HateosResourceName, HateosResourceName> {
+        implements NameTesting2<HateosResourceName, HateosResourceName> {
 
     @Override
     public HateosResourceName createName(final String name) {
@@ -49,6 +49,26 @@ public final class HateosResourceNameTest extends ClassTestCase<HateosResourceNa
     @Override
     public String nameTextLess() {
         return "albania";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return ASCII_UPPERCASE + ASCII_LOWERCASE;
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + RFC2045_TSPECIAL;
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierNameTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ebnf/EbnfIdentifierNameTest.java
@@ -19,7 +19,7 @@
 package walkingkooka.text.cursor.parser.ebnf;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.naming.PropertiesPath;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class EbnfIdentifierNameTest extends ClassTestCase<EbnfIdentifierName>
-        implements NameTesting<EbnfIdentifierName, EbnfIdentifierName> {
+        implements NameTesting2<EbnfIdentifierName, EbnfIdentifierName> {
 
     @Test
     public void testCreateContainsSeparatorFails() {
@@ -80,6 +80,28 @@ final public class EbnfIdentifierNameTest extends ClassTestCase<EbnfIdentifierNa
     @Override
     public String nameTextLess() {
         return "abc";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return 0 == position ?
+                ASCII_LETTERS :
+                ASCII_LETTERS_DIGITS;
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return NameTesting2.subtract(ASCII, ASCII_LETTERS_DIGITS + "_");
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorAttributeNameTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorAttributeNameTest.java
@@ -19,7 +19,7 @@
 package walkingkooka.text.cursor.parser.select;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.type.MemberVisibility;
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class NodeSelectorAttributeNameTest extends ClassTestCase<NodeSelectorAttributeName>
-        implements NameTesting<NodeSelectorAttributeName, NodeSelectorAttributeName> {
+        implements NameTesting2<NodeSelectorAttributeName, NodeSelectorAttributeName> {
 
     @Test
     public void testWithInvalidInitialFails() {
@@ -89,6 +89,28 @@ final public class NodeSelectorAttributeNameTest extends ClassTestCase<NodeSelec
     @Override
     public String nameTextLess() {
         return "attribute_1";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return NodeSelectorNodeName.MAX_LENGTH;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return 0 == position ?
+                ASCII_LETTERS :
+                ASCII_LETTERS_DIGITS + "_";
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + BYTE_NON_ASCII;
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorFunctionNameTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorFunctionNameTest.java
@@ -19,18 +19,16 @@
 package walkingkooka.text.cursor.parser.select;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.type.MemberVisibility;
-
-import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class NodeSelectorFunctionNameTest extends ClassTestCase<NodeSelectorFunctionName>
-        implements NameTesting<NodeSelectorFunctionName, NodeSelectorFunctionName> {
+        implements NameTesting2<NodeSelectorFunctionName, NodeSelectorFunctionName> {
 
     @Test
     public void testWithInvalidInitialFails() {
@@ -43,16 +41,6 @@ final public class NodeSelectorFunctionNameTest extends ClassTestCase<NodeSelect
     public void testWithInvalidPartFails() {
         assertThrows(IllegalArgumentException.class, () -> {
             NodeSelectorFunctionName.with("abc$def");
-        });
-    }
-
-    @Test
-    public void testWithInvalidLengthFails() {
-        final char[] c = new char[NodeSelectorFunctionName.MAX_LENGTH + 1];
-        Arrays.fill(c, 'a');
-
-        assertThrows(IllegalArgumentException.class, () -> {
-            NodeSelectorFunctionName.with(new String(c));
         });
     }
 
@@ -89,6 +77,28 @@ final public class NodeSelectorFunctionNameTest extends ClassTestCase<NodeSelect
     @Override
     public String nameTextLess() {
         return "function-1";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return NodeSelectorFunctionName.MAX_LENGTH;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return 0 == position ?
+                ASCII_LETTERS :
+                ASCII_LETTERS_DIGITS + "_";
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + BYTE_NON_ASCII;
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorNodeNameTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorNodeNameTest.java
@@ -19,7 +19,7 @@
 package walkingkooka.text.cursor.parser.select;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.type.MemberVisibility;
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class NodeSelectorNodeNameTest extends ClassTestCase<NodeSelectorNodeName>
-        implements NameTesting<NodeSelectorNodeName, NodeSelectorNodeName> {
+        implements NameTesting2<NodeSelectorNodeName, NodeSelectorNodeName> {
 
     @Test
     public void testWithInvalidInitialFails() {
@@ -89,6 +89,28 @@ final public class NodeSelectorNodeNameTest extends ClassTestCase<NodeSelectorNo
     @Override
     public String nameTextLess() {
         return "node-1";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return NodeSelectorNodeName.MAX_LENGTH;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return 0 == position ?
+                ASCII_LETTERS :
+                ASCII_LETTERS_DIGITS + "_";
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + BYTE_NON_ASCII;
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionNameTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/spreadsheet/SpreadsheetFunctionNameTest.java
@@ -19,18 +19,19 @@
 package walkingkooka.text.cursor.parser.spreadsheet;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.type.MemberVisibility;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class SpreadsheetFunctionNameTest extends ClassTestCase<SpreadsheetFunctionName>
-        implements NameTesting<SpreadsheetFunctionName, SpreadsheetFunctionName> {
+        implements NameTesting2<SpreadsheetFunctionName, SpreadsheetFunctionName> {
 
     @Test
     public void testWithInvalidInitialFails() {
@@ -54,6 +55,15 @@ final public class SpreadsheetFunctionNameTest extends ClassTestCase<Spreadsheet
         assertThrows(IllegalArgumentException.class, () -> {
             SpreadsheetFunctionName.with(new String(c));
         });
+    }
+
+    @Test
+    public void testX() {
+        for(Method m : this.getClass().getMethods()){
+            if(m.isAnnotationPresent(Test.class)){
+                System.out.println(m.toGenericString());
+            }
+        }
     }
 
     @Test
@@ -89,6 +99,28 @@ final public class SpreadsheetFunctionNameTest extends ClassTestCase<Spreadsheet
     @Override
     public String nameTextLess() {
         return "abs";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return 0 == position ?
+                ASCII_LETTERS :
+                ASCII_LETTERS_DIGITS + ".";
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + BYTE_NON_ASCII;
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNodeNameTest.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNodeNameTest.java
@@ -19,7 +19,7 @@
 package walkingkooka.tree.expression;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.type.MemberVisibility;
@@ -27,7 +27,7 @@ import walkingkooka.type.MemberVisibility;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public final class ExpressionNodeNameTest extends ClassTestCase<ExpressionNodeName>
-        implements NameTesting<ExpressionNodeName, ExpressionNodeName> {
+        implements NameTesting2<ExpressionNodeName, ExpressionNodeName> {
 
     @Test
     public void testToString() {
@@ -57,6 +57,28 @@ public final class ExpressionNodeNameTest extends ClassTestCase<ExpressionNodeNa
     @Override
     public String nameTextLess() {
         return "a1";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return 0 == position ?
+                ASCII_LETTERS :
+                ASCII_LETTERS_DIGITS + "-";
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return NameTesting2.subtract(ASCII, this.possibleValidChars(position));
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/pojo/PojoNameTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoNameTest.java
@@ -17,7 +17,7 @@
 package walkingkooka.tree.pojo;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.type.MemberVisibility;
@@ -25,7 +25,7 @@ import walkingkooka.type.MemberVisibility;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class PojoNameTest extends ClassTestCase<PojoName>
-        implements NameTesting<PojoName, PojoName> {
+        implements NameTesting2<PojoName, PojoName> {
 
     private final static String PROPERTY = "abc";
 
@@ -98,6 +98,28 @@ public final class PojoNameTest extends ClassTestCase<PojoName>
     @Override
     public String nameTextLess() {
         return "address";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return 0 == position ?
+                ASCII_LETTERS :
+                ASCII_LETTERS_DIGITS;
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL + WHITESPACE;
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/search/SearchNodeAttributeNameTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchNodeAttributeNameTest.java
@@ -19,7 +19,7 @@
 package walkingkooka.tree.search;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.type.MemberVisibility;
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class SearchNodeAttributeNameTest extends ClassTestCase<SearchNodeAttributeName>
-        implements NameTesting<SearchNodeAttributeName, SearchNodeAttributeName> {
+        implements NameTesting2<SearchNodeAttributeName, SearchNodeAttributeName> {
 
     @Test
     public void testWithInvalidInitialFails() {
@@ -99,6 +99,28 @@ public final class SearchNodeAttributeNameTest extends ClassTestCase<SearchNodeA
     @Override
     public String nameTextLess() {
         return "country";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return 0 == position ?
+                ASCII_LETTERS :
+                ASCII_LETTERS_DIGITS + "-";
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return CONTROL;
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/search/SearchNodeNameTest.java
+++ b/src/test/java/walkingkooka/tree/search/SearchNodeNameTest.java
@@ -19,7 +19,7 @@
 package walkingkooka.tree.search;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.naming.NameTesting;
+import walkingkooka.naming.NameTesting2;
 import walkingkooka.test.ClassTestCase;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.type.MemberVisibility;
@@ -27,7 +27,7 @@ import walkingkooka.type.MemberVisibility;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public final class SearchNodeNameTest extends ClassTestCase<SearchNodeName>
-        implements NameTesting<SearchNodeName, SearchNodeName> {
+        implements NameTesting2<SearchNodeName, SearchNodeName> {
 
     @Test
     public void testToString() {
@@ -57,6 +57,30 @@ public final class SearchNodeNameTest extends ClassTestCase<SearchNodeName>
     @Override
     public String nameTextLess() {
         return "state";
+    }
+
+    @Override
+    public int minLength() {
+        return 1;
+    }
+
+    @Override
+    public int maxLength() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public String possibleValidChars(final int position) {
+        return 0 == position ?
+                ASCII_LETTERS :
+                ASCII_LETTERS_DIGITS + "-.";
+    }
+
+    @Override
+    public String possibleInvalidChars(final int position) {
+        return 0 == position ?
+                CONTROL + ASCII_DIGITS :
+                CONTROL;
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/xml/XmlProcessingInstructionTest.java
+++ b/src/test/java/walkingkooka/tree/xml/XmlProcessingInstructionTest.java
@@ -64,7 +64,7 @@ public final class XmlProcessingInstructionTest extends XmlLeafNodeTestCase<XmlP
                 SearchNode.sequence(Lists.of(
                         SearchNode.text(TARGET, TARGET),
                         SearchNode.text(PROCESSING_INSTRUCTION, PROCESSING_INSTRUCTION)
-                )).setName(SearchNodeName.with("Processing Instruction")));
+                )).setName(SearchNodeName.with("ProcessingInstruction")));
     }
 
     // toString.....................................................................................................


### PR DESCRIPTION
- LanguageTagName only allow ascii letters and underscores.
- ExpressionNodeName, HateosResourceName: allow letters & letters and digits and dash
- UrlPathName allow slashes (assumes will be encoded in url).
- SearchNodeName: java identifier legal chars, except for nul.
- Improved invalid character reporting for a few names.