### PR TITLE
JsonNode.value (doesnt implement Value).

### DIFF
--- a/src/main/java/walkingkooka/tree/json/JsonNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonNode.java
@@ -273,6 +273,10 @@ public abstract class JsonNode implements Node<JsonNode, JsonNodeName, Name, Obj
         throw new UnsupportedOperationException();
     }
 
+    // Value<Object>................................................................................................
+
+    public abstract Object value();
+
     // isXXX............................................................................................................
 
     abstract public boolean isArray();

--- a/src/main/java/walkingkooka/tree/json/JsonParentNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonParentNode.java
@@ -19,6 +19,7 @@
 package walkingkooka.tree.json;
 
 import walkingkooka.Cast;
+import walkingkooka.test.SkipPropertyNeverReturnsNullCheck;
 import walkingkooka.tree.search.SearchNode;
 
 import java.util.List;
@@ -82,6 +83,14 @@ abstract class JsonParentNode<C extends List<JsonNode>> extends JsonNode {
      * Factory that creates a {@link JsonParentNode} of the same type as this with the given new properties.
      */
     abstract JsonParentNode<C> create(final JsonNodeName name, final int index, final C children);
+
+    // Value....................................................................................................
+
+    @Override
+    @SkipPropertyNeverReturnsNullCheck({JsonArrayNode.class, JsonObjectNode.class})
+    public final Object value() {
+        throw new UnsupportedOperationException();
+    }
 
     // HasSearchNode...............................................................................................
 

--- a/src/test/java/walkingkooka/tree/json/JsonParentNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/json/JsonParentNodeTestCase.java
@@ -24,6 +24,7 @@ import walkingkooka.tree.search.SearchNode;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class JsonParentNodeTestCase<N extends JsonParentNode<C>, C extends List<JsonNode>>
         extends JsonNodeTestCase<N> {
@@ -61,6 +62,12 @@ public abstract class JsonParentNodeTestCase<N extends JsonParentNode<C>, C exte
     @Override
     public final void testSetSameAttributes() {
         throw new UnsupportedOperationException();
+    }
+
+    public final void testValueFails() {
+        assertThrows(UnsupportedOperationException.class, ()-> {
+            this.createJsonNode().value();
+        });
     }
 
     @Test


### PR DESCRIPTION
- JsonNode cant implement Value because sub classes want Value with their own separate(different) type parameters.
- JsonArrayNode & JsonObjectNode throw UOE, others already implemented.