### PR TITLE
HasJsonNode.toJsonNodeType

### DIFF
--- a/src/main/java/walkingkooka/tree/json/HasJsonNode.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNode.java
@@ -89,6 +89,13 @@ public interface HasJsonNode {
     }
 
     /**
+     * Sub classes such as enums should override this, to return the "public" type.
+     */
+    default Class<?> toJsonNodeType() {
+        return this.getClass();
+    }
+
+    /**
      * Returns the {@link JsonNode} equivalent of this object.
      */
     JsonNode toJsonNode();

--- a/src/main/java/walkingkooka/tree/json/HasJsonNode2.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNode2.java
@@ -204,7 +204,12 @@ final class HasJsonNode2 {
      * Serializes the node into json with a wrapper json object holding the type=json.
      */
     static JsonNode toJsonNode(final HasJsonNode has) {
-        return registrationOrFail(has.getClass().getName())
+        final Class<?> type = has.toJsonNodeType();
+        if (!type.isInstance(has)) {
+            throw new JsonNodeException("Type " + type.getName() + " is not compatible with " + has.getClass().getName());
+        }
+
+        return registrationOrFail(type.getName())
                 .objectWithType().set(VALUE, has.toJsonNode());
     }
 

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeTesting.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeTesting.java
@@ -26,6 +26,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public interface HasJsonNodeTesting<H extends HasJsonNode> {
 
@@ -56,6 +57,14 @@ public interface HasJsonNodeTesting<H extends HasJsonNode> {
         assertThrows(IllegalArgumentException.class, () -> {
             this.fromJsonNode(from);
         });
+    }
+
+    @Test
+    default void testToJsonNodeType() {
+        final H has = this.createHasJsonNode();
+        final Class<?> type = has.toJsonNodeType();
+        assertTrue(type.isInstance(has),
+                has + " is not an instance of " + type.getName());
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/json/HasJsonNode2Test.java
+++ b/src/test/java/walkingkooka/tree/json/HasJsonNode2Test.java
@@ -162,6 +162,44 @@ public final class HasJsonNode2Test implements ClassTesting<HasJsonNode2> {
                 "fromJsonNodeWithType " + json);
     }
 
+    // toJsonNode..........................................................................
+
+    @Test
+    public void testToJsonWithType() {
+        final String typeName = TestHasJsonNode.class.getName();
+
+        try {
+            HasJsonNode2.register(TestHasJsonNode.class, TestHasJsonNode::fromJsonNode);
+            assertEquals(JsonNode.object()
+                            .set(HasJsonNode2.TYPE, JsonNode.string(typeName))
+                            .set(HasJsonNode2.VALUE, JsonNode.string("FIRST")),
+                    TestHasJsonNode.FIRST.toJsonNodeWithType());
+        } finally {
+            HasJsonNode2.TYPENAME_TO_FACTORY.remove(typeName);
+        }
+    }
+
+    enum TestHasJsonNode implements HasJsonNode {
+        FIRST,
+        SECOND;
+
+        static TestHasJsonNode fromJsonNode(final JsonNode node) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public JsonNode toJsonNode() {
+            return JsonNode.string(this.name());
+        }
+
+        @Override
+        public Class<TestHasJsonNode> toJsonNodeType() {
+            return TestHasJsonNode.class;
+        }
+    }
+
+    // toJsonNode List..........................................................................
+
     @Test
     public void testToJsonNodeListWithTypeColorRoundtrip() {
         final Color color1 = Color.fromRgb(0x111);


### PR DESCRIPTION
- Allows enums to use the enclosing enum as the toJsonNodeWithType type.