### PR TITLE
NodeSelector PathSeparator removed

### DIFF
--- a/src/main/java/walkingkooka/naming/PathSeparator.java
+++ b/src/main/java/walkingkooka/naming/PathSeparator.java
@@ -19,8 +19,6 @@ package walkingkooka.naming;
 
 import walkingkooka.test.HashCodeEqualsDefined;
 import walkingkooka.text.CharSequences;
-import walkingkooka.tree.Node;
-import walkingkooka.tree.select.NodeSelectorBuilder;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -131,26 +129,6 @@ final public class PathSeparator implements HashCodeEqualsDefined, Serializable 
                     (this.requiredAtStart ? "is missing" : "should not start with") +
                     " " + CharSequences.quote(this.string) + " " + CharSequences.quote(path));
         }
-    }
-
-    /**
-     * Factory that creates a {@link NodeSelectorBuilder} with an absolute path.
-     */
-    public <N extends Node<N, NAME, ANAME, AVALUE>,
-            NAME extends Name,
-            ANAME extends Name,
-            AVALUE> NodeSelectorBuilder<N, NAME, ANAME, AVALUE> absoluteNodeSelectorBuilder(final Class<N> node) {
-        return NodeSelectorBuilder.absolute(node, this);
-    }
-
-    /**
-     * Factory that creates a {@link NodeSelectorBuilder} with an relative path.
-     */
-    public <N extends Node<N, NAME, ANAME, AVALUE>,
-            NAME extends Name,
-            ANAME extends Name,
-            AVALUE> NodeSelectorBuilder<N, NAME, ANAME, AVALUE> relativeNodeSelectorBuilder(final Class<N> node) {
-        return NodeSelectorBuilder.relative(node, this);
     }
 
     // Serializable

--- a/src/main/java/walkingkooka/net/header/LinkRelationConstantGenerator.java
+++ b/src/main/java/walkingkooka/net/header/LinkRelationConstantGenerator.java
@@ -24,6 +24,7 @@ import walkingkooka.io.printer.Printers;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.tree.expression.ExpressionNodeName;
 import walkingkooka.tree.expression.function.ExpressionFunction;
+import walkingkooka.tree.select.NodeSelectorBuilder;
 import walkingkooka.tree.select.NodeSelectorContexts;
 import walkingkooka.tree.xml.XmlAttributeName;
 import walkingkooka.tree.xml.XmlDocument;
@@ -48,7 +49,7 @@ final class LinkRelationConstantGenerator {
     public static void main(final String[] args) throws Exception {
         final XmlDocument document = XmlDocument.fromXml(DocumentBuilderFactory.newInstance().newDocumentBuilder(),
                 file());
-        XmlNode.PATH_SEPARATOR.absoluteNodeSelectorBuilder(XmlNode.class)
+        NodeSelectorBuilder.absolute(XmlNode.class)
                 .descendant()
                 .named(XmlName.element("record"))
                 .build()

--- a/src/main/java/walkingkooka/text/cursor/parser/ParserTokenNode.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserTokenNode.java
@@ -19,7 +19,6 @@ package walkingkooka.text.cursor.parser;
 import walkingkooka.Cast;
 import walkingkooka.Value;
 import walkingkooka.collect.map.Maps;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.text.CharSequences;
 import walkingkooka.tree.HasChildrenValues;
 import walkingkooka.tree.Node;
@@ -36,11 +35,6 @@ import java.util.Optional;
 public abstract class ParserTokenNode implements Node<ParserTokenNode, ParserTokenNodeName, ParserTokenNodeAttributeName, String>,
         HasChildrenValues<ParserToken, ParserTokenNode>,
         Value<ParserToken> {
-
-    /**
-     * The {@link PathSeparator} for node selector paths.
-     */
-    public static final PathSeparator PATH_SEPARATOR = PathSeparator.requiredAtStart('/');
 
     /**
      * Wraps the provided node.

--- a/src/main/java/walkingkooka/tree/TraversableTesting.java
+++ b/src/main/java/walkingkooka/tree/TraversableTesting.java
@@ -20,16 +20,12 @@ package walkingkooka.tree;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.test.BeanPropertiesTesting;
 import walkingkooka.test.HashCodeEqualsDefined;
 import walkingkooka.test.HashCodeEqualsDefinedTesting;
 import walkingkooka.test.ToStringTesting;
 import walkingkooka.test.TypeNameTesting;
-import walkingkooka.type.FieldAttributes;
-import walkingkooka.type.MemberVisibility;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,15 +41,6 @@ public interface TraversableTesting<T extends Traversable<T> & HashCodeEqualsDef
         HashCodeEqualsDefinedTesting<T>,
         ToStringTesting<T>,
         TypeNameTesting<T> {
-
-    @Test
-    default void testPathSeparatorConstant() throws Exception {
-        final Field field = this.type().getField("PATH_SEPARATOR");
-
-        assertEquals(MemberVisibility.PUBLIC, MemberVisibility.get(field), () -> "PATH_SEPARATOR constant must be public=" + field);
-        assertEquals(true, FieldAttributes.STATIC.is(field), () -> "PATH_SEPARATOR constant must be static=" + field);
-        assertEquals(PathSeparator.class, field.getType(), () -> "PATH_SEPARATOR constant type=" + field);
-    }
 
     @Test
     default void testParentCached() {

--- a/src/main/java/walkingkooka/tree/expression/ExpressionNode.java
+++ b/src/main/java/walkingkooka/tree/expression/ExpressionNode.java
@@ -22,7 +22,6 @@ import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.naming.Name;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.text.CharSequences;
 import walkingkooka.tree.Node;
 import walkingkooka.tree.json.HasJsonNode;
@@ -50,11 +49,6 @@ public abstract class ExpressionNode implements Node<ExpressionNode, ExpressionN
                                                     final Class<N> type) {
         HasJsonNode.register("expression" + suffix, factory, type);
     }
-
-    /**
-     * The {@link PathSeparator} for node selector paths.
-     */
-    public static final PathSeparator PATH_SEPARATOR = PathSeparator.requiredAtStart('/');
 
     /**
      * An empty list that holds no children.

--- a/src/main/java/walkingkooka/tree/file/FilesystemNode.java
+++ b/src/main/java/walkingkooka/tree/file/FilesystemNode.java
@@ -20,7 +20,6 @@ package walkingkooka.tree.file;
 
 import walkingkooka.Cast;
 import walkingkooka.Value;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.HasText;
 import walkingkooka.tree.Node;
@@ -72,11 +71,6 @@ public abstract class FilesystemNode implements Node<FilesystemNode, FilesystemN
         Objects.requireNonNull(path, "path");
         Objects.requireNonNull(context, "context");
     }
-
-    /**
-     * The {@link PathSeparator} for node selector paths.
-     */
-    public static final PathSeparator PATH_SEPARATOR = PathSeparator.requiredAtStart('/');
 
     /**
      * Package private to limit sub classing.

--- a/src/main/java/walkingkooka/tree/json/JsonNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonNode.java
@@ -25,7 +25,6 @@ import walkingkooka.io.printer.IndentingPrinters;
 import walkingkooka.io.printer.Printer;
 import walkingkooka.io.printer.Printers;
 import walkingkooka.naming.Name;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.test.HashCodeEqualsDefined;
 import walkingkooka.text.HasText;
 import walkingkooka.text.Indentation;
@@ -107,11 +106,6 @@ public abstract class JsonNode implements Node<JsonNode, JsonNodeName, Name, Obj
     public static JsonStringNode string(final String value) {
         return JsonStringNode.with(value);
     }
-
-    /**
-     * The {@link PathSeparator} for node selector paths.
-     */
-    public static final PathSeparator PATH_SEPARATOR = PathSeparator.notRequiredAtStart('/');
 
     private final static Optional<JsonNode> NO_PARENT = Optional.empty();
 

--- a/src/main/java/walkingkooka/tree/pojo/PojoNode.java
+++ b/src/main/java/walkingkooka/tree/pojo/PojoNode.java
@@ -44,11 +44,6 @@ public abstract class PojoNode implements Node<PojoNode, PojoName, PojoNodeAttri
         Value<Object>,
         Comparable<PojoNode> {
 
-    /**
-     * The {@link PathSeparator} for node selector paths.
-     */
-    public static final PathSeparator PATH_SEPARATOR = PathSeparator.requiredAtStart('/');
-
     private final static Optional<PojoNode> NO_PARENT = Optional.empty();
 
     /**

--- a/src/main/java/walkingkooka/tree/search/SearchNode.java
+++ b/src/main/java/walkingkooka/tree/search/SearchNode.java
@@ -21,7 +21,6 @@ package walkingkooka.tree.search;
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.HasText;
 import walkingkooka.tree.Node;
@@ -44,11 +43,6 @@ import java.util.function.Function;
 public abstract class SearchNode implements Node<SearchNode, SearchNodeName, SearchNodeAttributeName, String>,
         HasText,
         TraversableHasTextOffset<SearchNode>  {
-
-    /**
-     * The {@link PathSeparator} for node selector paths.
-     */
-    public static final PathSeparator PATH_SEPARATOR = PathSeparator.requiredAtStart('/');
 
     /**
      * An empty list with no children.

--- a/src/main/java/walkingkooka/tree/select/AbsoluteNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/AbsoluteNodeSelector.java
@@ -16,8 +16,8 @@
  */
 package walkingkooka.tree.select;
 
+import walkingkooka.Cast;
 import walkingkooka.naming.Name;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.tree.Node;
 import walkingkooka.tree.pointer.NodePointer;
 
@@ -32,19 +32,20 @@ final class AbsoluteNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
         NonLogicalNodeSelector<N, NAME, ANAME, AVALUE> {
 
     /**
-     * Type safe {@link AbsoluteNodeSelector} factory
+     * Type safe {@link AbsoluteNodeSelector} getter
      */
-    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> AbsoluteNodeSelector<N, NAME, ANAME, AVALUE> with(final PathSeparator separator) {
-        Objects.requireNonNull(separator, "separator");
-        return new AbsoluteNodeSelector<N, NAME, ANAME, AVALUE>(separator, NodeSelector.terminal());
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> AbsoluteNodeSelector<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(INSTANCE);
     }
+
+    @SuppressWarnings("unchecked")
+    private final static AbsoluteNodeSelector INSTANCE = new AbsoluteNodeSelector(NodeSelector.terminal());
 
     /**
      * Private constructor
      */
-    private AbsoluteNodeSelector(final PathSeparator separator, final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+    private AbsoluteNodeSelector(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
         super(selector);
-        this.separator = separator;
     }
 
     // NodeSelector
@@ -56,7 +57,7 @@ final class AbsoluteNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
                 this :
                 selector instanceof DescendantNodeSelector ?
                         selector :
-                        new AbsoluteNodeSelector<N, NAME, ANAME, AVALUE>(this.separator, selector);
+                        new AbsoluteNodeSelector<N, NAME, ANAME, AVALUE>(selector);
     }
 
     @Override
@@ -68,21 +69,18 @@ final class AbsoluteNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME ex
 
     @Override
     final int hashCode0(final NodeSelector<N, NAME, ANAME, AVALUE> next) {
-        return Objects.hash(this.separator, next);
+        return Objects.hash(next);
     }
 
     @Override
     final boolean equals1(final NonLogicalNodeSelector<?, ?, ?, ?> other) {
-        return this.separator.equals(AbsoluteNodeSelector.class.cast(other).separator);
+        return true;
     }
 
     @Override
     void toString1(final NodeSelectorToStringBuilder b) {
-        b.absolute(this.separator);
+        b.absolute();
     }
-
-    // ignore in hashcode / equals...
-    private final PathSeparator separator;
 
     @Override
     boolean canBeEqual(final Object other) {

--- a/src/main/java/walkingkooka/tree/select/DescendantOrSelfNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/DescendantOrSelfNodeSelector.java
@@ -18,11 +18,9 @@
 
 package walkingkooka.tree.select;
 
+import walkingkooka.Cast;
 import walkingkooka.naming.Name;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.tree.Node;
-
-import java.util.Objects;
 
 
 /**
@@ -35,17 +33,18 @@ final class DescendantOrSelfNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
     /**
      * Type safe {@link DescendantOrSelfNodeSelector} getter
      */
-    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> DescendantOrSelfNodeSelector<N, NAME, ANAME, AVALUE> with(final PathSeparator separator) {
-        Objects.requireNonNull(separator, "separator");
-        return new DescendantOrSelfNodeSelector<N, NAME, ANAME, AVALUE>(separator, NodeSelector.terminal());
+    static <N extends Node<N, NAME, ANAME, AVALUE>, NAME extends Name, ANAME extends Name, AVALUE> DescendantOrSelfNodeSelector<N, NAME, ANAME, AVALUE> get() {
+        return Cast.to(INSTANCE);
     }
+
+    @SuppressWarnings("unchecked")
+    private final static DescendantOrSelfNodeSelector INSTANCE = new DescendantOrSelfNodeSelector(NodeSelector.terminal());
 
     /**
      * Private constructor
      */
-    private DescendantOrSelfNodeSelector(final PathSeparator separator, final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+    private DescendantOrSelfNodeSelector(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
         super(selector);
-        this.separator = separator;
     }
 
     // NodeSelector
@@ -54,7 +53,7 @@ final class DescendantOrSelfNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
         // no point appending a descending to another...
         return selector instanceof DescendantOrSelfNodeSelector ?
                 this :
-                new DescendantOrSelfNodeSelector<>(this.separator, selector);
+                new DescendantOrSelfNodeSelector<>(selector);
     }
 
     @Override
@@ -71,11 +70,8 @@ final class DescendantOrSelfNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
 
     @Override
     void toString1(final NodeSelectorToStringBuilder b) {
-        b.descendantOrSelf(this.separator);
+        b.descendantOrSelf();
     }
-
-    // ignore in hashcode / equals...
-    private final PathSeparator separator;
 
     @Override
     boolean canBeEqual(final Object other) {

--- a/src/main/java/walkingkooka/tree/select/NamedNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/NamedNodeSelector.java
@@ -19,7 +19,6 @@ package walkingkooka.tree.select;
 
 import walkingkooka.Cast;
 import walkingkooka.naming.Name;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.tree.Node;
 
 import java.util.Objects;
@@ -37,27 +36,25 @@ final class NamedNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME exten
     static <N extends Node<N, NAME, ANAME, AVALUE>,
             NAME extends Name,
             ANAME extends Name,
-            AVALUE> NamedNodeSelector<N, NAME, ANAME, AVALUE> with(final NAME name, final PathSeparator separator) {
+            AVALUE> NamedNodeSelector<N, NAME, ANAME, AVALUE> with(final NAME name) {
         Objects.requireNonNull(name, "name");
-        Objects.requireNonNull(separator, "separator");
 
-        return new NamedNodeSelector<N, NAME, ANAME, AVALUE>(name, separator, NodeSelector.terminal());
+        return new NamedNodeSelector<N, NAME, ANAME, AVALUE>(name, NodeSelector.terminal());
     }
 
     /**
      * Private constructor
      */
-    private NamedNodeSelector(final NAME name, final PathSeparator separator, final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
+    private NamedNodeSelector(final NAME name, final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
         super(selector);
         this.name = name;
-        this.separator = separator;
     }
 
     // NodeSelector
 
     @Override
     NodeSelector<N, NAME, ANAME, AVALUE> append1(final NodeSelector<N, NAME, ANAME, AVALUE> selector) {
-        return new NamedNodeSelector<>(this.name, this.separator, selector);
+        return new NamedNodeSelector<>(this.name, selector);
     }
 
     @Override
@@ -71,11 +68,8 @@ final class NamedNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME exten
 
     @Override
     void toString1(final NodeSelectorToStringBuilder b) {
-        b.separator(this.separator);
         b.node(this.name.value());
     }
-
-    private final PathSeparator separator;
 
     @Override
     int hashCode0(final NodeSelector<N, NAME, ANAME, AVALUE> next) {
@@ -93,7 +87,6 @@ final class NamedNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME exten
     }
 
     private boolean equals2(final NamedNodeSelector<N, NAME, ANAME, AVALUE> other) {
-        return this.name.equals(other.name) &&
-                this.separator.equals(other.separator);
+        return this.name.equals(other.name);
     }
 }

--- a/src/main/java/walkingkooka/tree/select/NodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelector.java
@@ -18,8 +18,8 @@
 package walkingkooka.tree.select;
 
 import walkingkooka.naming.Name;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.test.HashCodeEqualsDefined;
+import walkingkooka.text.CharacterConstant;
 import walkingkooka.text.cursor.parser.select.NodeSelectorExpressionParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorNodeName;
 import walkingkooka.text.cursor.parser.select.NodeSelectorParserToken;
@@ -40,6 +40,11 @@ public abstract class NodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
         NAME extends Name,
         ANAME extends Name,
         AVALUE> implements HashCodeEqualsDefined {
+
+    /**
+     * Path separator
+     */
+    final static CharacterConstant SEPARATOR = CharacterConstant.with('/');
 
     /**
      * Creates a {@link NodeSelector} from a {@link NodeSelectorParserToken}.
@@ -68,8 +73,8 @@ public abstract class NodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
     static <N extends Node<N, NAME, ANAME, AVALUE>,
             NAME extends Name,
             ANAME extends Name,
-            AVALUE> AbsoluteNodeSelector<N, NAME, ANAME, AVALUE> absolute(final PathSeparator separator) {
-        return AbsoluteNodeSelector.with(separator);
+            AVALUE> AbsoluteNodeSelector<N, NAME, ANAME, AVALUE> absolute() {
+        return AbsoluteNodeSelector.get();
     }
 
     /**
@@ -166,8 +171,8 @@ public abstract class NodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
             NAME extends Name,
             ANAME extends Name,
             AVALUE>
-    DescendantOrSelfNodeSelector<N, NAME, ANAME, AVALUE> descendantOrSelf(final PathSeparator separator) {
-        return DescendantOrSelfNodeSelector.with(separator);
+    DescendantOrSelfNodeSelector<N, NAME, ANAME, AVALUE> descendantOrSelf() {
+        return DescendantOrSelfNodeSelector.get();
     }
 
     /**
@@ -242,8 +247,8 @@ public abstract class NodeSelector<N extends Node<N, NAME, ANAME, AVALUE>,
             NAME extends Name,
             ANAME extends Name,
             AVALUE>
-    NamedNodeSelector<N, NAME, ANAME, AVALUE> name(final NAME name, final PathSeparator separator) {
-        return NamedNodeSelector.with(name, separator);
+    NamedNodeSelector<N, NAME, ANAME, AVALUE> name(final NAME name) {
+        return NamedNodeSelector.with(name);
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorBuilder.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorBuilder.java
@@ -21,7 +21,6 @@ import walkingkooka.build.Builder;
 import walkingkooka.build.BuilderException;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.naming.Name;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.tree.Node;
 import walkingkooka.tree.expression.ExpressionNode;
 
@@ -39,10 +38,9 @@ public final class NodeSelectorBuilder<N extends Node<N, NAME, ANAME, AVALUE>, N
     public static <N extends Node<N, NAME, ANAME, AVALUE>,
             NAME extends Name,
             ANAME extends Name,
-            AVALUE> NodeSelectorBuilder<N, NAME, ANAME, AVALUE> absolute(final Class<N> node,
-                                                                         final PathSeparator separator) {
-        check(node, separator);
-        return new NodeSelectorBuilder<N, NAME, ANAME, AVALUE>(separator).absolute();
+            AVALUE> NodeSelectorBuilder<N, NAME, ANAME, AVALUE> absolute(final Class<N> node) {
+        check(node);
+        return new NodeSelectorBuilder<N, NAME, ANAME, AVALUE>().append(AbsoluteNodeSelector.get());
     }
 
     /**
@@ -51,35 +49,23 @@ public final class NodeSelectorBuilder<N extends Node<N, NAME, ANAME, AVALUE>, N
     public static <N extends Node<N, NAME, ANAME, AVALUE>,
             NAME extends Name,
             ANAME extends Name,
-            AVALUE> NodeSelectorBuilder<N, NAME, ANAME, AVALUE> relative(final Class<N> node,
-                                                                         final PathSeparator separator) {
-        check(node, separator);
-        return new NodeSelectorBuilder<>(separator);
+            AVALUE> NodeSelectorBuilder<N, NAME, ANAME, AVALUE> relative(final Class<N> node) {
+        check(node);
+        return new NodeSelectorBuilder<>();
     }
 
     /**
      * Checks the parameters are not null.
      */
-    private static void check(final Class<?> node, final PathSeparator separator) {
+    private static void check(final Class<?> node) {
         Objects.requireNonNull(node, "node");
-        Objects.requireNonNull(separator, "separator");
     }
 
     /**
      * Private ctor use factory.
      */
-    private NodeSelectorBuilder(final PathSeparator separator) {
+    private NodeSelectorBuilder() {
         super();
-        this.separator = separator;
-    }
-
-    private final PathSeparator separator;
-
-    /**
-     * {@see AncestorNodeSelector}
-     */
-    public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> absolute() {
-        return this.append(AbsoluteNodeSelector.with(this.separator));
     }
 
     /**
@@ -164,7 +150,7 @@ public final class NodeSelectorBuilder<N extends Node<N, NAME, ANAME, AVALUE>, N
      * {@see DescendantOrSelfNodeSelector}
      */
     public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> descendantOrSelf() {
-        return this.append(DescendantOrSelfNodeSelector.with(this.separator));
+        return this.append(DescendantOrSelfNodeSelector.get());
     }
 
     /**
@@ -206,7 +192,7 @@ public final class NodeSelectorBuilder<N extends Node<N, NAME, ANAME, AVALUE>, N
      * {@see NamedNodeSelector}
      */
     public NodeSelectorBuilder<N, NAME, ANAME, AVALUE> named(final NAME name) {
-        return this.append(NamedNodeSelector.with(name, this.separator));
+        return this.append(NamedNodeSelector.with(name));
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitor.java
@@ -20,7 +20,6 @@ package walkingkooka.tree.select;
 
 import walkingkooka.collect.list.Lists;
 import walkingkooka.naming.Name;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.text.cursor.parser.select.NodeSelectorAbsoluteParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorAncestorOrSelfParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorAncestorParserToken;
@@ -69,12 +68,11 @@ final class NodeSelectorNodeSelectorParserTokenVisitor<N extends Node<N, NAME, A
         Objects.requireNonNull(functions, "functions");
         Objects.requireNonNull(node, "name");
 
-        return new NodeSelectorNodeSelectorParserTokenVisitor<>(NodeSelectorBuilder.relative(node, SEPARATOR),
+        return new NodeSelectorNodeSelectorParserTokenVisitor<>(NodeSelectorBuilder.relative(node),
                 nameFactory,
-                functions).acceptAndBuild(token);
+                functions,
+                node).acceptAndBuild(token);
     }
-
-    private final static PathSeparator SEPARATOR = PathSeparator.requiredAtStart('/');
 
     /**
      * Private ctor use static factory
@@ -82,12 +80,15 @@ final class NodeSelectorNodeSelectorParserTokenVisitor<N extends Node<N, NAME, A
     // @VisibleForTesting
     NodeSelectorNodeSelectorParserTokenVisitor(final NodeSelectorBuilder<N, NAME, ANAME, AVALUE> builder,
                                                final Function<NodeSelectorNodeName, NAME> nameFactory,
-                                               final Predicate<ExpressionNodeName> functions) {
+                                               final Predicate<ExpressionNodeName> functions,
+                                               final Class<N> node) {
         super();
 
         this.builder = builder;
         this.nameFactory = nameFactory;
         this.functions = functions;
+        this.node = node;
+
         this.reset();
     }
 
@@ -120,7 +121,7 @@ final class NodeSelectorNodeSelectorParserTokenVisitor<N extends Node<N, NAME, A
 
     @Override
     protected void visit(final NodeSelectorAbsoluteParserToken token) {
-        this.builder.absolute();
+        this.builder = NodeSelectorBuilder.absolute(this.node);
         this.reset();
     }
 
@@ -146,7 +147,7 @@ final class NodeSelectorNodeSelectorParserTokenVisitor<N extends Node<N, NAME, A
 
     @Override
     protected void visit(final NodeSelectorDescendantOrSelfParserToken token) {
-        this.axis(NodeSelector.descendantOrSelf(SEPARATOR));
+        this.axis(NodeSelector.descendantOrSelf());
     }
 
     @Override
@@ -257,6 +258,11 @@ final class NodeSelectorNodeSelectorParserTokenVisitor<N extends Node<N, NAME, A
     private final Function<NodeSelectorNodeName, NAME> nameFactory;
 
     /**
+     * The node types.
+     */
+    private final Class<N> node;
+
+    /**
      * Zero or more predicates for this step. Note that predicate is the xpath name for this concept.
      */
     private List<ExpressionNode> predicates;
@@ -264,7 +270,7 @@ final class NodeSelectorNodeSelectorParserTokenVisitor<N extends Node<N, NAME, A
     /**
      * Builds the selector.
      */
-    private final NodeSelectorBuilder<N, NAME, ANAME, AVALUE> builder;
+    private NodeSelectorBuilder<N, NAME, ANAME, AVALUE> builder;
 
     @Override
     public String toString() {

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorToStringBuilder.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorToStringBuilder.java
@@ -21,7 +21,7 @@ package walkingkooka.tree.select;
 import walkingkooka.NeverError;
 import walkingkooka.build.Builder;
 import walkingkooka.build.tostring.ToStringBuilder;
-import walkingkooka.naming.PathSeparator;
+import walkingkooka.text.CharacterConstant;
 
 /**
  * Accepts the string representation of an axis, node and predicate node selector and builds up a {@link NodeSelector#toString()}.
@@ -36,17 +36,15 @@ final class NodeSelectorToStringBuilder implements Builder<String> {
         super();
     }
 
-    void absolute(final PathSeparator separator) {
-        this.separator = separator;
+    void absolute() {
         this.commit();
-        this.b.append(separator.character());
+        this.b.append(NodeSelector.SEPARATOR.character());
     }
 
-    void descendantOrSelf(final PathSeparator separator) {
-        this.separator = separator;
+    void descendantOrSelf() {
         this.commit();
 
-        final char c = separator.character();
+        final char c = NodeSelector.SEPARATOR.character();
         this.b.append(c);
         this.b.append(c);
     }
@@ -61,10 +59,6 @@ final class NodeSelectorToStringBuilder implements Builder<String> {
         this.commit();
         this.appendSeparator();
         this.b.append("..");
-    }
-
-    void separator(final PathSeparator separator) {
-        this.separator = separator;
     }
 
     void append(final String toString) {
@@ -154,7 +148,7 @@ final class NodeSelectorToStringBuilder implements Builder<String> {
     private void appendSeparator() {
         final StringBuilder b = this.b;
 
-        final PathSeparator separator = this.separator;
+        final CharacterConstant separator = NodeSelector.SEPARATOR;
         final int length = b.length();
         if (length > 0) {
             final char c = separator.character();
@@ -174,7 +168,6 @@ final class NodeSelectorToStringBuilder implements Builder<String> {
     private String axis;
     private String node;
     private String predicate;
-    private PathSeparator separator = PathSeparator.requiredAtStart('/');
 
     private final StringBuilder b = new StringBuilder();
 

--- a/src/test/java/walkingkooka/naming/PathSeparatorTest.java
+++ b/src/test/java/walkingkooka/naming/PathSeparatorTest.java
@@ -22,11 +22,9 @@ import walkingkooka.test.ClassTesting2;
 import walkingkooka.test.HashCodeEqualsDefinedTesting;
 import walkingkooka.test.SerializationTesting;
 import walkingkooka.test.ToStringTesting;
-import walkingkooka.tree.TestNode;
 import walkingkooka.type.MemberVisibility;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -118,18 +116,6 @@ final public class PathSeparatorTest implements ClassTesting2<PathSeparator>,
     @Test
     public void testNotRequiredDotSingleton() {
         this.check(PathSeparator.notRequiredAtStart('.'), '.', false);
-    }
-
-    @Test
-    public void testAbsoluteNodeSelectorBuilder() {
-        assertNotNull(PathSeparator.requiredAtStart(SEPARATOR)
-                .absoluteNodeSelectorBuilder(TestNode.class));
-    }
-
-    @Test
-    public void testRelativeNodeSelectorBuilder() {
-        assertNotNull(PathSeparator.requiredAtStart(SEPARATOR)
-                .relativeNodeSelectorBuilder(TestNode.class));
     }
 
     // HashCodeEqualsDefined ..................................................................................................

--- a/src/test/java/walkingkooka/text/cursor/parser/ParserTokenParentNodeTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/ParserTokenParentNodeTest.java
@@ -21,6 +21,7 @@ import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.tree.select.NodeSelector;
+import walkingkooka.tree.select.NodeSelectorBuilder;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -158,7 +159,7 @@ public final class ParserTokenParentNodeTest extends ParserTokenNodeTestCase<Par
 
     @Test
     public void testSelectorByName() {
-        final NodeSelector<ParserTokenNode, ParserTokenNodeName, ParserTokenNodeAttributeName, String> selector = ParserTokenNode.PATH_SEPARATOR.absoluteNodeSelectorBuilder(ParserTokenNode.class)
+        final NodeSelector<ParserTokenNode, ParserTokenNodeName, ParserTokenNodeAttributeName, String> selector = NodeSelectorBuilder.absolute(ParserTokenNode.class)
                 .descendant()
                 .named(StringParserToken.NAME)
                 .build();

--- a/src/test/java/walkingkooka/tree/file/FilesystemNodeTest.java
+++ b/src/test/java/walkingkooka/tree/file/FilesystemNodeTest.java
@@ -26,6 +26,7 @@ import walkingkooka.collect.map.Maps;
 import walkingkooka.test.ClassTesting2;
 import walkingkooka.text.CharSequences;
 import walkingkooka.tree.NodeTesting;
+import walkingkooka.tree.select.NodeSelectorBuilder;
 import walkingkooka.type.MemberVisibility;
 
 import java.io.FileInputStream;
@@ -278,7 +279,7 @@ public final class FilesystemNodeTest implements ClassTesting2<FilesystemNode>,
     public void testSelectorUsage() {
         final FilesystemNode node = this.createNode();
         this.selectorAcceptAndCheckCount(node,
-                FilesystemNode.PATH_SEPARATOR.absoluteNodeSelectorBuilder(FilesystemNode.class)
+                NodeSelectorBuilder.absolute(FilesystemNode.class)
                         .descendant()
                         .named(FilesystemNodeName.with(SUB_FILE))
                         .build(),

--- a/src/test/java/walkingkooka/tree/json/JsonArrayNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonArrayNodeTest.java
@@ -24,6 +24,7 @@ import walkingkooka.collect.map.Maps;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.color.Color;
 import walkingkooka.tree.search.SearchNode;
+import walkingkooka.tree.select.NodeSelectorBuilder;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -526,7 +527,7 @@ public final class JsonArrayNodeTest extends JsonParentNodeTestCase<JsonArrayNod
         final JsonNode expected = array.get(1);
 
         this.selectorAcceptAndCheck(array,
-                JsonNode.PATH_SEPARATOR.absoluteNodeSelectorBuilder(JsonNode.class)
+                NodeSelectorBuilder.absolute(JsonNode.class)
                         .descendant()
                         .named(expected.name())
                         .build(),
@@ -544,7 +545,7 @@ public final class JsonArrayNodeTest extends JsonParentNodeTestCase<JsonArrayNod
         final JsonNode replaced = JsonNode.number(999);
 
         this.selectorAcceptMapAndCheck(array,
-                JsonNode.PATH_SEPARATOR.absoluteNodeSelectorBuilder(JsonNode.class)
+                NodeSelectorBuilder.absolute(JsonNode.class)
                         .descendant()
                         .named(array.get(1).name())
                         .build(),

--- a/src/test/java/walkingkooka/tree/json/JsonObjectNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonObjectNodeTest.java
@@ -30,6 +30,7 @@ import walkingkooka.text.LineEnding;
 import walkingkooka.tree.Node;
 import walkingkooka.tree.search.SearchNode;
 import walkingkooka.tree.search.SearchNodeName;
+import walkingkooka.tree.select.NodeSelectorBuilder;
 import walkingkooka.tree.visit.Visiting;
 
 import java.util.List;
@@ -730,7 +731,7 @@ public final class JsonObjectNodeTest extends JsonParentNodeTestCase<JsonObjectN
         final JsonNodeName key2 = this.key2();
 
         this.selectorAcceptAndCheck(object,
-                JsonNode.PATH_SEPARATOR.absoluteNodeSelectorBuilder(JsonNode.class)
+                NodeSelectorBuilder.absolute(JsonNode.class)
                         .descendant()
                         .named(key2)
                         .build(),
@@ -747,7 +748,7 @@ public final class JsonObjectNodeTest extends JsonParentNodeTestCase<JsonObjectN
         final JsonNode replaced = JsonNode.string("*");
 
         this.selectorAcceptMapAndCheck(object,
-                JsonNode.PATH_SEPARATOR.absoluteNodeSelectorBuilder(JsonNode.class)
+                NodeSelectorBuilder.absolute(JsonNode.class)
                         .descendant()
                         .named(key2)
                         .build(),

--- a/src/test/java/walkingkooka/tree/pojo/PojoNodeTest.java
+++ b/src/test/java/walkingkooka/tree/pojo/PojoNodeTest.java
@@ -21,6 +21,7 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.test.ClassTesting2;
 import walkingkooka.tree.select.NodeSelector;
+import walkingkooka.tree.select.NodeSelectorBuilder;
 import walkingkooka.tree.select.NodeSelectorTesting;
 import walkingkooka.type.MemberVisibility;
 
@@ -37,7 +38,7 @@ public final class PojoNodeTest implements ClassTesting2<PojoNode>,
     public void testSelectorNodeByClassName() {
         final TestBean bean = new TestBean("1", "2", 99, "3");
 
-        final NodeSelector<PojoNode, PojoName, PojoNodeAttributeName, Object> selector = PojoNode.PATH_SEPARATOR.absoluteNodeSelectorBuilder(PojoNode.class)
+        final NodeSelector<PojoNode, PojoName, PojoNodeAttributeName, Object> selector = NodeSelectorBuilder.absolute(PojoNode.class)
                 .descendant()
                 .attributeValueEquals(PojoNodeAttributeName.CLASS, String.class.getName())
                 .build();

--- a/src/test/java/walkingkooka/tree/select/AbsoluteNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/AbsoluteNodeSelectorTest.java
@@ -26,20 +26,12 @@ import walkingkooka.tree.TestNode;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class AbsoluteNodeSelectorTest extends
         NonLogicalNodeSelectorTestCase<AbsoluteNodeSelector<TestNode, StringName, StringName, Object>> {
 
     private final static PathSeparator SEPARATOR = PathSeparator.requiredAtStart('/');
     private final static Predicate<TestNode> PREDICATE = Predicates.customToString(Predicates.always(), "always");
-
-    @Test
-    public void testWithNullPathSeparatorFails() {
-        assertThrows(NullPointerException.class, () -> {
-            AbsoluteNodeSelector.with(null);
-        });
-    }
 
     @Test
     public void testAppendDescendant() {
@@ -114,12 +106,6 @@ final public class AbsoluteNodeSelectorTest extends
     }
 
     @Test
-    public void testEqualsDifferentPathSeparator() {
-        this.checkNotEquals(this.createSelector(PathSeparator.requiredAtStart('.'),
-                this.wrapped()));
-    }
-
-    @Test
     public void testToString() {
         this.toStringAndCheck(this.createSelector(), "/");
     }
@@ -129,19 +115,9 @@ final public class AbsoluteNodeSelectorTest extends
         this.toStringAndCheck(this.createSelector2(), "/*[" + PREDICATE + "]");
     }
 
-    @Test
-    public void testToStringPathSeparatorNotRequiredAtStart() {
-        final PathSeparator separator = PathSeparator.notRequiredAtStart('/');
-        this.toStringAndCheck(this.createSelector(separator), "/");
-    }
-
     @Override
     AbsoluteNodeSelector<TestNode, StringName, StringName, Object> createSelector() {
-        return this.createSelector(SEPARATOR);
-    }
-
-    private AbsoluteNodeSelector<TestNode, StringName, StringName, Object> createSelector(final PathSeparator separator) {
-        return AbsoluteNodeSelector.with(separator);
+        return AbsoluteNodeSelector.get();
     }
 
     private NodeSelector<TestNode, StringName, StringName, Object> createSelector2() {
@@ -151,10 +127,5 @@ final public class AbsoluteNodeSelectorTest extends
     @Override
     public Class<AbsoluteNodeSelector<TestNode, StringName, StringName, Object>> type() {
         return Cast.to(AbsoluteNodeSelector.class);
-    }
-
-    private AbsoluteNodeSelector<TestNode, StringName, StringName, Object> createSelector(final PathSeparator pathSeparator,
-                                                                                          final NodeSelector<TestNode, StringName, StringName, Object> selector) {
-        return Cast.to(AbsoluteNodeSelector.<TestNode, StringName, StringName, Object>with(pathSeparator).append(selector));
     }
 }

--- a/src/test/java/walkingkooka/tree/select/AndNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/AndNodeSelectorTest.java
@@ -35,8 +35,8 @@ public final class AndNodeSelectorTest extends
         final TestNode sibling = TestNode.with("sibling");
         final TestNode root = TestNode.with("root", parent, sibling);
 
-        this.acceptAndCheck(this.createSelector0(NamedNodeSelector.with(Names.string("unknown1"), SEPARATOR),
-                NamedNodeSelector.with(Names.string("unknown1"), SEPARATOR)),
+        this.acceptAndCheck(this.createSelector0(NamedNodeSelector.with(Names.string("unknown1")),
+                NamedNodeSelector.with(Names.string("unknown1"))),
                 root.child(0));
     }
 

--- a/src/test/java/walkingkooka/tree/select/DescendantOrSelfNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/DescendantOrSelfNodeSelectorTest.java
@@ -23,17 +23,8 @@ import walkingkooka.Cast;
 import walkingkooka.naming.StringName;
 import walkingkooka.tree.TestNode;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 final public class DescendantOrSelfNodeSelectorTest extends
         NonLogicalNodeSelectorTestCase<DescendantOrSelfNodeSelector<TestNode, StringName, StringName, Object>> {
-
-    @Test
-    public void testWithNullPathSeparatorFails() {
-        assertThrows(NullPointerException.class, () -> {
-            DescendantOrSelfNodeSelector.with(null);
-        });
-    }
 
     @Test
     public void testChildless() {
@@ -135,7 +126,7 @@ final public class DescendantOrSelfNodeSelectorTest extends
 
     @Override
     DescendantOrSelfNodeSelector<TestNode, StringName, StringName, Object> createSelector() {
-        return DescendantOrSelfNodeSelector.with(SEPARATOR);
+        return DescendantOrSelfNodeSelector.get();
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/select/NamedNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NamedNodeSelectorTest.java
@@ -20,7 +20,6 @@ package walkingkooka.tree.select;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.naming.Names;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.naming.StringName;
 import walkingkooka.tree.TestNode;
 
@@ -30,12 +29,11 @@ final public class NamedNodeSelectorTest extends
         NonLogicalNodeSelectorTestCase<NamedNodeSelector<TestNode, StringName, StringName, Object>> {
 
     private final static StringName NAME = Names.string("never");
-    private final static PathSeparator SEPARATOR = PathSeparator.requiredAtStart('/');
 
     @Test
-    public void testWithNullPathSeparatorFails() {
+    public void testWithNullNameFails() {
         assertThrows(NullPointerException.class, () -> {
-            NamedNodeSelector.with(NAME, null);
+            NamedNodeSelector.with(null);
         });
     }
 
@@ -94,28 +92,12 @@ final public class NamedNodeSelectorTest extends
 
     @Test
     public void testEqualsDifferentName() {
-        this.checkNotEquals(this.createSelector(Names.string("different-name-2"),
-                SEPARATOR,
-                this.wrapped()));
-    }
-
-    @Test
-    public void testEqualsDifferentPathSeparator() {
-        this.checkNotEquals(this.createSelector(NAME,
-                PathSeparator.requiredAtStart('.'),
-                this.wrapped()));
+        this.checkNotEquals(this.createSelector(Names.string("different-name-2"), this.wrapped()));
     }
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createSelector(),
-                NAME.value());
-    }
-
-    @Test
-    public void testToStringPathSeparatorNotRequiredAtStart() {
-        this.toStringAndCheck(this.createSelector(PathSeparator.notRequiredAtStart('/')),
-                NAME.value());
+        this.toStringAndCheck(this.createSelector(), NAME.value());
     }
 
     @Override
@@ -124,11 +106,7 @@ final public class NamedNodeSelectorTest extends
     }
 
     private NamedNodeSelector<TestNode, StringName, StringName, Object> createSelector(final StringName name) {
-        return NamedNodeSelector.with(name, SEPARATOR);
-    }
-
-    private NamedNodeSelector<TestNode, StringName, StringName, Object> createSelector(final PathSeparator separator) {
-        return NamedNodeSelector.with(NAME, separator);
+        return NamedNodeSelector.with(name);
     }
 
     final void acceptAndCheck(final StringName match, final TestNode start, final TestNode... nodes) {
@@ -141,8 +119,7 @@ final public class NamedNodeSelectorTest extends
     }
 
     private NamedNodeSelector<TestNode, StringName, StringName, Object> createSelector(final StringName name,
-                                                                                       final PathSeparator pathSeparator,
                                                                                        final NodeSelector<TestNode, StringName, StringName, Object> selector) {
-        return Cast.to(NamedNodeSelector.<TestNode, StringName, StringName, Object>with(name, pathSeparator).append(selector));
+        return Cast.to(NamedNodeSelector.<TestNode, StringName, StringName, Object>with(name).append(selector));
     }
 }

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorBuilderTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorBuilderTest.java
@@ -75,28 +75,15 @@ public final class NodeSelectorBuilderTest implements ClassTesting2<NodeSelector
     @Test
     public void testAbsoluteNullClassFails() {
         assertThrows(NullPointerException.class, () -> {
-            NodeSelectorBuilder.absolute(null, this.separator());
+            NodeSelectorBuilder.absolute(null);
         });
     }
 
-    @Test
-    public void testAbsoluteNullSeparatorFails() {
-        assertThrows(NullPointerException.class, () -> {
-            NodeSelectorBuilder.absolute(TestNode.class, null);
-        });
-    }
 
     @Test
     public void testRelativeNullClassFails() {
         assertThrows(NullPointerException.class, () -> {
-            NodeSelectorBuilder.relative(null, this.separator());
-        });
-    }
-
-    @Test
-    public void testRelativeNullSeparatorFails() {
-        assertThrows(NullPointerException.class, () -> {
-            NodeSelectorBuilder.relative(TestNode.class, null);
+            NodeSelectorBuilder.relative(null);
         });
     }
 
@@ -439,8 +426,7 @@ public final class NodeSelectorBuilderTest implements ClassTesting2<NodeSelector
 
     @Test
     public void testToStringAbsoluteManySelectors() {
-        final NodeSelectorBuilder<TestNode, StringName, StringName, Object> b = this.absolute();
-        b.absolute()
+        final NodeSelectorBuilder<TestNode, StringName, StringName, Object> b = this.absolute()
                 .precedingSibling()
                 .self()
                 .followingSibling();
@@ -450,8 +436,7 @@ public final class NodeSelectorBuilderTest implements ClassTesting2<NodeSelector
 
     @Test
     public void testToStringAbsoluteManySelectors2() {
-        final NodeSelectorBuilder<TestNode, StringName, StringName, Object> b = this.absolute();
-        b.absolute()
+        final NodeSelectorBuilder<TestNode, StringName, StringName, Object> b = this.absolute()
                 .preceding()
                 .self()
                 .following();
@@ -485,11 +470,11 @@ public final class NodeSelectorBuilderTest implements ClassTesting2<NodeSelector
     }
 
     private NodeSelectorBuilder<TestNode, StringName, StringName, Object> absolute() {
-        return this.separator().absoluteNodeSelectorBuilder(TestNode.class);
+        return NodeSelectorBuilder.absolute(TestNode.class);
     }
 
     private NodeSelectorBuilder<TestNode, StringName, StringName, Object> relative() {
-        return this.separator().relativeNodeSelectorBuilder(TestNode.class);
+        return NodeSelectorBuilder.relative(TestNode.class);
     }
 
     private PathSeparator separator() {

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
@@ -1316,7 +1316,7 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
 
     @Override
     public NodeSelectorNodeSelectorParserTokenVisitor<TestNode, StringName, StringName, Object> createVisitor() {
-        return new NodeSelectorNodeSelectorParserTokenVisitor<>(null, null, null);
+        return new NodeSelectorNodeSelectorParserTokenVisitor<>(null, null, null, null);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase2.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase2.java
@@ -24,7 +24,6 @@ import walkingkooka.collect.set.Sets;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.Converters;
 import walkingkooka.math.DecimalNumberContexts;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.naming.StringName;
 import walkingkooka.test.ClassTesting2;
 import walkingkooka.test.HashCodeEqualsDefinedTesting;
@@ -51,8 +50,6 @@ abstract public class NodeSelectorTestCase2<S extends NodeSelector<TestNode, Str
         implements ClassTesting2<S>,
         HashCodeEqualsDefinedTesting<S>,
         ToStringTesting<S> {
-
-    final static PathSeparator SEPARATOR = PathSeparator.requiredAtStart('/');
 
     @BeforeEach
     public void beforeEachTest() {

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorToStringBuilderTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorToStringBuilderTest.java
@@ -20,7 +20,6 @@ package walkingkooka.tree.select;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.build.BuilderTesting;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.test.ClassTesting2;
 import walkingkooka.type.MemberVisibility;
 
@@ -185,36 +184,6 @@ public final class NodeSelectorToStringBuilderTest implements ClassTesting2<Node
     }
 
     @Test
-    public void testNode3DifferentPathRequiredAtStart() {
-        final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.separator(PathSeparator.requiredAtStart('\\'));
-        b.node("abc1");
-        b.node("def2");
-        b.node("ghi3");
-        this.buildAndCheck(b, "abc1\\def2\\ghi3");
-    }
-
-    @Test
-    public void testNode3DifferentPathRequiredAtStartAbsolute() {
-        final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.absolute(PathSeparator.requiredAtStart('\\'));
-        b.node("abc1");
-        b.node("def2");
-        b.node("ghi3");
-        this.buildAndCheck(b, "\\abc1\\def2\\ghi3");
-    }
-
-    @Test
-    public void testNode3DifferentPath() {
-        final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.separator(PathSeparator.notRequiredAtStart('\\'));
-        b.node("abc1");
-        b.node("def2");
-        b.node("ghi3");
-        this.buildAndCheck(b, "abc1\\def2\\ghi3");
-    }
-
-    @Test
     public void testNodeNodeAxis() {
         final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
         b.node("abc1");
@@ -272,14 +241,14 @@ public final class NodeSelectorToStringBuilderTest implements ClassTesting2<Node
     @Test
     public void testAbsolute() {
         final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.absolute(PathSeparator.requiredAtStart('/'));
+        b.absolute();
         this.buildAndCheck(b, "/");
     }
 
     @Test
     public void testAbsoluteNode() {
         final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.absolute(PathSeparator.requiredAtStart('/'));
+        b.absolute();
         b.node("abc1");
         this.buildAndCheck(b, "/abc1");
     }
@@ -287,7 +256,7 @@ public final class NodeSelectorToStringBuilderTest implements ClassTesting2<Node
     @Test
     public void testAbsoluteNode2() {
         final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.absolute(PathSeparator.requiredAtStart('/'));
+        b.absolute();
         b.node("abc1");
         b.node("def2");
         this.buildAndCheck(b, "/abc1/def2");
@@ -296,7 +265,7 @@ public final class NodeSelectorToStringBuilderTest implements ClassTesting2<Node
     @Test
     public void testAbsoluteNodePredicateNode() {
         final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.absolute(PathSeparator.requiredAtStart('/'));
+        b.absolute();
         b.node("abc1");
         b.predicate("i>1");
         b.node("def2");
@@ -306,14 +275,14 @@ public final class NodeSelectorToStringBuilderTest implements ClassTesting2<Node
     @Test
     public void testDescendantOrSelf() {
         final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.descendantOrSelf(PathSeparator.requiredAtStart('/'));
+        b.descendantOrSelf();
         this.buildAndCheck(b, "//");
     }
 
     @Test
     public void testDescendantOrSelfNode() {
         final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.descendantOrSelf(PathSeparator.requiredAtStart('/'));
+        b.descendantOrSelf();
         b.node("abc1");
         this.buildAndCheck(b, "//abc1");
     }
@@ -321,7 +290,7 @@ public final class NodeSelectorToStringBuilderTest implements ClassTesting2<Node
     @Test
     public void testDescendantOrSelfNode2() {
         final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.descendantOrSelf(PathSeparator.requiredAtStart('/'));
+        b.descendantOrSelf();
         b.node("abc1");
         b.node("def2");
         this.buildAndCheck(b, "//abc1/def2");
@@ -330,7 +299,7 @@ public final class NodeSelectorToStringBuilderTest implements ClassTesting2<Node
     @Test
     public void testDescendantOrSelfNodePredicateNode() {
         final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.descendantOrSelf(PathSeparator.requiredAtStart('/'));
+        b.descendantOrSelf();
         b.node("abc1");
         b.predicate("i>1");
         b.node("def2");
@@ -340,7 +309,7 @@ public final class NodeSelectorToStringBuilderTest implements ClassTesting2<Node
     @Test
     public void testNodePredicateAxis() {
         final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.descendantOrSelf(PathSeparator.requiredAtStart('/'));
+        b.descendantOrSelf();
         b.node("abc1");
         b.predicate("i>1");
         b.axis("child1");
@@ -350,7 +319,7 @@ public final class NodeSelectorToStringBuilderTest implements ClassTesting2<Node
     @Test
     public void testNodePredicateAxisNode() {
         final NodeSelectorToStringBuilder b = NodeSelectorToStringBuilder.empty();
-        b.descendantOrSelf(PathSeparator.requiredAtStart('/'));
+        b.descendantOrSelf();
         b.node("abc1");
         b.predicate("i>1");
         b.axis("child1");

--- a/src/test/java/walkingkooka/tree/select/OrNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/OrNodeSelectorTest.java
@@ -35,8 +35,8 @@ public final class OrNodeSelectorTest extends
         final TestNode sibling = TestNode.with("sibling");
         final TestNode root = TestNode.with("root", parent, sibling);
 
-        this.acceptAndCheck(this.createSelector0(NamedNodeSelector.with(Names.string("unknown1"), SEPARATOR),
-                NamedNodeSelector.with(Names.string("unknown1"), SEPARATOR)),
+        this.acceptAndCheck(this.createSelector0(NamedNodeSelector.with(Names.string("unknown1")),
+                NamedNodeSelector.with(Names.string("unknown1"))),
                 root.child(0));
     }
 

--- a/src/test/java/walkingkooka/tree/select/SelfNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/SelfNodeSelectorTest.java
@@ -20,7 +20,6 @@ package walkingkooka.tree.select;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.naming.Names;
-import walkingkooka.naming.PathSeparator;
 import walkingkooka.naming.StringName;
 import walkingkooka.tree.TestNode;
 
@@ -88,7 +87,7 @@ final public class SelfNodeSelectorTest
 
     private NodeSelector<TestNode, StringName, StringName, Object> selfAndNamed() {
         return Cast.to(SelfNodeSelector.get()
-                .append(NamedNodeSelector.with(Names.string("child"), PathSeparator.requiredAtStart('/'))));
+                .append(NamedNodeSelector.with(Names.string("child"))));
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/xml/XmlDocumentTest.java
+++ b/src/test/java/walkingkooka/tree/xml/XmlDocumentTest.java
@@ -29,6 +29,7 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.test.ResourceTesting;
 import walkingkooka.tree.search.SearchNodeName;
 import walkingkooka.tree.select.NodeSelector;
+import walkingkooka.tree.select.NodeSelectorBuilder;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.transform.TransformerFactory;
@@ -802,7 +803,7 @@ public final class XmlDocumentTest extends XmlParentNodeTestCase<XmlDocument>
     @Test
     public void testSelectorUsage() throws Exception {
         final XmlDocument document = this.fromXml();
-        final NodeSelector<XmlNode, XmlName, XmlAttributeName, String> selector = XmlNode.PATH_SEPARATOR.absoluteNodeSelectorBuilder(XmlNode.class)
+        final NodeSelector<XmlNode, XmlName, XmlAttributeName, String> selector = NodeSelectorBuilder.absolute(XmlNode.class)
                 .descendant()
                 .named(XmlName.element("img"))
                 .build();
@@ -813,7 +814,7 @@ public final class XmlDocumentTest extends XmlParentNodeTestCase<XmlDocument>
     public void testSelectorUsage2() throws Exception {
         final XmlDocument document = this.fromXml();
 
-        final NodeSelector<XmlNode, XmlName, XmlAttributeName, String> selector = XmlNode.PATH_SEPARATOR.absoluteNodeSelectorBuilder(XmlNode.class)
+        final NodeSelector<XmlNode, XmlName, XmlAttributeName, String> selector = NodeSelectorBuilder.absolute(XmlNode.class)
                 .descendant()
                 .named(XmlName.element("a"))
                 .attributeValueContains(XmlNode.attribute("href", XmlNode.NO_PREFIX), "19")


### PR DESCRIPTION
- PATH_SEPARATOR requirement for all Node's removed.
- PathSeparator NodeSelectorBuilder factory methods removed.
- name and descendantsOrSelf no longer take PathSeparator.