### PR TITLE
HasJsonNode.toJsonNode(Object) improvements.

### DIFF
--- a/src/main/java/walkingkooka/tree/json/HasJsonNode.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNode.java
@@ -184,7 +184,7 @@ public interface HasJsonNode {
      * Supports all basic types such as primitive wrappers including null, {@link String} and implementations of {@link HasJsonNode}.
      */
     static JsonNode toJsonNodeWithType(final Object object) {
-        return HasJsonNodeMapper.toJsonNodeWithType(object);
+        return HasJsonNodeMapper.toJsonNodeWithTypeObject(object);
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeBigDecimalMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeBigDecimalMapper.java
@@ -43,7 +43,7 @@ final class HasJsonNodeBigDecimalMapper extends HasJsonNodeMapper2<BigDecimal> {
     private final JsonStringNode TYPE_NAME = JsonStringNode.with("big-decimal");
 
     @Override
-    JsonNode toJsonNodeObjectValue(final BigDecimal value) {
+    JsonNode toJsonNode0(final BigDecimal value) {
         return JsonNode.string(value.toString());
     }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeBigIntegerMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeBigIntegerMapper.java
@@ -43,7 +43,7 @@ final class HasJsonNodeBigIntegerMapper extends HasJsonNodeMapper2<BigInteger> {
     private final JsonStringNode TYPE_NAME = JsonStringNode.with("big-integer");
 
     @Override
-    JsonNode toJsonNodeObjectValue(final BigInteger value) {
+    JsonNode toJsonNode0(final BigInteger value) {
         return JsonNode.string(value.toString());
     }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeBooleanMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeBooleanMapper.java
@@ -34,14 +34,19 @@ final class HasJsonNodeBooleanMapper extends HasJsonNodeMapper<Boolean> {
     }
 
     @Override
-    JsonNode toJsonNode0(final Boolean value) {
-        return JsonNode.booleanNode(value);
+    JsonNode toJsonNodeWithType0(final Boolean value) {
+        return this.toJsonNode0(value);
     }
 
     @Override
     JsonStringNode typeName() {
-        return JSON_STRING_NODE;
+        return TYPE_NAME;
     }
 
-    private final JsonStringNode JSON_STRING_NODE = JsonStringNode.with("boolean");
+    private final JsonStringNode TYPE_NAME = JsonStringNode.with("boolean");
+
+    @Override
+    JsonNode toJsonNode0(final Boolean value) {
+        return JsonNode.booleanNode(value);
+    }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeCollectionMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeCollectionMapper.java
@@ -49,23 +49,16 @@ abstract class HasJsonNodeCollectionMapper<C extends Collection<?>> extends HasJ
     abstract Collector<?, ?, C> collector();
 
     @Override
-    final JsonNode toJsonNodeObjectValue(final C value) {
+    final JsonNode toJsonNode0(final C value) {
         return JsonObjectNode.array()
                 .setChildren(value.stream()
-                        .map(HasJsonNodeMapper::toJsonNodeWithType)
+                        .map(HasJsonNodeMapper::toJsonNodeWithTypeObject)
                         .collect(Collectors.toList()));
-    }
-
-    final JsonNode toJsonNodeWithTypeCollection(final C collection) {
-        return null == collection ?
-                JsonNode.nullNode() :
-                this.objectWithType()
-                        .set(VALUE, this.toJsonNodeObjectValue(collection));
     }
 
     final JsonNode toJsonNodeWithTypeCollection0(final C collection) {
         return null == collection ?
                 JsonNode.nullNode() :
-                this.toJsonNodeObjectValue(collection);
+                this.toJsonNode0(collection);
     }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeDoubleMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeDoubleMapper.java
@@ -34,8 +34,8 @@ final class HasJsonNodeDoubleMapper extends HasJsonNodeMapper<Double> {
     }
 
     @Override
-    JsonNode toJsonNode0(final Double value) {
-        return JsonNode.number(value);
+    JsonNode toJsonNodeWithType0(final Double value) {
+        return this.toJsonNode0(value);
     }
 
     @Override
@@ -44,4 +44,9 @@ final class HasJsonNodeDoubleMapper extends HasJsonNodeMapper<Double> {
     }
 
     private final JsonStringNode JSON_STRING_NODE = JsonStringNode.with("double");
+
+    @Override
+    JsonNode toJsonNode0(final Double value) {
+        return JsonNode.number(value);
+    }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeHasJsonNodeMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeHasJsonNodeMapper.java
@@ -49,7 +49,7 @@ final class HasJsonNodeHasJsonNodeMapper<T extends HasJsonNode> extends HasJsonN
     private final JsonStringNode typeName;
 
     @Override
-    JsonNode toJsonNodeObjectValue(final T value) {
+    JsonNode toJsonNode0(final T value) {
         return value.toJsonNode();
     }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeJsonNodeMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeJsonNodeMapper.java
@@ -49,7 +49,7 @@ final class HasJsonNodeJsonNodeMapper<T extends JsonNode> extends HasJsonNodeMap
     private final JsonStringNode typeName;
 
     @Override
-    JsonNode toJsonNodeObjectValue(final T value) {
+    JsonNode toJsonNode0(final T value) {
         return value;
     }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeLocalDateMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeLocalDateMapper.java
@@ -43,7 +43,7 @@ final class HasJsonNodeLocalDateMapper extends HasJsonNodeMapper2<LocalDate> {
     private final JsonStringNode TYPE_NAME = JsonStringNode.with("local-date");
 
     @Override
-    JsonNode toJsonNodeObjectValue(final LocalDate value) {
+    JsonNode toJsonNode0(final LocalDate value) {
         return JsonNode.string(value.toString());
     }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeLocalDateTimeMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeLocalDateTimeMapper.java
@@ -43,7 +43,7 @@ final class HasJsonNodeLocalDateTimeMapper extends HasJsonNodeMapper2<LocalDateT
     private final JsonStringNode TYPE_NAME = JsonStringNode.with("local-datetime");
 
     @Override
-    JsonNode toJsonNodeObjectValue(final LocalDateTime value) {
+    JsonNode toJsonNode0(final LocalDateTime value) {
         return JsonNode.string(value.toString());
     }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeLocalTimeMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeLocalTimeMapper.java
@@ -43,7 +43,7 @@ final class HasJsonNodeLocalTimeMapper extends HasJsonNodeMapper2<LocalTime> {
     private final JsonStringNode TYPE_NAME = JsonStringNode.with("local-time");
 
     @Override
-    JsonNode toJsonNodeObjectValue(final LocalTime value) {
+    JsonNode toJsonNode0(final LocalTime value) {
         return JsonNode.string(value.toString());
     }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeLongMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeLongMapper.java
@@ -18,6 +18,8 @@
 
 package walkingkooka.tree.json;
 
+import walkingkooka.text.CharSequences;
+
 final class HasJsonNodeLongMapper extends HasJsonNodeMapper2<Long> {
 
     final static HasJsonNodeLongMapper instance() {
@@ -30,18 +32,31 @@ final class HasJsonNodeLongMapper extends HasJsonNodeMapper2<Long> {
 
     @Override
     Long fromJsonNode0(final JsonNode node) {
-        return JsonNode.fromJsonNodeLong(node);
+        try {
+            final String text = node.stringValueOrFail();
+            if (!text.startsWith(LONG_PREFIX)) {
+                throw new IllegalArgumentException("Long string missing prefix " + CharSequences.quote(LONG_PREFIX) + "=" + node);
+            }
+            return Long.parseLong(text.substring(2), 16);
+        } catch (final JsonNodeException cause) {
+            throw new IllegalArgumentException(cause.getMessage(), cause);
+        }
     }
 
     @Override
     JsonStringNode typeName() {
-        return JSON_STRING_NODE;
+        return TYPE_NAME;
     }
 
-    private final JsonStringNode JSON_STRING_NODE = JsonStringNode.with("long");
+    private final JsonStringNode TYPE_NAME = JsonStringNode.with("long");
 
     @Override
-    JsonNode toJsonNodeObjectValue(final Long value) {
-        return JsonNode.wrapLong(value);
+    JsonNode toJsonNode0(final Long value) {
+        return JsonNode.string(LONG_PREFIX + Long.toHexString(value).toLowerCase());
     }
+
+    /**
+     * Prefix included at the start of all longs encoded as a string.
+     */
+    private final static String LONG_PREFIX = "0x";
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeMapMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeMapMapper.java
@@ -51,8 +51,8 @@ final class HasJsonNodeMapMapper extends HasJsonNodeMapper2<Map<?, ?>> {
 
     private static JsonNode toMapChildrenEntry(final Entry<?, ?> entry) {
         return JsonNode.object()
-                .set(ENTRY_KEY, toJsonNodeWithType(entry.getKey()))
-                .set(ENTRY_VALUE, toJsonNodeWithType(entry.getValue()));
+                .set(ENTRY_KEY, toJsonNodeWithTypeObject(entry.getKey()))
+                .set(ENTRY_VALUE, toJsonNodeWithTypeObject(entry.getValue()));
     }
 
     private HasJsonNodeMapMapper() {
@@ -97,7 +97,7 @@ final class HasJsonNodeMapMapper extends HasJsonNodeMapper2<Map<?, ?>> {
     private final JsonStringNode JSON_STRING_NODE = JsonStringNode.with("map");
 
     @Override
-    JsonNode toJsonNodeObjectValue(final Map<?, ?> map) {
+    JsonNode toJsonNode0(final Map<?, ?> map) {
         return JsonNode.array()
                 .setChildren(map.entrySet()
                         .stream()

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeMapper2.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeMapper2.java
@@ -27,9 +27,9 @@ abstract class HasJsonNodeMapper2<T> extends HasJsonNodeMapper<T> {
     abstract T fromJsonNode0(final JsonNode node);
 
     @Override
-    final JsonNode toJsonNode0(final T value) {
+    final JsonNode toJsonNodeWithType0(final T value) {
         return this.objectWithType()
-                .set(HasJsonNodeMapper.VALUE, this.toJsonNodeObjectValue(value));
+                .set(HasJsonNodeMapper.VALUE, this.toJsonNode0(value));
     }
 
     /**
@@ -45,6 +45,4 @@ abstract class HasJsonNodeMapper2<T> extends HasJsonNodeMapper<T> {
     }
 
     private JsonObjectNode objectWithType;
-
-    abstract JsonNode toJsonNodeObjectValue(final T value);
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeMapper3.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeMapper3.java
@@ -43,7 +43,7 @@ abstract class HasJsonNodeMapper3<T extends Number> extends HasJsonNodeMapper2<T
     abstract T fromJsonNode2(final Number number);
 
     @Override
-    final JsonNode toJsonNodeObjectValue(final T value) {
+    final JsonNode toJsonNode0(final T value) {
         return JsonNode.number(value.doubleValue());
     }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeNumberMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeNumberMapper.java
@@ -34,14 +34,19 @@ final class HasJsonNodeNumberMapper extends HasJsonNodeMapper<Number> {
     }
 
     @Override
-    JsonNode toJsonNode0(Number value) {
-        return JsonNode.number(value.doubleValue());
+    JsonNode toJsonNodeWithType0(final Number value) {
+        return this.toJsonNode0(value);
     }
 
     @Override
     JsonStringNode typeName() {
-        return JSON_STRING_NODE;
+        return TYPE_NAME;
     }
 
-    private final JsonStringNode JSON_STRING_NODE = JsonStringNode.with("number");
+    private final JsonStringNode TYPE_NAME = JsonStringNode.with("number");
+
+    @Override
+    JsonNode toJsonNode0(final Number value) {
+        return JsonNode.number(value.doubleValue());
+    }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeStringMapper.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeStringMapper.java
@@ -34,14 +34,19 @@ final class HasJsonNodeStringMapper extends HasJsonNodeMapper<String> {
     }
 
     @Override
-    JsonNode toJsonNode0(final String value) {
-        return JsonNode.string(value);
+    JsonNode toJsonNodeWithType0(final String value) {
+        return this.toJsonNode0(value);
     }
 
     @Override
     JsonStringNode typeName() {
-        return JSON_STRING_NODE;
+        return TYPE_NAME;
     }
 
-    private final JsonStringNode JSON_STRING_NODE = JsonStringNode.with("string");
+    private final JsonStringNode TYPE_NAME = JsonStringNode.with("string");
+
+    @Override
+    JsonNode toJsonNode0(final String value) {
+        return JsonNode.string(value);
+    }
 }

--- a/src/main/java/walkingkooka/tree/json/HasJsonNodeTesting.java
+++ b/src/main/java/walkingkooka/tree/json/HasJsonNodeTesting.java
@@ -118,7 +118,7 @@ public interface HasJsonNodeTesting<H extends HasJsonNode> {
 
         assertEquals(
                 map2,
-                HasJsonNode.fromJsonNodeWithType(HasJsonNodeMapper.toJsonNodeWithType(map2)),
+                HasJsonNode.fromJsonNodeWithType(HasJsonNodeMapper.toJsonNodeWithTypeObject(map2)),
                 () -> "Roundtrip to -> from -> to failed map=" + map);
     }
 

--- a/src/main/java/walkingkooka/tree/json/JsonArrayNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonArrayNode.java
@@ -34,14 +34,6 @@ import java.util.stream.Collectors;
  */
 public final class JsonArrayNode extends JsonParentNode<List<JsonNode>>{
 
-    /**
-     * Simply returns the given {@link JsonNode}.
-     */
-    static JsonArrayNode fromJsonNode0(final JsonNode node) {
-        return node.toJsonNode()
-                .cast();
-    }
-
     private final static JsonNodeName NAME = JsonNodeName.fromClass(JsonArrayNode.class);
 
     final static JsonArrayNode EMPTY = new JsonArrayNode(NAME, NO_INDEX, Lists.empty());

--- a/src/main/java/walkingkooka/tree/json/JsonBooleanNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonBooleanNode.java
@@ -28,14 +28,6 @@ import java.util.Optional;
  */
 public final class JsonBooleanNode extends JsonLeafNode<Boolean>{
 
-    /**
-     * Simply returns the given {@link JsonNode}.
-     */
-    static JsonBooleanNode fromJsonNode0(final JsonNode node) {
-        return node.toJsonNode()
-                .cast();
-    }
-
     static JsonBooleanNode with(final boolean value) {
         return new JsonBooleanNode(NAME, NO_INDEX, value);
     }

--- a/src/main/java/walkingkooka/tree/json/JsonNullNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonNullNode.java
@@ -28,14 +28,6 @@ import java.util.Optional;
  */
 public final class JsonNullNode extends JsonLeafNode<Void>{
 
-    /**
-     * Simply returns the given {@link JsonNode}.
-     */
-    static JsonNullNode fromJsonNode0(final JsonNode node) {
-        return node.toJsonNode()
-                .cast();
-    }
-
     private final static JsonNodeName NAME = JsonNodeName.fromClass(JsonNullNode.class);
 
     final static JsonNullNode INSTANCE = new JsonNullNode(NAME,NO_INDEX, null);

--- a/src/main/java/walkingkooka/tree/json/JsonNumberNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonNumberNode.java
@@ -28,14 +28,6 @@ import java.util.Optional;
  */
 public final class JsonNumberNode extends JsonLeafNode<Double>{
 
-    /**
-     * Simply returns the given {@link JsonNode}.
-     */
-    static JsonNumberNode fromJsonNode0(final JsonNode node) {
-        return node.toJsonNode()
-                .cast();
-    }
-
     static JsonNumberNode with(final double value) {
         return new JsonNumberNode(NAME, NO_INDEX, value);
     }

--- a/src/main/java/walkingkooka/tree/json/JsonObjectNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonObjectNode.java
@@ -39,14 +39,6 @@ import java.util.stream.Collectors;
  */
 public final class JsonObjectNode extends JsonParentNode<JsonObjectNodeList> {
 
-    /**
-     * Simply returns the given {@link JsonNode}.
-     */
-    static JsonObjectNode fromJsonNode0(final JsonNode node) {
-        return node.toJsonNode()
-                .cast();
-    }
-
     private final static JsonNodeName NAME = JsonNodeName.fromClass(JsonObjectNode.class);
 
     /**

--- a/src/main/java/walkingkooka/tree/json/JsonStringNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonStringNode.java
@@ -30,14 +30,6 @@ import java.util.Optional;
  */
 public final class JsonStringNode extends JsonLeafNode<String>{
 
-    /**
-     * Simply returns the given {@link JsonNode}.
-     */
-    static JsonStringNode fromJsonNode0(final JsonNode node) {
-        return node.toJsonNode()
-                .cast();
-    }
-
     static JsonStringNode with(final String value) {
         Objects.requireNonNull(value, "value");
         return new JsonStringNode(NAME, NO_INDEX, value);

--- a/src/test/java/walkingkooka/tree/json/HasJsonNodeBooleanMapperTest.java
+++ b/src/test/java/walkingkooka/tree/json/HasJsonNodeBooleanMapperTest.java
@@ -34,12 +34,12 @@ public final class HasJsonNodeBooleanMapperTest extends HasJsonNodeMapperTestCas
 
     @Test
     public void testToTrue() {
-        this.toJsonNodeAndCheck(true,JsonNode.booleanNode(true));
+        this.toJsonNodeWithTypeAndCheck(true,JsonNode.booleanNode(true));
     }
 
     @Test
     public void testToFalse() {
-        this.toJsonNodeAndCheck(false, JsonNode.booleanNode(false));
+        this.toJsonNodeWithTypeAndCheck(false, JsonNode.booleanNode(false));
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/json/HasJsonNodeJsonNodeMapperTest.java
+++ b/src/test/java/walkingkooka/tree/json/HasJsonNodeJsonNodeMapperTest.java
@@ -26,7 +26,7 @@ public final class HasJsonNodeJsonNodeMapperTest extends HasJsonNodeMapperTestCa
     @Test
     public void testToJsonWithType() {
         final JsonStringNode string = JsonNode.string("abc123");
-        this.toJsonNodeAndCheck(string,
+        this.toJsonNodeWithTypeAndCheck(string,
                 JsonNode.object()
                 .set(HasJsonNodeMapper.TYPE, JsonNode.string("JsonString"))
                 .set(HasJsonNodeMapper.VALUE, string));

--- a/src/test/java/walkingkooka/tree/json/HasJsonNodeListMapperTest.java
+++ b/src/test/java/walkingkooka/tree/json/HasJsonNodeListMapperTest.java
@@ -33,7 +33,12 @@ public final class HasJsonNodeListMapperTest extends HasJsonNodeMapperTestCase2<
 
     @Test
     public void testToEmptyList() {
-        this.toJsonNodeAndCheck(Lists.empty(), this.typeAndValue(JsonNode.array()));
+        this.toJsonNodeWithTypeAndCheck(Lists.empty(), this.typeAndValue(JsonNode.array()));
+    }
+
+    @Override
+    public void testRoundtripToJsonNodeObjectFromJsonNodeWithType() {
+        // ignore
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/json/HasJsonNodeLocalTimeMapperTest.java
+++ b/src/test/java/walkingkooka/tree/json/HasJsonNodeLocalTimeMapperTest.java
@@ -26,12 +26,12 @@ public final class HasJsonNodeLocalTimeMapperTest extends HasJsonNodeMapperTestC
 
     @Test
     public void testRoundtripNoon() {
-        this.toJsonNodeAndCheck(LocalTime.NOON, this.typeAndValue(JsonNode.string("12:00")));
+        this.toJsonNodeWithTypeAndCheck(LocalTime.NOON, this.typeAndValue(JsonNode.string("12:00")));
     }
 
     @Test
     public void testRoundtripLocalTimeMAX() {
-        this.toJsonNodeAndCheck(LocalTime.MAX, this.typeAndValue(JsonNode.string(LocalTime.MAX.toString())));
+        this.toJsonNodeWithTypeAndCheck(LocalTime.MAX, this.typeAndValue(JsonNode.string(LocalTime.MAX.toString())));
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/json/HasJsonNodeLongMapperTest.java
+++ b/src/test/java/walkingkooka/tree/json/HasJsonNodeLongMapperTest.java
@@ -37,7 +37,7 @@ public final class HasJsonNodeLongMapperTest extends HasJsonNodeMapperTestCase2<
 
     @Override
     JsonNode node() {
-        return JsonNode.wrapLong(this.value());
+        return JsonNode.string("0x" + Long.toHexString(this.value()));
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/json/HasJsonNodeMapMapperTest.java
+++ b/src/test/java/walkingkooka/tree/json/HasJsonNodeMapMapperTest.java
@@ -33,7 +33,12 @@ public final class HasJsonNodeMapMapperTest extends HasJsonNodeMapperTestCase2<H
 
     @Test
     public void testToEmptyMap() {
-        this.toJsonNodeAndCheck(Maps.empty(), this.typeAndValue(JsonNode.array()));
+        this.toJsonNodeWithTypeAndCheck(Maps.empty(), this.typeAndValue(JsonNode.array()));
+    }
+
+    @Override
+    public void testRoundtripToJsonNodeObjectFromJsonNodeWithType() {
+        // ignore
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/json/HasJsonNodeMapperTest.java
+++ b/src/test/java/walkingkooka/tree/json/HasJsonNodeMapperTest.java
@@ -95,7 +95,7 @@ public final class HasJsonNodeMapperTest extends HasJsonNodeMapperTestCase<HasJs
 
     @Test
     public void testFromJsonNodeAndTypeByteWithTypeFail() {
-        this.fromJsonNodeAndTypeAndFail(HasJsonNodeMapMapper.toJsonNodeWithType((byte) 1), Byte.class, JsonNodeException.class);
+        this.fromJsonNodeAndTypeAndFail(HasJsonNodeMapMapper.toJsonNodeWithTypeObject((byte) 1), Byte.class, JsonNodeException.class);
     }
 
     @Test
@@ -110,7 +110,7 @@ public final class HasJsonNodeMapperTest extends HasJsonNodeMapperTestCase<HasJs
 
     @Test
     public void testFromJsonNodeAndTypeLong() {
-        this.fromJsonNodeAndTypeAndCheck(JsonNode.wrapLong(1), 1L);
+        this.fromJsonNodeAndTypeAndCheck(JsonNode.string("0x123"), 0x123L);
     }
 
     @Test
@@ -269,7 +269,7 @@ public final class HasJsonNodeMapperTest extends HasJsonNodeMapperTestCase<HasJs
     private <E> void fromJsonNodeListAndCheck(final E value,
                                               final Class<E> elementType) {
         this.fromJsonNodeListAndCheck(JsonNode.array()
-                        .appendChild(JsonNode.wrapOrFail(value)),
+                        .appendChild(HasJsonNode.toJsonNodeObject(value)),
                 elementType,
                 Lists.of(value));
     }
@@ -383,7 +383,7 @@ public final class HasJsonNodeMapperTest extends HasJsonNodeMapperTestCase<HasJs
     private <E> void fromJsonNodeSetAndCheck(final E value,
                                              final Class<E> elementType) {
         this.fromJsonNodeSetAndCheck(JsonNode.array()
-                        .appendChild(JsonNode.wrapOrFail(value)),
+                        .appendChild(HasJsonNodeMapper.toJsonNodeObject(value)),
                 elementType,
                 Sets.of(value));
     }
@@ -504,8 +504,8 @@ public final class HasJsonNodeMapperTest extends HasJsonNodeMapperTestCase<HasJs
                                                 final Class<V> valueType) {
         this.fromJsonNodeMapAndCheck(JsonNode.array()
                         .appendChild(JsonNode.object()
-                                .set(HasJsonNodeMapper.ENTRY_KEY, JsonNode.wrapOrFail(key))
-                                .set(HasJsonNodeMapper.ENTRY_VALUE, JsonNode.wrapOrFail(value))),
+                                .set(HasJsonNodeMapper.ENTRY_KEY, HasJsonNodeMapper.toJsonNodeObject(key))
+                                .set(HasJsonNodeMapper.ENTRY_VALUE, HasJsonNodeMapper.toJsonNodeObject(value))),
                 Maps.one(key, value),
                 keyType,
                 valueType);
@@ -1177,7 +1177,7 @@ public final class HasJsonNodeMapperTest extends HasJsonNodeMapperTestCase<HasJs
 
     private void toJsonNodeObjectAndCheck(final Object value, final JsonNode expected) {
         assertEquals(expected,
-                HasJsonNodeMapper.toJsonNodeWithType(value),
+                HasJsonNodeMapper.toJsonNodeWithTypeObject(value),
                 "value " + CharSequences.quoteIfChars(value) + " toJsonNodeObject failed");
     }
     
@@ -1297,7 +1297,7 @@ public final class HasJsonNodeMapperTest extends HasJsonNodeMapperTestCase<HasJs
 
     private void toJsonNodeWithTypeAndCheck(final Object value, final JsonNode expected) {
         assertEquals(expected,
-                HasJsonNodeMapper.toJsonNodeWithType(value),
+                HasJsonNodeMapper.toJsonNodeWithTypeObject(value),
                 "value " + CharSequences.quoteIfChars(value) + " toJsonNodeWithType failed");
     }
 
@@ -1395,7 +1395,7 @@ public final class HasJsonNodeMapperTest extends HasJsonNodeMapperTestCase<HasJs
     }
 
     private JsonNode typeNameAndValue(final long value) {
-        return this.typeNameAndValue("long", JsonNode.wrapLong(value));
+        return this.typeNameAndValue("long", JsonNode.string("0x" + Long.toHexString(value)));
     }
 
     private JsonNode typeNameAndValue(final Class<?> type, final JsonNode value) {
@@ -1416,7 +1416,7 @@ public final class HasJsonNodeMapperTest extends HasJsonNodeMapperTestCase<HasJs
 
     private void roundtripAndCheck(final Object value) {
         assertEquals(value,
-                HasJsonNodeMapper.fromJsonNodeWithType(HasJsonNodeMapper.toJsonNodeWithType(value)),
+                HasJsonNodeMapper.fromJsonNodeWithType(HasJsonNodeMapper.toJsonNodeWithTypeObject(value)),
                 () -> "roundtrip " + value);
     }
 

--- a/src/test/java/walkingkooka/tree/json/HasJsonNodeMapperTestCase2.java
+++ b/src/test/java/walkingkooka/tree/json/HasJsonNodeMapperTestCase2.java
@@ -52,13 +52,18 @@ public abstract class HasJsonNodeMapperTestCase2<M extends HasJsonNodeMapper<T>,
     }
 
     @Test
-    public final void testToJsonNodeNull() {
+    public final void testToJsonNodeWithNull() {
         this.toJsonNodeAndCheck(null, JsonNode.nullNode());
     }
 
     @Test
     public final void testToJsonNode() {
-        this.toJsonNodeAndCheck(this.value(), this.nodeWithType());
+        this.toJsonNodeAndCheck(this.value(), this.node());
+    }
+
+    @Test
+    public final void testToJsonNodeWithTypeNull() {
+        this.toJsonNodeWithTypeAndCheck(null, JsonNode.nullNode());
     }
 
     @Test
@@ -67,30 +72,55 @@ public abstract class HasJsonNodeMapperTestCase2<M extends HasJsonNodeMapper<T>,
     }
 
     @Test
-    public final void testRoundtripValue() {
-        final T value = this.value();
-
-        assertEquals(value,
-                HasJsonNodeMapper.fromJsonNodeWithType(this.mapper().toJsonNode(value)),
-                () -> "rountrip starting with value failed " + value);
+    public final void testToJsonNodeWithType2() {
+        this.toJsonNodeWithTypeObjectAndCheck(this.value(), this.nodeWithType());
     }
 
     @Test
-    public final void testRoundtripNodeWithType() {
-        final JsonNode maybe = this.nodeWithType();
+    public final void testRoundtripMapperToJsonNodeWithTypeFromJsonNodeWithType() {
+        final T value = this.value();
 
-        assertEquals(maybe,
-                this.mapper().toJsonNode(HasJsonNodeMapper.fromJsonNodeWithType(maybe)),
-                () -> "rountrip starting with node failed " + this.node());
+        final JsonNode json = this.mapper().toJsonNodeWithType(value);
+
+        assertEquals(value,
+                HasJsonNodeMapper.fromJsonNodeWithType(json),
+                () -> "roundtrip starting with value failed fromValue: " + value + " -> json: " + json);
     }
 
     @Test
-    public final void testRoundtrip() {
+    public final void testRoundtripFromJsonNodeWithTypeMapperToJsonNodeWithType() {
+        final JsonNode json = this.nodeWithType();
+
+        final T value = HasJsonNodeMapper.fromJsonNodeWithType(json);
+
+        assertEquals(json,
+                this.mapper().toJsonNodeWithType(value),
+                () -> "roundtrip starting with node failed, json: " + json + " -> value:: " + value);
+    }
+
+    @Test
+    public final void testRoundtripToJsonNodeWithTypeObjectFromJsonNodeWithType() {
         final T value = this.value();
 
+        final JsonNode json = HasJsonNodeMapper.toJsonNodeWithTypeObject(value);
+
         assertEquals(value,
-                HasJsonNodeMapper.fromJsonNodeWithType(HasJsonNodeMapper.toJsonNodeWithType(value)),
-                () -> "rountrip starting with value failed " + value);
+                HasJsonNodeMapper.fromJsonNodeWithType(json),
+                () -> "roundtrip starting with value failed, value: " + value + " -> json: " + json);
+    }
+
+    /**
+     * Overridden to ignore by List, Map, Set.
+     */
+    @Test
+    public void testRoundtripToJsonNodeObjectFromJsonNodeWithType() {
+        final T value = this.value();
+        final Class<?> valueType = value.getClass();
+        final JsonNode json = HasJsonNodeMapper.toJsonNodeObject(value);
+
+        assertEquals(value,
+                HasJsonNodeMapper.fromJsonNode(json, valueType),
+                () -> "roundtrip starting with value failed, value: " + value + " " + valueType.getName() + " -> json: " + json);
     }
 
     @Test
@@ -138,13 +168,15 @@ public abstract class HasJsonNodeMapperTestCase2<M extends HasJsonNodeMapper<T>,
                 () -> "fromJsonNode failed " + node);
     }
 
-    final void toJsonNodeFailed(final T value, final Class<? extends Throwable> thrown) {
+    final void toJsonNodeWithTypeFailed(final T value,
+                                        final Class<? extends Throwable> thrown) {
         assertThrows(thrown, () -> {
-            this.mapper().toJsonNode(value);
+            this.mapper().toJsonNodeWithType(value);
         });
     }
 
-    final void toJsonNodeAndCheck(final T value, final JsonNode node) {
+    final void toJsonNodeAndCheck(final T value,
+                                  final JsonNode node) {
         this.toJsonNodeAndCheck(this.mapper(), value, node);
     }
 
@@ -156,10 +188,24 @@ public abstract class HasJsonNodeMapperTestCase2<M extends HasJsonNodeMapper<T>,
                 () -> "toJsonNode failed " + node);
     }
 
-    final void toJsonNodeWithTypeAndCheck(final T value, final JsonNode node) {
+    final void toJsonNodeWithTypeAndCheck(final T value,
+                                          final JsonNode node) {
+        this.toJsonNodeWithTypeAndCheck(this.mapper(), value, node);
+    }
+
+    final void toJsonNodeWithTypeAndCheck(final HasJsonNodeMapper<T> mapper,
+                                          final T value,
+                                          final JsonNode node) {
         assertEquals(node,
-                HasJsonNode.toJsonNodeWithType(value),
-                () -> "HasJsonNode.toJsonNodeWithType failed " + node);
+                mapper.toJsonNodeWithType(value),
+                () -> "toJsonNodeWithType failed " + node);
+    }
+
+    final void toJsonNodeWithTypeObjectAndCheck(final T value,
+                                                final JsonNode node) {
+        assertEquals(node,
+                HasJsonNodeMapMapper.toJsonNodeWithTypeObject(value),
+                () -> "HasJsonNode.toJsonNodeWithTypeObject failed " + node);
     }
 
     abstract String typeName();

--- a/src/test/java/walkingkooka/tree/json/HasJsonNodeNumberMapperTest.java
+++ b/src/test/java/walkingkooka/tree/json/HasJsonNodeNumberMapperTest.java
@@ -53,7 +53,7 @@ public final class HasJsonNodeNumberMapperTest extends HasJsonNodeMapperTestCase
     }
 
     private void toJsonNodeAndCheck2(final Number value) {
-        this.toJsonNodeAndCheck(value, JsonNode.number(value.doubleValue()));
+        this.toJsonNodeWithTypeAndCheck(value, JsonNode.number(value.doubleValue()));
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/json/HasJsonNodeSetMapperTest.java
+++ b/src/test/java/walkingkooka/tree/json/HasJsonNodeSetMapperTest.java
@@ -33,7 +33,12 @@ public final class HasJsonNodeSetMapperTest extends HasJsonNodeMapperTestCase2<H
 
     @Test
     public void testToEmptyList() {
-        this.toJsonNodeAndCheck(Sets.empty(), this.typeAndValue(JsonNode.array()));
+        this.toJsonNodeWithTypeAndCheck(Sets.empty(), this.typeAndValue(JsonNode.array()));
+    }
+
+    @Override
+    public void testRoundtripToJsonNodeObjectFromJsonNodeWithType() {
+        // ignore
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/json/JsonNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonNodeTest.java
@@ -19,17 +19,10 @@
 package walkingkooka.tree.json;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.color.Color;
 import walkingkooka.test.ClassTesting2;
 import walkingkooka.test.ParseStringTesting;
-import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.parser.ParserException;
 import walkingkooka.type.MemberVisibility;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class JsonNodeTest implements ClassTesting2<JsonNode>,
         ParseStringTesting<JsonNode> {
@@ -91,150 +84,6 @@ public final class JsonNodeTest implements ClassTesting2<JsonNode>,
                 JsonNode.object()
                         .set(JsonNodeName.with("prop2"), JsonNode.string("value2"))
                         .set(JsonNodeName.with("prop1"), JsonNode.string("value1")));
-    }
-
-    // wrap....................................................................................................
-
-    @Test
-    public void testWrapNull() {
-        this.wrapAndCheck(null, JsonNode.nullNode());
-    }
-
-    @Test
-    public void testWrapBooleanTrue() {
-        this.wrapAndCheck(true, JsonNode.booleanNode(true));
-    }
-
-    @Test
-    public void testWrapBooleanFalse() {
-        this.wrapAndCheck(false, JsonNode.booleanNode(false));
-    }
-
-    @Test
-    public void testWrapByte() {
-        this.wrapAndCheck((byte)123, JsonNode.number(123));
-    }
-
-    @Test
-    public void testWrapShort() {
-        this.wrapAndCheck((short)123, JsonNode.number(123));
-    }
-
-    @Test
-    public void testWrapInteger() {
-        this.wrapAndCheck(123, JsonNode.number(123));
-    }
-
-    @Test
-    public void testWrapLongFails() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            JsonNode.wrap(1L);
-        });
-    }
-
-    @Test
-    public void testWrapFloat() {
-        this.wrapAndCheck(123.5f, JsonNode.number(123.5));
-    }
-
-    @Test
-    public void testWrapDouble() {
-        this.wrapAndCheck(123.5, JsonNode.number(123.5));
-    }
-
-    @Test
-    public void testWrapString() {
-        this.wrapAndCheck("abc", JsonNode.string("abc"));
-    }
-
-    @Test
-    public void testWrapOptionalEmpty() {
-        this.wrapAndCheck(Optional.empty());
-    }
-
-    @Test
-    public void testWrapOptionalString() {
-        this.wrapAndCheck(Optional.of("abc"), JsonNode.string("abc"));
-    }
-
-    @Test
-    public void testWrapJsonNode() {
-        final JsonNode jsonNode = JsonNode.string("abc123");
-        this.wrapAndCheck(jsonNode, jsonNode);
-    }
-
-    @Test
-    public void testWrapHasJsonNode() {
-        final Color color = Color.fromRgb(0x123456);
-        this.wrapAndCheck(color, color.toJsonNode());
-    }
-
-    @Test
-    public void testWrapUnsupported() {
-        this.wrapAndCheck(this);
-    }
-
-    private void wrapAndCheck(final Object value) {
-        this.wrapAndCheck(value, Optional.empty());
-    }
-
-    private void wrapAndCheck(final Object value, final JsonNode node) {
-        this.wrapAndCheck(value, Optional.of(node));
-    }
-
-
-    private void wrapAndCheck(final Object value, final Optional<JsonNode> node) {
-        assertEquals(node,
-                JsonNode.wrap(value),
-                "With value " + CharSequences.quoteIfChars(value));
-    }
-
-    // wrapLong.............................................................................................
-
-    @Test
-    public void testWrapLong() {
-        assertEquals(JsonNode.string("0x1234"),
-                JsonNode.wrapLong(0x1234));
-    }
-
-    // fromJsonNodeLong.............................................................................................
-
-    @Test
-    public void testFromJsonNodeLongNullFails() {
-        assertThrows(NullPointerException.class, () -> {
-            JsonNode.fromJsonNodeLong(null);
-        });
-    }
-
-    @Test
-    public void testFromJsonNodeLongNonStringFails() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            JsonNode.fromJsonNodeLong(JsonNode.booleanNode(true));
-        });
-    }
-
-    @Test
-    public void testFromJsonNodeLongNumberFails() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            JsonNode.fromJsonNodeLong(JsonNode.number(123));
-        });
-    }
-
-    @Test
-    public void testFromJsonNodeLongMissingPrefixFails() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            JsonNode.fromJsonNodeLong(JsonNode.string("1234abc"));
-        });
-    }
-
-    @Test
-    public void testFromJsonNodeLong() {
-        assertEquals(0x1234L, JsonNode.fromJsonNodeLong(JsonNode.string("0x1234")));
-    }
-
-    @Test
-    public void testFromJsonNodeLong2() {
-        assertEquals(0x1234ABCL, JsonNode.fromJsonNodeLong(JsonNode.string("0x1234ABC")));
     }
 
     // ClassTesting.............................................................................................


### PR DESCRIPTION
- Reworked HasJsonNodeMapper to support toJsonNode with and without type.
- Removed a few dead methods.