### PR TITLE
NodeSelector.accept with map support.

### DIFF
--- a/src/main/java/walkingkooka/net/header/LinkRelationConstantGenerator.java
+++ b/src/main/java/walkingkooka/net/header/LinkRelationConstantGenerator.java
@@ -85,8 +85,9 @@ final class LinkRelationConstantGenerator {
      * </record>
      * </pre>
      */
-    private static void record(final XmlNode node) {
+    private static XmlNode record(final XmlNode node) {
         record0(XmlElement.class.cast(node));
+        return node;
     }
 
     private static void record0(final XmlElement element) {

--- a/src/main/java/walkingkooka/tree/Node.java
+++ b/src/main/java/walkingkooka/tree/Node.java
@@ -132,9 +132,12 @@ public interface Node<N extends Node<N, NAME, ANAME, AVALUE>,
     default N replace(final N node) {
         Objects.requireNonNull(node, "node");
 
-        return this.parent()
-                .map(p -> p.replaceChild(Cast.to(this), node).children().get(this.index()))
-                .orElse(node.removeParent());
+        // early abort if $node is the same as this, this prevents failures in readonly Node.setChildren that throw UOE.
+        return this.equals(node) ?
+                node :
+                this.parent()
+                        .map(p -> p.replaceChild(Cast.to(this), node).children().get(this.index()))
+                        .orElse(node.parent().map(n -> n.removeParent()).orElse(node));
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/select/AbsoluteNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/AbsoluteNodeSelector.java
@@ -19,6 +19,7 @@ package walkingkooka.tree.select;
 import walkingkooka.naming.Name;
 import walkingkooka.naming.PathSeparator;
 import walkingkooka.tree.Node;
+import walkingkooka.tree.pointer.NodePointer;
 
 import java.util.Objects;
 
@@ -59,8 +60,10 @@ final class AbsoluteNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
     }
 
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.select(node.root(), context);
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        final NodePointer<N, NAME> pointer = node.pointer();
+        final N node2 = this.select(node.root(), context);
+        return pointer.traverse(node2).orElse(node2); // try and return the Node at the equivalent location as $node otherwise return node2 itself.
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/AncestorNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/AncestorNodeSelector.java
@@ -55,15 +55,15 @@ final class AncestorNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
     }
 
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.selectParent(node, context);
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.selectParent(node, context);
     }
 
     @Override
-    void select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        super.select(node, context);
+    N select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        final N node2 = super.select(node, context);
 
-        this.selectParent(node, context);
+        return this.selectParent(node2, context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/AncestorOrSelfNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/AncestorOrSelfNodeSelector.java
@@ -57,15 +57,15 @@ final class AncestorOrSelfNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, N
     }
 
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.select(node, context);
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.select(node, context);
     }
 
     @Override
-    void select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        super.select(node, context);
+    N select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        final N node2 = super.select(node, context);
 
-        this.selectParent(node, context);
+        return this.selectParent(node2, context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/AndNodeSelectorNodeSelectorContext.java
+++ b/src/main/java/walkingkooka/tree/select/AndNodeSelectorNodeSelectorContext.java
@@ -18,12 +18,13 @@
 
 package walkingkooka.tree.select;
 
+import walkingkooka.collect.set.Sets;
 import walkingkooka.naming.Name;
 import walkingkooka.tree.Node;
 import walkingkooka.tree.expression.ExpressionNodeName;
 
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.Set;
 
 /**
  * The context used by {@link AndNodeSelector} which batches selected nodes so they can be ANDED with another batch.
@@ -36,15 +37,13 @@ final class AndNodeSelectorNodeSelectorContext<N extends Node<N, NAME, ANAME, AV
     static <N extends Node<N, NAME, ANAME, AVALUE>,
             NAME extends Name,
             ANAME extends Name,
-            AVALUE> AndNodeSelectorNodeSelectorContext<N, NAME, ANAME, AVALUE> with(final NodeSelectorContext<N, NAME, ANAME, AVALUE> context,
-                                                                                    final Consumer<N> selected) {
-        return new AndNodeSelectorNodeSelectorContext<N, NAME, ANAME, AVALUE>(context, selected);
+            AVALUE> AndNodeSelectorNodeSelectorContext<N, NAME, ANAME, AVALUE> with(final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return new AndNodeSelectorNodeSelectorContext<N, NAME, ANAME, AVALUE>(context);
     }
 
-    private AndNodeSelectorNodeSelectorContext(final NodeSelectorContext<N, NAME, ANAME, AVALUE> context,
-                                               final Consumer<N> selected) {
+    private AndNodeSelectorNodeSelectorContext(final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        super();
         this.context = context;
-        this.selected = selected;
     }
 
     /**
@@ -56,11 +55,12 @@ final class AndNodeSelectorNodeSelectorContext<N extends Node<N, NAME, ANAME, AV
     }
 
     @Override
-    public void selected(final N node) {
-        this.selected.accept(node);
+    public N selected(final N node) {
+        this.selected.add(node);
+        return node;
     }
 
-    private final Consumer<N> selected;
+    Set<N> selected = Sets.ordered();
 
     @Override
     public <T> T convert(final Object value, final Class<T> target) {

--- a/src/main/java/walkingkooka/tree/select/BasicNodeSelectorContext.java
+++ b/src/main/java/walkingkooka/tree/select/BasicNodeSelectorContext.java
@@ -44,26 +44,26 @@ final class BasicNodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>, NAM
             NAME extends Name,
             ANAME extends Name,
             AVALUE> BasicNodeSelectorContext<N, NAME, ANAME, AVALUE> with(final Consumer<N> potential,
-                                                                          final Consumer<N> selected,
+                                                                          final Function<N, N> mapper,
                                                                           final Function<ExpressionNodeName, Optional<ExpressionFunction<?>>> functions,
                                                                           final Converter converter,
                                                                           final DecimalNumberContext decimalNumberContext) {
         Objects.requireNonNull(potential, "potential");
-        Objects.requireNonNull(selected, "selected");
+        Objects.requireNonNull(mapper, "mapper");
         Objects.requireNonNull(functions, "functions");
         Objects.requireNonNull(converter, "converter");
         Objects.requireNonNull(decimalNumberContext, "decimalNumberContext");
 
-        return new BasicNodeSelectorContext<>(potential, selected, functions, converter, decimalNumberContext);
+        return new BasicNodeSelectorContext<>(potential, mapper, functions, converter, decimalNumberContext);
     }
 
     private BasicNodeSelectorContext(final Consumer<N> potential,
-                                     final Consumer<N> selected,
+                                     final Function<N, N> mapper,
                                      final Function<ExpressionNodeName, Optional<ExpressionFunction<?>>> functions,
                                      final Converter converter,
                                      final DecimalNumberContext decimalNumberContext) {
         this.potential = potential;
-        this.selected = selected;
+        this.mapper = mapper;
         this.functions = functions;
         this.converter = converter;
         this.decimalNumberContext = decimalNumberContext;
@@ -82,11 +82,11 @@ final class BasicNodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>, NAM
     private final Consumer<N> potential;
 
     @Override
-    public void selected(final N node) {
-        this.selected.accept(node);
+    public N selected(final N node) {
+        return this.mapper.apply(node);
     }
 
-    private final Consumer<N> selected;
+    private final Function<N, N> mapper;
 
     @Override
     public <T> T convert(final Object value, final Class<T> target) {
@@ -119,6 +119,6 @@ final class BasicNodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>, NAM
 
     @Override
     public String toString() {
-        return this.potential + " " + this.selected + " " + this.functions + " " + this.converter + " " + this.decimalNumberContext;
+        return this.potential + " " + this.mapper + " " + this.functions + " " + this.converter + " " + this.decimalNumberContext;
     }
 }

--- a/src/main/java/walkingkooka/tree/select/ChildrenNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/ChildrenNodeSelector.java
@@ -54,8 +54,8 @@ final class ChildrenNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
     // NodeSelector
 
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.selectChildren(node, context);
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.selectChildren(node, context);
     }
 
     // Object

--- a/src/main/java/walkingkooka/tree/select/CustomToStringNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/CustomToStringNodeSelector.java
@@ -60,13 +60,13 @@ final class CustomToStringNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, N
     }
 
     @Override
-    void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.selector.accept1(node, context);
+    N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.selector.accept1(node, context);
     }
 
     @Override
-    void select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.selector.select(node, context);
+    N select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.selector.select(node, context);
     }
 
     // Object

--- a/src/main/java/walkingkooka/tree/select/DescendantNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/DescendantNodeSelector.java
@@ -55,17 +55,16 @@ final class DescendantNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
                 new DescendantNodeSelector<N, NAME, ANAME, AVALUE>(selector);
     }
 
-
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.selectChildren(node, context);
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.selectChildren(node, context);
     }
 
     @Override
-    void select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        super.select(node, context);
+    N select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        final N node2 = super.select(node, context);
 
-        this.selectChildren(node, context);
+        return this.selectChildren(node2, context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/DescendantOrSelfNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/DescendantOrSelfNodeSelector.java
@@ -58,15 +58,15 @@ final class DescendantOrSelfNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
     }
 
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.select(node, context);
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.select(node, context);
     }
 
     @Override
-    void select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        super.select(node, context);
+    N select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        final N node2 = super.select(node, context);
 
-        this.selectChildren(node, context);
+        return this.selectChildren(node2, context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/FakeNodeSelectorContext.java
+++ b/src/main/java/walkingkooka/tree/select/FakeNodeSelectorContext.java
@@ -36,7 +36,7 @@ public class FakeNodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>,
     }
 
     @Override
-    public void selected(final N node) {
+    public N selected(final N node) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/tree/select/FirstChildNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/FirstChildNodeSelector.java
@@ -53,11 +53,9 @@ final class FirstChildNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
         return new FirstChildNodeSelector<>(selector);
     }
 
-    // NodeSelector
-
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.select(node.firstChild(), context);
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.selectChild(node.firstChild(), node, context);
     }
 
     // Object

--- a/src/main/java/walkingkooka/tree/select/FollowingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/FollowingNodeSelector.java
@@ -57,15 +57,14 @@ final class FollowingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
     }
 
     @Override
-    void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.selectChildren(node, context);
-        this.selectFollowingSiblings(node, context);
+    N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.selectFollowingSiblings(node, context);
     }
 
     @Override
-    void select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        super.select(node, context);
-        this.selectChildren(node, context);
+    N select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        final N node2 = super.select(node, context);
+        return this.selectChildren(node2, context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/FollowingSiblingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/FollowingSiblingNodeSelector.java
@@ -56,8 +56,8 @@ final class FollowingSiblingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
     }
 
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.selectFollowingSiblings(node, context);
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.selectFollowingSiblings(node, context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/IndexedChildNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/IndexedChildNodeSelector.java
@@ -58,12 +58,13 @@ final class IndexedChildNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAM
     }
 
     @Override
-    void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         final List<N> children = node.children();
         final int index = this.index - INDEX_BIAS;
-        if (index < children.size()) {
-            this.select(children.get(index), context);
-        }
+
+        return index < children.size() ?
+                this.select(children.get(index), context).parentOrFail() :
+                node;
     }
 
     private final int index;

--- a/src/main/java/walkingkooka/tree/select/LastChildNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/LastChildNodeSelector.java
@@ -57,8 +57,8 @@ final class LastChildNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
     // NodeSelector
 
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.select(node.lastChild(), context);
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.selectChild(node.lastChild(), node, context);
     }
 
     // Object

--- a/src/main/java/walkingkooka/tree/select/LogicalNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/LogicalNodeSelector.java
@@ -56,17 +56,17 @@ abstract class LogicalNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
     }
 
     @Override
-    NodeSelector<N, NAME, ANAME, AVALUE> append0(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+    final NodeSelector<N, NAME, ANAME, AVALUE> append0(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    void select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    final N select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         throw new NeverError(this.getClass().getName() + ".select(Node, NodeSelectorContext)");
     }
 
     @Override
-    void toString0(final NodeSelectorToStringBuilder b) {
+    final void toString0(final NodeSelectorToStringBuilder b) {
         String between = "";
         for (NodeSelector<N, NAME, ANAME, AVALUE> selector : this.selectors) {
             b.append(between);
@@ -79,10 +79,12 @@ abstract class LogicalNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
 
     // Object
 
+    @Override
     public final int hashCode() {
         return this.selectors.hashCode();
     }
 
+    @Override
     public final boolean equals(final Object other) {
         return this == other || this.canBeEqual(other) && this.equals0(Cast.to(other));
     }

--- a/src/main/java/walkingkooka/tree/select/NamedNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/NamedNodeSelector.java
@@ -55,15 +55,16 @@ final class NamedNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME exten
 
     // NodeSelector
 
+    @Override
     NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
         return new NamedNodeSelector<>(this.name, this.separator, selector);
     }
 
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        if (this.name.equals(node.name())) {
-            this.select(node, context);
-        }
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.name.equals(node.name()) ?
+                this.select(node, context) :
+                node;
     }
 
     private final NAME name;

--- a/src/main/java/walkingkooka/tree/select/NodePredicateNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/NodePredicateNodeSelector.java
@@ -55,15 +55,16 @@ final class NodePredicateNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NA
 
     // NodeSelector
 
+    @Override
     NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
         return new NodePredicateNodeSelector<>(this.predicate, selector);
     }
 
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        if (this.predicate.test(node)) {
-            context.selected(node);
-        }
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.predicate.test(node) ?
+                node.replace(context.selected(node)) :
+                node;
     }
 
     private final Predicate<N> predicate;

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorContext.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorContext.java
@@ -36,5 +36,5 @@ public interface NodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>, NAM
     /**
      * Invoked with each and every selected {@link Node node}.
      */
-    void selected(final N node);
+    N selected(final N node);
 }

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorContexts.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorContexts.java
@@ -41,11 +41,11 @@ public final class NodeSelectorContexts implements PublicStaticHelper {
             NAME extends Name,
             ANAME extends Name,
             AVALUE> NodeSelectorContext<N, NAME, ANAME, AVALUE> basic(final Consumer<N> potential,
-                                                                      final Consumer<N> selected,
+                                                                      final Function<N, N> mapper,
                                                                       final Function<ExpressionNodeName, Optional<ExpressionFunction<?>>> functions,
                                                                       final Converter converter,
                                                                       final DecimalNumberContext decimalNumberContext) {
-        return BasicNodeSelectorContext.with(potential, selected, functions, converter, decimalNumberContext);
+        return BasicNodeSelectorContext.with(potential, mapper, functions, converter, decimalNumberContext);
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/select/NonLogicalNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/NonLogicalNodeSelector.java
@@ -42,20 +42,24 @@ abstract class NonLogicalNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NA
     abstract NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector);
 
     /**
-     * Used to match a node wrapped in an optional. Empty optionals have no effect.
+     * Used to select a node wrapped in an optional. Empty optionals have no effect.
      */
-    final void select(final Optional<N> node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        if (node.isPresent()) {
-            this.select(node.get(), context);
-        }
+    final N selectChild(final Optional<N> node,
+                        final N parent,
+                        final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+//        if (node.isPresent()) {
+//            this.select(node.get(), context);
+//        }
+        return node.map(child -> this.select(child, context).parentOrFail())
+                .orElse(parent);
     }
 
     /**
      * The default simply records the {@link Node} to the {@link NodeSelectorContext}.
      */
     @Override
-    void select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.next.accept0(node, context);
+    N select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.next.accept0(node, context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/OrNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/OrNodeSelector.java
@@ -55,10 +55,14 @@ final class OrNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extends 
     // LogicalNodeSelector
 
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        N last = node;
+
         for (NodeSelector<N, NAME, ANAME, AVALUE> selector : this.selectors) {
-            selector.accept1(node, context);
+            last = selector.accept1(last, context);
         }
+
+        return last;
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/ParentNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/ParentNodeSelector.java
@@ -53,8 +53,8 @@ final class ParentNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME exte
     }
 
     @Override
-    public void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.selectParent(node, context);
+    N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.selectParent(node, context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/PathNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PathNodeSelector.java
@@ -57,28 +57,37 @@ final class PathNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extend
     }
 
     @Override
-    void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        N current = node;
+
         boolean abort = false;
 
-        N current = node;
         for (Integer index : this.path) {
-            final int zeroIndex = index - 1;
+            final int zeroIndex = index - INDEX_BIAS;
             final List<N> children = current.children();
             if (zeroIndex >= children.size()) {
                 abort = true;
+                current = node; // reset result to node.
                 break;
             }
             current = children.get(zeroIndex);
         }
 
-        if (!abort) {
-            this.select(current, context);
+        if(!abort) {
+            current = current.replace(this.select(current, context));
+
+            final int parentPop = this.path.size();
+            for(int i = 0; i < parentPop; i++) {
+                current = current.parentOrFail();
+            }
         }
+
+        return current;
     }
 
     @Override
-    void select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        context.selected(node);
+    N select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return context.selected(node);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/PrecedingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PrecedingNodeSelector.java
@@ -57,15 +57,14 @@ final class PrecedingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME e
     }
 
     @Override
-    void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.selectChildren(node, context);
-        this.selectPrecedingSiblings(node, context);
+    N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.selectPrecedingSiblings(node, context);
     }
 
     @Override
-    void select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        super.select(node, context);
-        this.selectChildren(node, context);
+    N select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        final N node2 = super.select(node, context);
+        return this.selectChildren(node2, context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/PrecedingSiblingNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/PrecedingSiblingNodeSelector.java
@@ -55,8 +55,8 @@ final class PrecedingSiblingNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
     }
 
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.selectPrecedingSiblings(node, context);
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.selectPrecedingSiblings(node, context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/SelfNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/SelfNodeSelector.java
@@ -57,8 +57,8 @@ final class SelfNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME extend
     }
 
     @Override
-    void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        this.select(node, context);
+    N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return this.select(node, context);
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/select/TerminalNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/TerminalNodeSelector.java
@@ -54,12 +54,12 @@ final class TerminalNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
     }
 
     @Override
-    final void accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
-        context.selected(node);
+    final N accept1(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+        return node.replace(context.selected(node));
     }
 
     @Override
-    void select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
+    N select(final N node, final NodeSelectorContext<N, NAME, ANAME, AVALUE> context) {
         throw new NeverError(this.getClass() + ".select(Node, NodeSelectorContext)");
     }
 

--- a/src/test/java/walkingkooka/tree/json/JsonArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonArrayNodeTest.java
@@ -533,6 +533,25 @@ public final class JsonArrayNodeTest extends JsonParentNodeTestCase<JsonArrayNod
                 expected);
     }
 
+    @Test
+    public void testSelectorMap() {
+        final JsonArrayNode array = JsonNode.array()
+                .appendChild(JsonNode.booleanNode(true))
+                .appendChild(JsonNode.number(2))
+                .appendChild(JsonNode.string("third"))
+                .appendChild(JsonNode.string("fourth"));
+
+        final JsonNode replaced = JsonNode.number(999);
+
+        this.selectorAcceptMapAndCheck(array,
+                JsonNode.PATH_SEPARATOR.absoluteNodeSelectorBuilder(JsonNode.class)
+                        .descendant()
+                        .named(array.get(1).name())
+                        .build(),
+                (n) -> replaced,
+                array.set(1, replaced));
+    }
+
     // HasJsonNode.......................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/tree/json/JsonObjectNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonObjectNodeTest.java
@@ -738,6 +738,24 @@ public final class JsonObjectNodeTest extends JsonParentNodeTestCase<JsonObjectN
     }
 
     @Test
+    public void testSelectorMap() {
+        final JsonObjectNode object = JsonNode.object()
+                .set(key1(), JsonNode.booleanNode(true))
+                .set(key2(), JsonNode.number(2))
+                .set(key3(), JsonNode.string("third"));
+        final JsonNodeName key2 = this.key2();
+        final JsonNode replaced = JsonNode.string("*");
+
+        this.selectorAcceptMapAndCheck(object,
+                JsonNode.PATH_SEPARATOR.absoluteNodeSelectorBuilder(JsonNode.class)
+                        .descendant()
+                        .named(key2)
+                        .build(),
+                (n) -> replaced,
+                object.set(key2, replaced));
+    }
+
+    @Test
     public void testPrintJsonWithoutIndentationAndNoneLineEnding() {
         final JsonObjectNode object = JsonNode.object()
                 .set(key1(), JsonNode.booleanNode(true))

--- a/src/test/java/walkingkooka/tree/select/AbsoluteNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/AbsoluteNodeSelectorTest.java
@@ -81,6 +81,39 @@ final public class AbsoluteNodeSelectorTest extends
     }
 
     @Test
+    public void testMap() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(1),
+                TestNode.with("grand*0",
+                        TestNode.with("parent1",
+                                TestNode.with("child1"), TestNode.with("child2")),
+                        TestNode.with("parent2", TestNode.with("child3")))
+                        .child(1));
+    }
+
+    @Test
+    public void testMap2() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent,
+                TestNode.with("grand*0",
+                        TestNode.with("parent1",
+                                TestNode.with("child1"), TestNode.with("child2")),
+                        TestNode.with("parent2", TestNode.with("child3"))));
+    }
+
+    @Test
     public void testEqualsDifferentPathSeparator() {
         this.checkNotEquals(this.createSelector(PathSeparator.requiredAtStart('.'),
                 this.wrapped()));

--- a/src/test/java/walkingkooka/tree/select/AncestorNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/AncestorNodeSelectorTest.java
@@ -74,6 +74,23 @@ final public class AncestorNodeSelectorTest extends
     }
 
     @Test
+    public void testMap() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(0).child(0),
+                TestNode.with("grand*1",
+                        TestNode.with("parent1*0",
+                                TestNode.with("child1"), TestNode.with("child2")),
+                        TestNode.with("parent2", TestNode.with("child3"))).child(0)
+                        .child(0));
+    }
+
+    @Test
     public void testToString() {
         this.toStringAndCheck(this.createSelector(), "ancestor::*");
     }

--- a/src/test/java/walkingkooka/tree/select/AncestorOrSelfNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/AncestorOrSelfNodeSelectorTest.java
@@ -67,6 +67,23 @@ final public class AncestorOrSelfNodeSelectorTest extends
     }
 
     @Test
+    public void testMap() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(0),
+                TestNode.with("grand*1",
+                        TestNode.with("parent1*0",
+                                TestNode.with("child1"), TestNode.with("child2")),
+                        TestNode.with("parent2", TestNode.with("child3")))
+                        .child(0));
+    }
+
+    @Test
     public void testToString() {
         this.toStringAndCheck(this.createSelector(), "ancestor-or-self::*");
     }

--- a/src/test/java/walkingkooka/tree/select/AndNodeSelectorNodeSelectorContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/AndNodeSelectorNodeSelectorContextTest.java
@@ -33,7 +33,7 @@ public final class AndNodeSelectorNodeSelectorContextTest implements ClassTestin
 
     @Override
     public AndNodeSelectorNodeSelectorContext<TestNode, StringName, StringName, Object> createContext() {
-        return AndNodeSelectorNodeSelectorContext.with(null, null);
+        return AndNodeSelectorNodeSelectorContext.with(null);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/select/AndNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/AndNodeSelectorTest.java
@@ -63,6 +63,42 @@ public final class AndNodeSelectorTest extends
                 child);
     }
 
+    @Test
+    public void testMap() {
+        final TestNode parent = TestNode.with("parent", TestNode.with("child1"), TestNode.with("child2"));
+
+        TestNode.clear();
+
+        // children selects $child1 & $child2, index(1) only selects $child1 giving $child1.
+        this.acceptMapAndCheck(this.createSelector0(ChildrenNodeSelector.get(), NodeSelector.indexedChild(1)),
+                parent, // parent1
+                TestNode.with("parent", TestNode.with("child1*0"), TestNode.with("child2")));
+    }
+
+    @Test
+    public void testMap2() {
+        final TestNode parent = TestNode.with("parent", TestNode.with("child1"), TestNode.with("child2"));
+
+        TestNode.clear();
+
+        // children selects $child1 & $child2, index(2) only selects $child2 giving $child2.
+        this.acceptMapAndCheck(this.createSelector0(ChildrenNodeSelector.get(), NodeSelector.indexedChild(2)),
+                parent, // parent1
+                TestNode.with("parent", TestNode.with("child1"), TestNode.with("child2*0")));
+    }
+
+    @Test
+    public void testMap3() {
+        final TestNode parent = TestNode.with("parent", TestNode.with("child1"), TestNode.with("child2"));
+
+        TestNode.clear();
+
+        // children and descendant both select all children.
+        this.acceptMapAndCheck(this.createSelector0(ChildrenNodeSelector.get(), NodeSelector.descendant()),
+                parent, // parent1
+                TestNode.with("parent", TestNode.with("child1*0"), TestNode.with("child2*1")));
+    }
+
     @Override
     NodeSelector<TestNode, StringName, StringName, Object> createSelector0(final List<NodeSelector<TestNode, StringName, StringName, Object>> selectors) {
         return AndNodeSelector.with(selectors);

--- a/src/test/java/walkingkooka/tree/select/BasicNodeSelectorContextTest.java
+++ b/src/test/java/walkingkooka/tree/select/BasicNodeSelectorContextTest.java
@@ -48,7 +48,7 @@ public final class BasicNodeSelectorContextTest implements ClassTesting2<BasicNo
     public void NullPointerException() {
         assertThrows(NullPointerException.class, () -> {
             BasicNodeSelectorContext.with(null,
-                    this.selected(),
+                    this.mapper(),
                     this.functions(),
                     this.converter(),
                     this.decimalNumberContext());
@@ -70,7 +70,7 @@ public final class BasicNodeSelectorContextTest implements ClassTesting2<BasicNo
     public void testWithNullFunctionsFails() {
         assertThrows(NullPointerException.class, () -> {
             BasicNodeSelectorContext.with(this.potential(),
-                    this.selected(),
+                    this.mapper(),
                     null,
                     this.converter(),
                     this.decimalNumberContext());
@@ -81,7 +81,7 @@ public final class BasicNodeSelectorContextTest implements ClassTesting2<BasicNo
     public void testWithNullConverterFails() {
         assertThrows(NullPointerException.class, () -> {
             BasicNodeSelectorContext.with(this.potential(),
-                    this.selected(),
+                    this.mapper(),
                     this.functions(),
                     null,
                     this.decimalNumberContext());
@@ -92,7 +92,7 @@ public final class BasicNodeSelectorContextTest implements ClassTesting2<BasicNo
     public void testWithNullDecimalNumberContextFails() {
         assertThrows(NullPointerException.class, () -> {
             BasicNodeSelectorContext.with(this.potential(),
-                    this.selected(),
+                    this.mapper(),
                     this.functions(),
                     this.converter(),
                     null);
@@ -105,7 +105,7 @@ public final class BasicNodeSelectorContextTest implements ClassTesting2<BasicNo
 
     @Override public BasicNodeSelectorContext<TestNode, StringName, StringName, Object> createContext() {
         return BasicNodeSelectorContext.with(this.potential(),
-                this.selected(),
+                this.mapper(),
                 this.functions(),
                 this.converter(),
                 this.decimalNumberContext());
@@ -116,9 +116,8 @@ public final class BasicNodeSelectorContextTest implements ClassTesting2<BasicNo
         };
     }
 
-    private Consumer<TestNode> selected() {
-        return (n) -> {
-        };
+    private Function<TestNode, TestNode> mapper() {
+        return Function.identity();
     }
 
     private Function<ExpressionNodeName, Optional<ExpressionFunction<?>>> functions() {

--- a/src/test/java/walkingkooka/tree/select/ChildrenNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/ChildrenNodeSelectorTest.java
@@ -67,10 +67,48 @@ final public class ChildrenNodeSelectorTest
     public void testIgnoresSiblings() {
         final TestNode child = TestNode.with("child");
         final TestNode parent = TestNode.with("parent", child);
-        final TestNode siblingOfParent = TestNode.with("siblingOfParent", child);
+        final TestNode siblingOfParent = TestNode.with("siblingOfParent", TestNode.with("siblingOfParent-child"));
         final TestNode grandParent = TestNode.with("grandParent", parent, siblingOfParent);
 
         this.acceptAndCheck(parent, child);
+    }
+
+    @Test
+    public void testMapWithoutChildren() {
+        this.acceptMapAndCheck(TestNode.with("without-children"));
+    }
+
+    @Test
+    public void testMap() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(0),
+                TestNode.with("grand",
+                        TestNode.with("parent1",
+                                TestNode.with("child1*0"), TestNode.with("child2*1")),
+                        TestNode.with("parent2", TestNode.with("child3")))
+                        .child(0));
+    }
+
+    @Test
+    public void testMap2() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent,
+                TestNode.with("grand",
+                        TestNode.with("parent1*0",
+                                TestNode.with("child1"), TestNode.with("child2")),
+                        TestNode.with("parent2*1", TestNode.with("child3"))));
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/select/CustomToStringNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/CustomToStringNodeSelectorTest.java
@@ -71,6 +71,16 @@ final public class CustomToStringNodeSelectorTest
     }
 
     @Test
+    public void testMap() {
+        final TestNode parent = TestNode.with("parent",
+                TestNode.with("child1"), TestNode.with("child2"), TestNode.with("child3"));
+
+        this.acceptMapAndCheck(NodeSelector.<TestNode, StringName, StringName, Object>firstChild().setToString(TOSTRING),
+                parent,
+                parent.setChild(0, TestNode.with("child1*0")));
+    }
+
+    @Test
     public void testEqualsDifferentWrappedNodeSelector() {
         this.checkNotEquals(CustomToStringNodeSelector.with(NodeSelector.<TestNode, StringName, StringName, Object>self(), TOSTRING));
     }

--- a/src/test/java/walkingkooka/tree/select/DescendantNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/DescendantNodeSelectorTest.java
@@ -72,10 +72,48 @@ final public class DescendantNodeSelectorTest extends
     public void testIgnoresSiblings() {
         final TestNode child = TestNode.with("child");
         final TestNode parent = TestNode.with("parent", child);
-        final TestNode siblingOfParent = TestNode.with("siblingOfParent", child);
+        final TestNode siblingOfParent = TestNode.with("siblingOfParent", TestNode.with("siblingOfParent-child"));
         final TestNode grandParent = TestNode.with("grandParent", parent, siblingOfParent);
 
         this.acceptAndCheck(parent, child);
+    }
+
+    @Test
+    public void testMapWithoutDescendants() {
+        this.acceptMapAndCheck(TestNode.with("without"));
+    }
+
+    @Test
+    public void testMap() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(0),
+                TestNode.with("grand",
+                        TestNode.with("parent1",
+                                TestNode.with("child1*0"), TestNode.with("child2*1")),
+                        TestNode.with("parent2", TestNode.with("child3")))
+                        .child(0));
+    }
+
+    @Test
+    public void testMap2() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent,
+                TestNode.with("grand",
+                        TestNode.with("parent1*0",
+                                TestNode.with("child1*1"), TestNode.with("child2*2")),
+                        TestNode.with("parent2*3", TestNode.with("child3*4"))));
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/select/DescendantOrSelfNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/DescendantOrSelfNodeSelectorTest.java
@@ -96,6 +96,39 @@ final public class DescendantOrSelfNodeSelectorTest extends
     }
 
     @Test
+    public void testMap() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(0),
+                TestNode.with("grand",
+                        TestNode.with("parent1*0",
+                                TestNode.with("child1*1"), TestNode.with("child2*2")),
+                        TestNode.with("parent2", TestNode.with("child3")))
+                        .child(0));
+    }
+
+    @Test
+    public void testMap2() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent,
+                TestNode.with("grand*0",
+                        TestNode.with("parent1*1",
+                                TestNode.with("child1*2"), TestNode.with("child2*3")),
+                        TestNode.with("parent2*4", TestNode.with("child3*5"))));
+    }
+
+    @Test
     public void testToString() {
         this.toStringAndCheck(this.createSelector(), "//");
     }

--- a/src/test/java/walkingkooka/tree/select/ExpressionNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/ExpressionNodeSelectorTest.java
@@ -54,6 +54,56 @@ final public class ExpressionNodeSelectorTest extends
     }
 
     @Test
+    public void testMapFalse() {
+        final TestNode node = TestNode.with("node");
+
+        this.acceptMapAndCheck(ExpressionNodeSelector.with(ExpressionNode.booleanNode(false)),
+                node);
+    }
+
+    @Test
+    public void testMapTrue() {
+        this.acceptMapAndCheck(ExpressionNodeSelector.with(ExpressionNode.booleanNode(true)),
+                TestNode.with("node"),
+                TestNode.with("node*0"));
+    }
+
+    @Test
+    public void testMapTrue2() {
+        final TestNode parent = TestNode.with("parent", TestNode.with("child"));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(ExpressionNodeSelector.with(ExpressionNode.booleanNode(true)),
+                parent.child(0),
+                TestNode.with("parent", TestNode.with("child*0")).child(0));
+    }
+
+    @Test
+    public void testMapNumberNegative() {
+        this.acceptMapAndCheck(ExpressionNodeSelector.with(ExpressionNode.longNode(-2)),
+                TestNode.with("node"));
+    }
+
+    @Test
+    public void testMapNumberOutOfRange() {
+        this.acceptMapAndCheck(ExpressionNodeSelector.with(ExpressionNode.longNode(999)),
+                TestNode.with("node"));
+    }
+
+    @Test
+    public void testMapNumberValidIndex() {
+        final TestNode parent = TestNode.with("parent", TestNode.with("child1"), TestNode.with("child2"));
+
+        TestNode.clear();
+
+        final int index = 1;
+        this.acceptMapAndCheck(ExpressionNodeSelector.with(ExpressionNode.longNode(NodeSelector.INDEX_BIAS + index)),
+                parent,
+                TestNode.with("parent", TestNode.with("child1"), TestNode.with("child2*0")));
+    }
+
+    @Test
     public void testToString() {
         this.toStringAndCheck(this.createSelector(), "*[" + expression() + "]");
     }

--- a/src/test/java/walkingkooka/tree/select/FakeNodeSelector.java
+++ b/src/test/java/walkingkooka/tree/select/FakeNodeSelector.java
@@ -29,12 +29,12 @@ class FakeNodeSelector extends NodeSelector<TestNode, StringName, StringName, Ob
     }
 
     @Override
-    void accept1(final TestNode node, final NodeSelectorContext<TestNode, StringName, StringName, Object> context) {
+    TestNode accept1(final TestNode node, final NodeSelectorContext<TestNode, StringName, StringName, Object> context) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    void select(TestNode node, NodeSelectorContext<TestNode, StringName, StringName, Object> context) {
+    TestNode select(TestNode node, NodeSelectorContext<TestNode, StringName, StringName, Object> context) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/walkingkooka/tree/select/FirstChildNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/FirstChildNodeSelectorTest.java
@@ -66,6 +66,37 @@ final public class FirstChildNodeSelectorTest extends
     }
 
     @Test
+    public void testMap() {
+        this.acceptMapAndCheck(TestNode.with("parent"));
+    }
+
+    @Test
+    public void testMap2() {
+        final TestNode parent = TestNode.with("parent",
+                TestNode.with("child1"), TestNode.with("child2"), TestNode.with("child3"));
+
+        this.acceptMapAndCheck(parent,
+                parent.setChild(0, TestNode.with("child1*0")));
+    }
+
+    @Test
+    public void testMap3() {
+        final TestNode grand = TestNode.with("grand-parent",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2"), TestNode.with("child3")),
+                TestNode.with("parent2", TestNode.with("child4")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grand.child(0),
+                TestNode.with("grand-parent",
+                        TestNode.with("parent1",
+                                TestNode.with("child1*0"), TestNode.with("child2"), TestNode.with("child3")),
+                        TestNode.with("parent2", TestNode.with("child4")))
+                        .child(0));
+    }
+
+    @Test
     public void testToString() {
         this.toStringAndCheck(this.createSelector(), "first-child::*");
     }

--- a/src/test/java/walkingkooka/tree/select/FollowingNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/FollowingNodeSelectorTest.java
@@ -40,10 +40,7 @@ final public class FollowingNodeSelectorTest extends
 
     @Test
     public void testChild() {
-        final TestNode child = TestNode.with("child");
-        final TestNode parent = TestNode.with("parent", child);
-
-        this.acceptAndCheck(parent, child);
+        this.acceptAndCheck(TestNode.with("parent", TestNode.with("child")));
     }
 
     @Test
@@ -94,7 +91,7 @@ final public class FollowingNodeSelectorTest extends
 
         final TestNode grandParent = TestNode.with("grandParent", parent, parentFollowingSibling);
 
-        this.acceptAndCheck(grandParent.child(0), child, parentFollowingSibling, parentFollowingSiblingChild);
+        this.acceptAndCheck(grandParent.child(0), parentFollowingSibling, parentFollowingSiblingChild);
     }
 
     @Test
@@ -119,6 +116,49 @@ final public class FollowingNodeSelectorTest extends
         final TestNode parent = TestNode.with("parent", preceding1, preceding2, self, following1, following2);
 
         this.acceptAndCheck(parent.child(2), following1, following2);
+    }
+
+    @Test
+    public void testMap() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")),
+                TestNode.with("parent3", TestNode.with("child4")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(1),
+                TestNode.with("grand",
+                        TestNode.with("parent1",
+                                TestNode.with("child1"), TestNode.with("child2")),
+                        TestNode.with("parent2", TestNode.with("child3")),
+                        TestNode.with("parent3*0", TestNode.with("child4*1")))
+                        .child(1));
+    }
+
+    @Test
+    public void testMapSeveralFollowingSiblings() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")),
+                TestNode.with("parent3", TestNode.with("child4")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(0),
+                TestNode.with("grand",
+                        TestNode.with("parent1",
+                                TestNode.with("child1"), TestNode.with("child2")),
+                        TestNode.with("parent2*0", TestNode.with("child3*1")),
+                        TestNode.with("parent3*2", TestNode.with("child4*3")))
+                        .child(0));
+    }
+
+    @Test
+    public void testMapWithoutFollowing() {
+        this.acceptMapAndCheck(TestNode.with("node123"));
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/select/FollowingSiblingNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/FollowingSiblingNodeSelectorTest.java
@@ -108,6 +108,49 @@ final public class FollowingSiblingNodeSelectorTest extends
     }
 
     @Test
+    public void testMap() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")),
+                TestNode.with("parent3", TestNode.with("child4")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(1),
+                TestNode.with("grand",
+                        TestNode.with("parent1",
+                                TestNode.with("child1"), TestNode.with("child2")),
+                        TestNode.with("parent2", TestNode.with("child3")),
+                        TestNode.with("parent3*0", TestNode.with("child4")))
+                        .child(1));
+    }
+
+    @Test
+    public void testMapSeveralFollowingSiblings() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")),
+                TestNode.with("parent3", TestNode.with("child4")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(0),
+                TestNode.with("grand",
+                        TestNode.with("parent1",
+                                TestNode.with("child1"), TestNode.with("child2")),
+                        TestNode.with("parent2*0", TestNode.with("child3")),
+                        TestNode.with("parent3*1", TestNode.with("child4")))
+                        .child(0));
+    }
+
+    @Test
+    public void testMapWithoutFollowingSiblings() {
+        this.acceptMapAndCheck(TestNode.with("node123"));
+    }
+
+    @Test
     public void testToString() {
         this.toStringAndCheck(this.createSelector(), "following-sibling::*");
     }

--- a/src/test/java/walkingkooka/tree/select/IndexedChildNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/IndexedChildNodeSelectorTest.java
@@ -75,6 +75,37 @@ final public class IndexedChildNodeSelectorTest extends
     }
 
     @Test
+    public void testMap() {
+        this.acceptMapAndCheck(TestNode.with("parent"));
+    }
+
+    @Test
+    public void testMap2() {
+        final TestNode parent = TestNode.with("parent",
+                TestNode.with("child1"), TestNode.with("child2"), TestNode.with("child3"));
+
+        this.acceptMapAndCheck(parent,
+                parent.setChild(1, TestNode.with("child2*0")));
+    }
+
+    @Test
+    public void testMap3() {
+        final TestNode grand = TestNode.with("grand-parent",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2"), TestNode.with("child3")),
+                TestNode.with("parent2", TestNode.with("child4")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grand.child(0),
+                TestNode.with("grand-parent",
+                        TestNode.with("parent1",
+                                TestNode.with("child1"), TestNode.with("child2*0"), TestNode.with("child3")),
+                        TestNode.with("parent2", TestNode.with("child4")))
+                        .child(0));
+    }
+
+    @Test
     public void testEqualsDifferentIndex() {
         this.createSelector(INDEX + 1, this.wrapped());
     }

--- a/src/test/java/walkingkooka/tree/select/LastChildNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/LastChildNodeSelectorTest.java
@@ -66,6 +66,37 @@ final public class LastChildNodeSelectorTest extends
     }
 
     @Test
+    public void testMap() {
+        this.acceptMapAndCheck(TestNode.with("parent"));
+    }
+
+    @Test
+    public void testMap2() {
+        final TestNode parent = TestNode.with("parent",
+                TestNode.with("child1"), TestNode.with("child2"), TestNode.with("child3"));
+
+        this.acceptMapAndCheck(parent,
+                parent.setChild(2, TestNode.with("child3*0")));
+    }
+
+    @Test
+    public void testMap3() {
+        final TestNode grand = TestNode.with("grand-parent",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2"), TestNode.with("child3")),
+                TestNode.with("parent2", TestNode.with("child4")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grand.child(0),
+                TestNode.with("grand-parent",
+                        TestNode.with("parent1",
+                                TestNode.with("child1"), TestNode.with("child2"), TestNode.with("child3*0")),
+                        TestNode.with("parent2", TestNode.with("child4")))
+                        .child(0));
+    }
+
+    @Test
     public void testToString() {
         this.toStringAndCheck(this.createSelector(), "last-child::*");
     }

--- a/src/test/java/walkingkooka/tree/select/NamedNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NamedNodeSelectorTest.java
@@ -77,6 +77,22 @@ final public class NamedNodeSelectorTest extends
     }
 
     @Test
+    public void testMap() {
+        final TestNode parent = TestNode.with("parent", TestNode.with(NAME.value()), TestNode.with("child"));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(parent.child(0),
+                TestNode.with("parent", TestNode.with(NAME.value() + "*0"), TestNode.with("child"))
+                        .child(0));
+    }
+
+    @Test
+    public void testMapUnmatched() {
+        this.acceptMapAndCheck(TestNode.with("different"));
+    }
+
+    @Test
     public void testEqualsDifferentName() {
         this.checkNotEquals(this.createSelector(Names.string("different-name-2"),
                 SEPARATOR,
@@ -85,7 +101,7 @@ final public class NamedNodeSelectorTest extends
 
     @Test
     public void testEqualsDifferentPathSeparator() {
-        this.checkNotEquals(this.createSelector(this.name(),
+        this.checkNotEquals(this.createSelector(NAME,
                 PathSeparator.requiredAtStart('.'),
                 this.wrapped()));
     }
@@ -128,9 +144,5 @@ final public class NamedNodeSelectorTest extends
                                                                                        final PathSeparator pathSeparator,
                                                                                        final NodeSelector<TestNode, StringName, StringName, Object> selector) {
         return Cast.to(NamedNodeSelector.<TestNode, StringName, StringName, Object>with(name, pathSeparator).append(selector));
-    }
-
-    private StringName name() {
-        return Names.string("name1");
     }
 }

--- a/src/test/java/walkingkooka/tree/select/NodePredicateNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodePredicateNodeSelectorTest.java
@@ -34,7 +34,8 @@ final public class NodePredicateNodeSelectorTest extends
 
     // constants
 
-    private final static Predicate<TestNode> PREDICATE = (n) -> n.name().value().equals("self");
+    private final static String MAGIC_VALUE = "self";
+    private final static Predicate<TestNode> PREDICATE = (n) -> n.name().value().equals(MAGIC_VALUE);
 
     @Test
     public void testWithNullPredicateFails() {
@@ -52,11 +53,22 @@ final public class NodePredicateNodeSelectorTest extends
     @Test
     public void testIgnoresNonSelfNodes() {
         final TestNode siblingBefore = TestNode.with("siblingBefore");
-        final TestNode self = TestNode.with("self", TestNode.with("child"));
+        final TestNode self = TestNode.with(MAGIC_VALUE, TestNode.with("child"));
         final TestNode siblingAfter = TestNode.with("siblingAfter");
         final TestNode parent = TestNode.with("parent", siblingBefore, self, siblingAfter);
 
         this.acceptAndCheck(parent.child(1), self);
+    }
+
+    @Test
+    public void testMap() {
+        final TestNode parent = TestNode.with("parent", TestNode.with(MAGIC_VALUE), TestNode.with("child"));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(parent.child(0),
+                TestNode.with("parent", TestNode.with(MAGIC_VALUE + "*0"), TestNode.with("child"))
+                        .child(0));
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
@@ -849,10 +849,17 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
         final TestNode leaf2 = node("leaf2");
         final TestNode branch2 = node("branch2", leaf2);
 
-        final TestNode root = node("root", branch1, branch2);
+        final TestNode leaf3 = node("leaf3");
+        final TestNode branch3 = node("branch3", leaf3);
 
-        this.parseExpressionAndCheck("following::*", root, branch1, leaf1, branch2, leaf2);
-        this.parseExpressionAndCheck("following::*", root.child(0), leaf1, branch2, leaf2);
+        final TestNode leaf4 = node("leaf4");
+        final TestNode branch4 = node("branch4", leaf4);
+        
+        final TestNode root = node("root", branch1, branch2, branch3, branch4);
+
+        this.parseExpressionAndCheck("following::*", root);
+        this.parseExpressionAndCheck("following::*", root.child(0), branch2, leaf2, branch3, leaf3, branch4, leaf4);
+        this.parseExpressionAndCheck("following::*", root.child(1), branch3, leaf3, branch4, leaf4);
     }
 
     // following-sibling...........................................................................................
@@ -955,10 +962,17 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
         final TestNode leaf2 = node("leaf2");
         final TestNode branch2 = node("branch2", leaf2);
 
-        final TestNode root = node("root", branch1, branch2);
+        final TestNode leaf3 = node("leaf3");
+        final TestNode branch3 = node("branch3", leaf3);
 
-        this.parseExpressionAndCheck("preceding::*", root.child(0), leaf1);
-        this.parseExpressionAndCheck("preceding::*", root.child(1), leaf2, branch1, leaf1);
+        final TestNode leaf4 = node("leaf4");
+        final TestNode branch4 = node("branch4", leaf4);
+
+        final TestNode root = node("root", branch1, branch2, branch3, branch4);
+
+        this.parseExpressionAndCheck("preceding::*", root.child(0));
+        this.parseExpressionAndCheck("preceding::*", root.child(1), branch1, leaf1);
+        this.parseExpressionAndCheck("preceding::*", root.child(2), branch2, leaf2, branch1, leaf1);
     }
 
     // preceding-sibling...........................................................................................
@@ -1185,8 +1199,9 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
             private TestNode node;
 
             @Override
-            public void selected(final TestNode node) {
+            public TestNode selected(final TestNode node) {
                 selected.add(node);
+                return node;
             }
 
             @Override

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase2.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase2.java
@@ -54,7 +54,7 @@ public abstract class NodeSelectorTestCase2<S extends NodeSelector<TestNode, Str
             int i = 0;
 
             @Override
-            public void selected(final TestNode node) {
+            public TestNode selected(final TestNode node) {
                 if (i == nodes.length) {
                     Assertions.fail("Unexpected matching node: " + node);
                 }
@@ -64,6 +64,8 @@ public abstract class NodeSelectorTestCase2<S extends NodeSelector<TestNode, Str
                 }
                 expected.remove(0);
                 i++;
+
+                return node;
             }
         });
 

--- a/src/test/java/walkingkooka/tree/select/NonLogicalNodeSelectorTestCase.java
+++ b/src/test/java/walkingkooka/tree/select/NonLogicalNodeSelectorTestCase.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public abstract class NonLogicalNodeSelectorTestCase<S extends NodeSelector<TestNode, StringName, StringName, Object>>
         extends NodeSelectorTestCase<S> {
@@ -53,8 +54,9 @@ public abstract class NonLogicalNodeSelectorTestCase<S extends NodeSelector<Test
                                             final TestNode start,
                                             final String[] nodes) {
         final Set<TestNode> selected = Sets.ordered();
-        selector.accept(start, context((n) -> {
-        }, (n) -> selected.add(n)));
+        assertSame(start,
+                selector.accept(start, context((n) -> {
+                }, (n) -> selected.add(n))));
         final List<String> selectedNames = selected
                 .stream()
                 .map(n -> n.name().value())

--- a/src/test/java/walkingkooka/tree/select/OrNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/OrNodeSelectorTest.java
@@ -67,6 +67,22 @@ public final class OrNodeSelectorTest extends
                 child, root);
     }
 
+    @Test
+    public void testMap() {
+        final TestNode grandParent = TestNode.with("grandParent",
+                TestNode.with("parent1", TestNode.with("child1")),
+                TestNode.with("parent2", TestNode.with("child2")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(this.createSelector0(ChildrenNodeSelector.get(), AncestorNodeSelector.get()),
+                grandParent.child(0), // parent1
+                TestNode.with("grandParent*1",
+                        TestNode.with("parent1", TestNode.with("child1*0")),
+                        TestNode.with("parent2", TestNode.with("child2")))
+                        .child(0));
+    }
+
     @Override
     final NodeSelector<TestNode, StringName, StringName, Object> createSelector0(final List<NodeSelector<TestNode, StringName, StringName, Object>> selectors) {
         return OrNodeSelector.with(selectors);

--- a/src/test/java/walkingkooka/tree/select/ParentNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/ParentNodeSelectorTest.java
@@ -67,6 +67,26 @@ final public class ParentNodeSelectorTest
     }
 
     @Test
+    public void testMap() {
+        final TestNode parent = TestNode.with("parent", TestNode.with("child"));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(parent.child(0),
+                TestNode.with("parent*0", TestNode.with("child"))
+                        .child(0));
+    }
+
+    @Test
+    public void testMapWithoutParent() {
+        final TestNode parent = TestNode.with("parent", TestNode.with("child"));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(parent);
+    }
+
+    @Test
     public void testToString() {
         this.toStringAndCheck(this.createSelector(), "..");
     }

--- a/src/test/java/walkingkooka/tree/select/PathNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/PathNodeSelectorTest.java
@@ -79,6 +79,49 @@ final public class PathNodeSelectorTest extends
     }
 
     @Test
+    public void testMapSelf() {
+        final TestNode parent = TestNode.with("parent",
+                TestNode.with("child1"), TestNode.with("child2"));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(PathNodeSelector.with(parent),
+                parent,
+                TestNode.with("parent*0",
+                        TestNode.with("child1"), TestNode.with("child2")));
+    }
+
+    @Test
+    public void testMapChild() {
+        final TestNode parent = TestNode.with("parent",
+                TestNode.with("child1"), TestNode.with("child2"));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(PathNodeSelector.with(parent.child(0)),
+                parent,
+                TestNode.with("parent",
+                        TestNode.with("child1*0"), TestNode.with("child2")));
+    }
+
+    @Test
+    public void testMapGrandChild() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(PathNodeSelector.with(grandParent.child(0).child(1)),
+                grandParent,
+                TestNode.with("grand",
+                        TestNode.with("parent1",
+                                TestNode.with("child1"), TestNode.with("child2*0")),
+                        TestNode.with("parent2", TestNode.with("child3"))));
+    }
+
+    @Test
     public void testEqualsDifferentNode() {
         this.checkNotEquals(this.createSelector(
                 TestNode.with("different-parent", TestNode.with("different-child-1"), TestNode.with("different-child-2")).child(1),

--- a/src/test/java/walkingkooka/tree/select/PrecedingNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/PrecedingNodeSelectorTest.java
@@ -40,10 +40,7 @@ final public class PrecedingNodeSelectorTest extends
 
     @Test
     public void testChild() {
-        final TestNode child = TestNode.with("child");
-        final TestNode parent = TestNode.with("parent", child);
-
-        this.acceptAndCheck(parent, child);
+        this.acceptAndCheck(TestNode.with("parent", TestNode.with("child")));
     }
 
     @Test
@@ -133,6 +130,49 @@ final public class PrecedingNodeSelectorTest extends
         final TestNode parent = TestNode.with("parent", preceding1, preceding2, self, following1, following2);
 
         this.acceptAndCheck(parent.child(2), preceding2, preceding1);
+    }
+
+    @Test
+    public void testMap() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")),
+                TestNode.with("parent3", TestNode.with("child4")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(1),
+                TestNode.with("grand",
+                        TestNode.with("parent1*0",
+                                TestNode.with("child1*1"), TestNode.with("child2*2")),
+                        TestNode.with("parent2", TestNode.with("child3")),
+                        TestNode.with("parent3", TestNode.with("child4")))
+                        .child(1));
+    }
+
+    @Test
+    public void testMapSeveralPreceding() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")),
+                TestNode.with("parent3", TestNode.with("child4")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(2),
+                TestNode.with("grand",
+                        TestNode.with("parent1*1",
+                                TestNode.with("child1"), TestNode.with("child2")),
+                        TestNode.with("parent2*0", TestNode.with("child3")),
+                        TestNode.with("parent3", TestNode.with("child4")))
+                        .child(2));
+    }
+
+    @Test
+    public void testMapWithoutPreceding() {
+        this.acceptMapAndCheck(TestNode.with("node123"));
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/select/PrecedingSiblingNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/PrecedingSiblingNodeSelectorTest.java
@@ -95,6 +95,49 @@ final public class PrecedingSiblingNodeSelectorTest extends
     }
 
     @Test
+    public void testMap() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")),
+                TestNode.with("parent3", TestNode.with("child4")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(1),
+                TestNode.with("grand",
+                        TestNode.with("parent1*0",
+                                TestNode.with("child1"), TestNode.with("child2")),
+                        TestNode.with("parent2", TestNode.with("child3")),
+                        TestNode.with("parent3", TestNode.with("child4")))
+                        .child(1));
+    }
+
+    @Test
+    public void testMapSeveralPrecedingSiblings() {
+        final TestNode grandParent = TestNode.with("grand",
+                TestNode.with("parent1",
+                        TestNode.with("child1"), TestNode.with("child2")),
+                TestNode.with("parent2", TestNode.with("child3")),
+                TestNode.with("parent3", TestNode.with("child4")));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(grandParent.child(2),
+                TestNode.with("grand",
+                        TestNode.with("parent1*1",
+                                TestNode.with("child1"), TestNode.with("child2")),
+                        TestNode.with("parent2*0", TestNode.with("child3")),
+                        TestNode.with("parent3", TestNode.with("child4")))
+                        .child(2));
+    }
+
+    @Test
+    public void testMapWithoutPrecedingSiblings() {
+        this.acceptMapAndCheck(TestNode.with("node123"));
+    }
+
+    @Test
     public void testToString() {
         this.toStringAndCheck(this.createSelector(), "preceding-sibling::*");
     }

--- a/src/test/java/walkingkooka/tree/select/SelfNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/SelfNodeSelectorTest.java
@@ -76,6 +76,16 @@ final public class SelfNodeSelectorTest
                 child);
     }
 
+    @Test
+    public void testMap() {
+        final TestNode parent = TestNode.with("parent", TestNode.with("child"));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(parent,
+                TestNode.with("parent*0", TestNode.with("child")));
+    }
+
     private NodeSelector<TestNode, StringName, StringName, Object> selfAndNamed() {
         return Cast.to(SelfNodeSelector.get()
                 .append(NamedNodeSelector.with(Names.string("child"), PathSeparator.requiredAtStart('/'))));

--- a/src/test/java/walkingkooka/tree/select/TerminalNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/TerminalNodeSelectorTest.java
@@ -26,6 +26,18 @@ final public class TerminalNodeSelectorTest
         extends NodeSelectorTestCase2<TerminalNodeSelector<TestNode, StringName, StringName, Object>> {
 
     @Test
+    public void testMap() {
+        final TestNode parent = TestNode.with("parent",
+                TestNode.with("child1"), TestNode.with("child2"), TestNode.with("child3"));
+
+        TestNode.clear();
+
+        this.acceptMapAndCheck(parent,
+                TestNode.with("parent*0",
+                        TestNode.with("child1"), TestNode.with("child2"), TestNode.with("child3")));
+    }
+
+    @Test
     public void testToString() {
         this.toStringAndCheck(this.createSelector(), "");
     }


### PR DESCRIPTION
- FollowingNodeSelector & PrecedingNodeSelector no longer select children.
- Node.replace includes an equals test to short circuit to exit early.

- Completes #1180