### PR TITLE
NodeTesting2 only parent node tests implement.

### DIFF
--- a/src/main/java/walkingkooka/tree/NodeTesting2.java
+++ b/src/main/java/walkingkooka/tree/NodeTesting2.java
@@ -18,8 +18,14 @@
 package walkingkooka.tree;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.naming.Name;
 
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -32,6 +38,28 @@ public interface NodeTesting2<N extends Node<N, NAME, ANAME, AVALUE>,
         AVALUE>
         extends
         NodeTesting<N, NAME, ANAME, AVALUE> {
+
+    @Test
+    default void testParentWithoutRoot() {
+        this.parentWithoutAndCheck(this.createNode().root());
+    }
+
+    @Test
+    default void testParentWithoutChild() {
+        final N parent = this.createNode();
+        final List<N> children = parent.children();
+        assertNotEquals(Lists.empty(), children, "expected at least 1 child");
+
+        this.parentWithoutAndCheck(children.get(0), parent.removeChild(0));
+        this.checkWithoutParent(this.createNode());
+    }
+
+    @Test
+    default void testRootWithoutParent() {
+        final N node = this.createNode();
+        assertEquals(Optional.empty(), node.parent(), "node must have no parent");
+        assertSame(node, node.root());
+    }
 
     @Test
     default void testChildrenCached() {

--- a/src/test/java/walkingkooka/tree/expression/ExpressionLeafNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionLeafNodeTestCase.java
@@ -64,51 +64,6 @@ public abstract class ExpressionLeafNodeTestCase<N extends ExpressionLeafNode<V>
         assertNotEquals(this.createExpressionNode(), this.createExpressionNode(this.differentValue()));
     }
 
-    @Override
-    public void testAppendChild() {
-        // Ignored
-    }
-
-    @Override
-    public void testAppendChild2() {
-        // Ignored
-    }
-
-    @Override
-    public void testRemoveChildFirst() {
-        // Ignored
-    }
-
-    @Override
-    public void testRemoveChildLast() {
-        // Ignored
-    }
-
-    @Override
-    public void testReplaceChildWithoutParent() {
-        // Ignored
-    }
-
-    @Override
-    public void testReplaceChildDifferentParent() {
-        // Ignored
-    }
-
-    @Override
-    public void testReplaceChild() {
-        // Ignored
-    }
-
-    @Override
-    public void testSetChildrenSame() {
-        // Ignored
-    }
-
-    @Override
-    public void testSetDifferentChildren() {
-        // Ignored
-    }
-
     @Test
     @Override
     public void testParentWithoutChild() {

--- a/src/test/java/walkingkooka/tree/expression/ExpressionNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionNodeTestCase.java
@@ -34,7 +34,7 @@ import walkingkooka.text.cursor.parser.ParserContext;
 import walkingkooka.text.cursor.parser.ParserContexts;
 import walkingkooka.text.cursor.parser.Parsers;
 import walkingkooka.tree.Node;
-import walkingkooka.tree.NodeTesting2;
+import walkingkooka.tree.NodeTesting;
 import walkingkooka.tree.json.HasJsonNodeTesting;
 import walkingkooka.type.MemberVisibility;
 
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public abstract class ExpressionNodeTestCase<N extends ExpressionNode> implements ClassTesting2<ExpressionNode>,
         HasJsonNodeTesting<ExpressionNode>,
         IsMethodTesting<N>,
-        NodeTesting2<ExpressionNode, ExpressionNodeName, Name, Object> {
+        NodeTesting<ExpressionNode, ExpressionNodeName, Name, Object> {
 
     ExpressionNodeTestCase() {
         super();

--- a/src/test/java/walkingkooka/tree/expression/ExpressionParentNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/expression/ExpressionParentNodeTestCase.java
@@ -19,13 +19,16 @@
 package walkingkooka.tree.expression;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.NodeTesting2;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-public abstract class ExpressionParentNodeTestCase<N extends ExpressionParentNode> extends ExpressionNodeTestCase<N> {
+public abstract class ExpressionParentNodeTestCase<N extends ExpressionParentNode> extends ExpressionNodeTestCase<N>
+        implements NodeTesting2<ExpressionNode, ExpressionNodeName, Name, Object> {
 
     ExpressionParentNodeTestCase() {
         super();

--- a/src/test/java/walkingkooka/tree/json/JsonLeafNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/json/JsonLeafNodeTestCase.java
@@ -76,51 +76,6 @@ public abstract class JsonLeafNodeTestCase<N extends JsonLeafNode<V>, V> extends
 
     abstract N setValue(final N node, final V value);
 
-    @Override
-    public final void testAppendChild() {
-        // Ignored
-    }
-
-    @Override
-    public final void testAppendChild2() {
-        // Ignored
-    }
-
-    @Override
-    public final void testRemoveChildFirst() {
-        // Ignored
-    }
-
-    @Override
-    public final void testRemoveChildLast() {
-        // Ignored
-    }
-
-    @Override
-    public final void testReplaceChildWithoutParent() {
-        // Ignored
-    }
-
-    @Override
-    public final void testReplaceChildDifferentParent() {
-        // Ignored
-    }
-
-    @Override
-    public final void testReplaceChild() {
-        // Ignored
-    }
-
-    @Override
-    public final void testSetChildrenSame() {
-        // Ignored
-    }
-
-    @Override
-    public final void testSetDifferentChildren() {
-        // Ignored
-    }
-
     @Test
     public final void testSetChildrenFails() {
         assertThrows(UnsupportedOperationException.class, () -> {

--- a/src/test/java/walkingkooka/tree/json/JsonNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/json/JsonNodeTestCase.java
@@ -31,7 +31,7 @@ import walkingkooka.test.IsMethodTesting;
 import walkingkooka.test.PublicStaticFactoryTesting;
 import walkingkooka.text.LineEnding;
 import walkingkooka.tree.Node;
-import walkingkooka.tree.NodeTesting2;
+import walkingkooka.tree.NodeTesting;
 import walkingkooka.tree.search.HasSearchNodeTesting;
 import walkingkooka.type.MemberVisibility;
 
@@ -49,7 +49,7 @@ public abstract class JsonNodeTestCase<N extends JsonNode> implements ClassTesti
         HasJsonNodeTesting<JsonNode>,
         HasSearchNodeTesting<N>,
         IsMethodTesting<N>,
-        NodeTesting2<JsonNode, JsonNodeName, Name, Object> {
+        NodeTesting<JsonNode, JsonNodeName, Name, Object> {
 
     JsonNodeTestCase() {
         super();

--- a/src/test/java/walkingkooka/tree/json/JsonParentNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/json/JsonParentNodeTestCase.java
@@ -19,6 +19,8 @@
 package walkingkooka.tree.json;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.naming.Name;
+import walkingkooka.tree.NodeTesting2;
 import walkingkooka.tree.search.SearchNode;
 
 import java.util.List;
@@ -27,7 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class JsonParentNodeTestCase<N extends JsonParentNode<C>, C extends List<JsonNode>>
-        extends JsonNodeTestCase<N> {
+        extends JsonNodeTestCase<N>
+        implements NodeTesting2<JsonNode, JsonNodeName, Name, Object> {
 
     JsonParentNodeTestCase() {
         super();

--- a/src/test/java/walkingkooka/tree/search/SearchLeafNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/search/SearchLeafNodeTestCase.java
@@ -176,51 +176,6 @@ public abstract class SearchLeafNodeTestCase<N extends SearchLeafNode<V>, V> ext
         assertNotEquals(this.createSearchNode(), this.createSearchNode(this.differentText(), this.differentValue()));
     }
 
-    @Override
-    public void testAppendChild() {
-        // Ignored
-    }
-
-    @Override
-    public void testAppendChild2() {
-        // Ignored
-    }
-
-    @Override
-    public void testRemoveChildFirst() {
-        // Ignored
-    }
-
-    @Override
-    public void testRemoveChildLast() {
-        // Ignored
-    }
-
-    @Override
-    public void testReplaceChildWithoutParent() {
-        // Ignored
-    }
-
-    @Override
-    public void testReplaceChildDifferentParent() {
-        // Ignored
-    }
-
-    @Override
-    public void testReplaceChild() {
-        // Ignored
-    }
-
-    @Override
-    public void testSetChildrenSame() {
-        // Ignored
-    }
-
-    @Override
-    public void testSetDifferentChildren() {
-        // Ignored
-    }
-
     @Test
     public final void testText() {
         assertEquals(this.text(), this.createSearchNode().text());

--- a/src/test/java/walkingkooka/tree/search/SearchNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/search/SearchNodeTestCase.java
@@ -26,7 +26,7 @@ import walkingkooka.test.ClassTesting2;
 import walkingkooka.test.IsMethodTesting;
 import walkingkooka.test.PublicStaticFactoryTesting;
 import walkingkooka.tree.Node;
-import walkingkooka.tree.NodeTesting2;
+import walkingkooka.tree.NodeTesting;
 import walkingkooka.type.MemberVisibility;
 
 import java.lang.reflect.Method;
@@ -40,10 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class SearchNodeTestCase<N extends SearchNode> implements ClassTesting2<SearchNode>,
         IsMethodTesting<N>,
-        NodeTesting2<SearchNode,
-                        SearchNodeName,
-                        SearchNodeAttributeName,
-                        String> {
+        NodeTesting<SearchNode, SearchNodeName, SearchNodeAttributeName, String> {
 
     SearchNodeTestCase() {
         super();

--- a/src/test/java/walkingkooka/tree/search/SearchParentNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/search/SearchParentNodeTestCase.java
@@ -20,6 +20,7 @@ package walkingkooka.tree.search;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.tree.NodeTesting2;
 
 import java.util.List;
 
@@ -28,7 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public abstract class SearchParentNodeTestCase<N extends SearchParentNode> extends SearchNodeTestCase<N> {
+public abstract class SearchParentNodeTestCase<N extends SearchParentNode> extends SearchNodeTestCase<N>
+        implements NodeTesting2<SearchNode, SearchNodeName, SearchNodeAttributeName, String> {
 
     SearchParentNodeTestCase() {
         super();


### PR DESCRIPTION
- removes need for leaf node tests to override to silence NodeTesting2 would be mutable methods.