### PR TITLE
NodeSelectorParserToken predicae arithmetic parser support

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/select/FakeNodeSelectorParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/FakeNodeSelectorParserTokenVisitor.java
@@ -28,12 +28,42 @@ public class FakeNodeSelectorParserTokenVisitor extends NodeSelectorParserTokenV
     }
 
     @Override
+    protected Visiting startVisit(final NodeSelectorAdditionParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorAdditionParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+    
+    @Override
     protected Visiting startVisit(final NodeSelectorAndParserToken token) {
         throw new UnsupportedOperationException();
     }
 
     @Override
     protected void endVisit(final NodeSelectorAndParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorAttributeParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorAttributeParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorDivisionParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorDivisionParserToken token) {
         throw new UnsupportedOperationException();
     }
 
@@ -88,6 +118,16 @@ public class FakeNodeSelectorParserTokenVisitor extends NodeSelectorParserTokenV
     }
 
     @Override
+    protected Visiting startVisit(final NodeSelectorGroupParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorGroupParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected Visiting startVisit(final NodeSelectorLessThanParserToken token) {
         throw new UnsupportedOperationException();
     }
@@ -107,6 +147,26 @@ public class FakeNodeSelectorParserTokenVisitor extends NodeSelectorParserTokenV
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    protected Visiting startVisit(final NodeSelectorModuloParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorModuloParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+    
+    @Override
+    protected Visiting startVisit(final NodeSelectorMultiplicationParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorMultiplicationParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+    
     @Override
     protected Visiting startVisit(final NodeSelectorNotEqualsParserToken token) {
         throw new UnsupportedOperationException();
@@ -137,6 +197,16 @@ public class FakeNodeSelectorParserTokenVisitor extends NodeSelectorParserTokenV
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    protected Visiting startVisit(final NodeSelectorSubtractionParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorSubtractionParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+    
     @Override
     protected void visit(final NodeSelectorAbsoluteParserToken token) {
         throw new UnsupportedOperationException();
@@ -193,6 +263,11 @@ public class FakeNodeSelectorParserTokenVisitor extends NodeSelectorParserTokenV
     }
 
     @Override
+    protected void visit(final NodeSelectorDivideSymbolParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected void visit(final NodeSelectorEqualsSymbolParserToken token) {
         throw new UnsupportedOperationException();
     }
@@ -243,6 +318,16 @@ public class FakeNodeSelectorParserTokenVisitor extends NodeSelectorParserTokenV
     }
 
     @Override
+    protected void visit(final NodeSelectorMinusSymbolParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final NodeSelectorModuloSymbolParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected void visit(final NodeSelectorNodeNameParserToken token) {
         throw new UnsupportedOperationException();
     }
@@ -279,6 +364,11 @@ public class FakeNodeSelectorParserTokenVisitor extends NodeSelectorParserTokenV
 
     @Override
     protected void visit(final NodeSelectorParentOfParserToken token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void visit(final NodeSelectorPlusSymbolParserToken token) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorAdditionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorAdditionParserToken.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+/**
+ * Holds an addition
+ */
+public final class NodeSelectorAdditionParserToken extends NodeSelectorArithmeticParserToken<NodeSelectorAdditionParserToken> {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorAdditionParserToken.class);
+
+    static NodeSelectorAdditionParserToken with(final List<ParserToken> value, final String text) {
+        return new NodeSelectorAdditionParserToken(copyAndCheckTokens(value),
+                checkTextNullOrWhitespace(text),
+                WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    private NodeSelectorAdditionParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
+        super(value, text, valueWithout);
+    }
+
+    @Override
+    public NodeSelectorAdditionParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorAdditionParserToken replaceText(final String text) {
+        return new NodeSelectorAdditionParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
+    }
+
+    @Override
+    public NodeSelectorAdditionParserToken setValue(final List<ParserToken> value) {
+        return this.setValue0(value).cast();
+    }
+
+    @Override
+    NodeSelectorParentParserToken replaceValue(final List<ParserToken> tokens, final List<ParserToken> without) {
+        return new NodeSelectorAdditionParserToken(tokens, this.text(), without);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is................................................................................................
+
+    @Override
+    public boolean isAddition() {
+        return true;
+    }
+
+    @Override
+    public boolean isDivision() {
+        return false;
+    }
+
+    @Override
+    public boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
+    public boolean isSubtraction() {
+        return false;
+    }
+
+    // Visitor........................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        if (Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
+    }
+
+    // Object........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorAdditionParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorAndParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorAndParserToken.java
@@ -70,9 +70,20 @@ public final class NodeSelectorAndParserToken extends NodeSelectorBinaryParserTo
     // is................................................................................................
 
     @Override
+    public boolean isAddition() {
+        return false;
+    }
+
+    @Override
     public boolean isAnd() {
         return true;
     }
+
+    @Override
+    public boolean isDivision() {
+        return false;
+    }
+
 
     @Override
     public boolean isEquals() {
@@ -100,12 +111,27 @@ public final class NodeSelectorAndParserToken extends NodeSelectorBinaryParserTo
     }
 
     @Override
+    public boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
     public boolean isNotEquals() {
         return false;
     }
 
     @Override
     public boolean isOr() {
+        return false;
+    }
+
+    @Override
+    public boolean isSubtraction() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorAndSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorAndSymbolParserToken.java
@@ -17,12 +17,15 @@
  */
 package walkingkooka.text.cursor.parser.select;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
 
 /**
  * Represents and symbol token.
  */
-public final class NodeSelectorAndSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorAndSymbolParserToken extends NodeSelectorBinaryOperandSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorAndSymbolParserToken.class);
 
@@ -62,17 +65,7 @@ public final class NodeSelectorAndSymbolParserToken extends NodeSelectorSymbolPa
     }
 
     @Override
-    public boolean isAtSignSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketCloseSymbol() {
+    public boolean isDivideSymbol() {
         return false;
     }
 
@@ -102,6 +95,21 @@ public final class NodeSelectorAndSymbolParserToken extends NodeSelectorSymbolPa
     }
 
     @Override
+    public boolean isMinusSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isModuloSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplySymbol() {
+        return false;
+    }
+
+    @Override
     public boolean isNotEqualsSymbol() {
         return false;
     }
@@ -112,28 +120,20 @@ public final class NodeSelectorAndSymbolParserToken extends NodeSelectorSymbolPa
     }
 
     @Override
-    public boolean isParameterSeparatorSymbol() {
+    public boolean isPlusSymbol() {
         return false;
     }
 
+    // operator priority..................................................................................................
+
     @Override
-    public boolean isParenthesisOpenSymbol() {
-        return false;
+    int operatorPriority() {
+        return LOWEST_PRIORITY;
     }
 
     @Override
-    public boolean isParenthesisCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isSlashSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isWhitespace() {
-        return false;
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.and(tokens, text);
     }
 
     // Visitor................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorArithmeticParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorArithmeticParserToken.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.List;
+
+/**
+ * Base class for any arithmetic token, addition etc.
+ */
+abstract public class NodeSelectorArithmeticParserToken<T extends NodeSelectorArithmeticParserToken> extends NodeSelectorBinaryParserToken<T> {
+
+    /**
+     * Package private to limit sub classing.
+     */
+    NodeSelectorArithmeticParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
+        super(value, text, valueWithout);
+    }
+
+    @Override
+    public final boolean isAnd() {
+        return false;
+    }
+
+    @Override
+    public final boolean isEquals() {
+        return false;
+    }
+
+    @Override
+    public final boolean isGreaterThan() {
+        return false;
+    }
+
+    @Override
+    public final boolean isGreaterThanEquals() {
+        return false;
+    }
+
+    @Override
+    public final boolean isLessThan() {
+        return false;
+    }
+
+    @Override
+    public final boolean isLessThanEquals() {
+        return false;
+    }
+
+    @Override
+    public final boolean isNotEquals() {
+        return false;
+    }
+
+    @Override
+    public final boolean isOr() {
+        return false;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorArithmeticSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorArithmeticSymbolParserToken.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+/**
+ * Base class for all binary arithmetic operand symbols
+ */
+abstract class NodeSelectorArithmeticSymbolParserToken extends NodeSelectorBinaryOperandSymbolParserToken {
+
+    NodeSelectorArithmeticSymbolParserToken(final String value, final String text) {
+        super(value, text);
+    }
+
+    // is..............................................................................................
+
+    @Override
+    public final boolean isAndSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isGreaterThanSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isGreaterThanEqualsSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isLessThanSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isLessThanEqualsSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isNotEqualsSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isOrSymbol() {
+        return false;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorAtSignSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorAtSignSymbolParserToken.java
@@ -22,7 +22,7 @@ import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 /**
  * Represents at sign symbol token that prefixes an attribute name.
  */
-public final class NodeSelectorAtSignSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorAtSignSymbolParserToken extends NodeSelectorNonBinaryOperandSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorAtSignSymbolParserToken.class);
 
@@ -47,6 +47,11 @@ public final class NodeSelectorAtSignSymbolParserToken extends NodeSelectorSymbo
         return new NodeSelectorAtSignSymbolParserToken(this.value, text);
     }
 
+    @Override
+    void checkText(final String text) {
+        checkTextNullOrWhitespace(text);
+    }
+
     // name................................................................................................
 
     @Override
@@ -55,11 +60,6 @@ public final class NodeSelectorAtSignSymbolParserToken extends NodeSelectorSymbo
     }
 
     // is..........................................................................................................
-
-    @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
 
     @Override
     public boolean isAtSignSymbol() {
@@ -73,41 +73,6 @@ public final class NodeSelectorAtSignSymbolParserToken extends NodeSelectorSymbo
 
     @Override
     public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isOrSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isNotEqualsSymbol() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorAttributeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorAttributeParserToken.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+/**
+ * Container for an attribute reference holding its component.
+ */
+public final class NodeSelectorAttributeParserToken extends NodeSelectorParentParserToken<NodeSelectorAttributeParserToken> {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorAttributeParserToken.class);
+
+    static NodeSelectorAttributeParserToken with(final List<ParserToken> value, final String text) {
+        return new NodeSelectorAttributeParserToken(copyAndCheckTokens(value),
+                checkTextNullOrWhitespace(text),
+                WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    private NodeSelectorAttributeParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
+        super(value, text, valueWithout);
+
+        final List<ParserToken> without = NodeSelectorAttributeParserToken.class.cast(this.withoutSymbols().get()).value();
+        final int count = without.size();
+        if (count < 1) {
+            throw new IllegalArgumentException("Expected at least 1 tokens but got " + count + "=" + without);
+        }
+        final NodeSelectorParserToken name = without.get(0).cast();
+        if (!name.isAttributeName()) {
+            throw new IllegalArgumentException("Attribute name missing from " + value);
+        }
+        this.attributeName = NodeSelectorAttributeNameParserToken.class.cast(name).value();
+    }
+
+    public NodeSelectorAttributeName attributeName() {
+        return this.attributeName;
+    }
+
+    private final NodeSelectorAttributeName attributeName;
+
+    @Override
+    public NodeSelectorAttributeParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorAttributeParserToken replaceText(final String text) {
+        return new NodeSelectorAttributeParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
+    }
+
+    @Override
+    public NodeSelectorAttributeParserToken setValue(final List<ParserToken> value) {
+        return this.setValue0(value).cast();
+    }
+
+    @Override
+    NodeSelectorParentParserToken replaceValue(final List<ParserToken> tokens, final List<ParserToken> without) {
+        return new NodeSelectorAttributeParserToken(tokens, this.text(), without);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is................................................................................................
+
+    @Override
+    public boolean isAddition() {
+        return false;
+    }
+
+    @Override
+    public boolean isAnd() {
+        return false;
+    }
+
+    @Override
+    public boolean isAttribute() {
+        return true;
+    }
+
+    @Override
+    public boolean isDivision() {
+        return false;
+    }
+
+    @Override
+    public boolean isEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isExpression() {
+        return false;
+    }
+
+    @Override
+    public boolean isFunction() {
+        return false;
+    }
+
+    @Override
+    public boolean isGreaterThan() {
+        return false;
+    }
+
+    @Override
+    public boolean isGreaterThanEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isGroup() {
+        return false;
+    }
+
+    @Override
+    public boolean isLessThan() {
+        return false;
+    }
+
+    @Override
+    public boolean isLessThanEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
+    public boolean isNegative() {
+        return false;
+    }
+
+    @Override
+    public boolean isNotEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isOr() {
+        return false;
+    }
+
+    @Override
+    public boolean isPredicate() {
+        return false;
+    }
+
+    @Override
+    public boolean isSubtraction() {
+        return false;
+    }
+
+    // Visitor........................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        if (Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
+    }
+
+    // Object........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorAttributeParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorBinaryOperandSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorBinaryOperandSymbolParserToken.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+/**
+ * Base class for all binary operand symbols
+ */
+abstract class NodeSelectorBinaryOperandSymbolParserToken extends NodeSelectorSymbolParserToken {
+
+    NodeSelectorBinaryOperandSymbolParserToken(final String value, final String text) {
+        super(value, text);
+    }
+
+    @Override
+    final void checkText(final String text) {
+        checkTextNullOrWhitespace(text);
+    }
+
+    // is..............................................................................................
+
+    @Override
+    public final boolean isAtSignSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isBracketOpenSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isBracketCloseSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isParameterSeparatorSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isParenthesisOpenSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isParenthesisCloseSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isSlashSeparatorSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isWhitespace() {
+        return false;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorBinaryParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorBinaryParserToken.java
@@ -70,6 +70,11 @@ abstract class NodeSelectorBinaryParserToken<T extends NodeSelectorBinaryParserT
     // is................................................................................................
 
     @Override
+    public final boolean isAttribute() {
+        return false;
+    }
+
+    @Override
     public final boolean isExpression() {
         return false;
     }
@@ -80,7 +85,18 @@ abstract class NodeSelectorBinaryParserToken<T extends NodeSelectorBinaryParserT
     }
 
     @Override
+    public final boolean isGroup() {
+        return false;
+    }
+
+    @Override
+    public final boolean isNegative() {
+        return false;
+    }
+
+    @Override
     public final boolean isPredicate() {
         return false;
     }
+
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorBracketCloseSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorBracketCloseSymbolParserToken.java
@@ -22,7 +22,7 @@ import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 /**
  * Represents a predicate / close bracket symbol token.
  */
-public final class NodeSelectorBracketCloseSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorBracketCloseSymbolParserToken extends NodeSelectorNonBinaryOperandSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorBracketCloseSymbolParserToken.class);
 
@@ -47,6 +47,11 @@ public final class NodeSelectorBracketCloseSymbolParserToken extends NodeSelecto
         return new NodeSelectorBracketCloseSymbolParserToken(this.value, text);
     }
 
+    @Override
+    void checkText(final String text) {
+        checkTextNullOrEmpty(text);
+    }
+
     // name................................................................................................
 
     @Override
@@ -55,11 +60,6 @@ public final class NodeSelectorBracketCloseSymbolParserToken extends NodeSelecto
     }
 
     // is..........................................................................................................
-
-    @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
 
     @Override
     public boolean isAtSignSymbol() {
@@ -74,41 +74,6 @@ public final class NodeSelectorBracketCloseSymbolParserToken extends NodeSelecto
     @Override
     public boolean isBracketCloseSymbol() {
         return true;
-    }
-
-    @Override
-    public boolean isEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isNotEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isOrSymbol() {
-        return false;
     }
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorBracketOpenSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorBracketOpenSymbolParserToken.java
@@ -22,7 +22,7 @@ import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 /**
  * Represents a predicate / open bracket symbol token.
  */
-public final class NodeSelectorBracketOpenSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorBracketOpenSymbolParserToken extends NodeSelectorNonBinaryOperandSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorBracketOpenSymbolParserToken.class);
 
@@ -47,6 +47,11 @@ public final class NodeSelectorBracketOpenSymbolParserToken extends NodeSelector
         return new NodeSelectorBracketOpenSymbolParserToken(this.value, text);
     }
 
+    @Override
+    void checkText(final String text) {
+        checkTextNullOrEmpty(text);
+    }
+
     // name................................................................................................
 
     @Override
@@ -55,11 +60,6 @@ public final class NodeSelectorBracketOpenSymbolParserToken extends NodeSelector
     }
 
     // is..........................................................................................................
-
-    @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
 
     @Override
     public boolean isAtSignSymbol() {
@@ -73,41 +73,6 @@ public final class NodeSelectorBracketOpenSymbolParserToken extends NodeSelector
 
     @Override
     public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isNotEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isOrSymbol() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorComparisonParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorComparisonParserToken.java
@@ -24,13 +24,18 @@ import java.util.List;
 /**
  * Base class for any condition token, which includes the left side, condition symbol and right side argument.
  */
-abstract public class NodeSelectorConditionParserToken<T extends NodeSelectorConditionParserToken> extends NodeSelectorBinaryParserToken<T> {
+abstract public class NodeSelectorComparisonParserToken<T extends NodeSelectorComparisonParserToken> extends NodeSelectorBinaryParserToken<T> {
 
     /**
      * Package private to limit sub classing.
      */
-    NodeSelectorConditionParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
+    NodeSelectorComparisonParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
         super(value, text, valueWithout);
+    }
+
+    @Override
+    public final boolean isAddition() {
+        return false;
     }
 
     @Override
@@ -39,7 +44,27 @@ abstract public class NodeSelectorConditionParserToken<T extends NodeSelectorCon
     }
 
     @Override
+    public final boolean isDivision() {
+        return false;
+    }
+
+    @Override
+    public final boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public final boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
     public final boolean isOr() {
+        return false;
+    }
+
+    @Override
+    public final boolean isSubtraction() {
         return false;
     }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorComparisonSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorComparisonSymbolParserToken.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+/**
+ * Base class for all binary arithmetic operand symbols
+ */
+abstract class NodeSelectorComparisonSymbolParserToken extends NodeSelectorBinaryOperandSymbolParserToken {
+
+    NodeSelectorComparisonSymbolParserToken(final String value, final String text) {
+        super(value, text);
+    }
+
+    @Override
+    public final boolean isAndSymbol() {
+        return false;
+    }
+    
+    @Override
+    public final boolean isDivideSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isMinusSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isModuloSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isMultiplySymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isOrSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isPlusSymbol() {
+        return false;
+    }
+
+    // operator priority..................................................................................................
+
+    @Override
+    final int operatorPriority() {
+        return COMPARISON_PRIORITY;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorDivideSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorDivideSymbolParserToken.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
+
+/**
+ * Represents a DIV symbol token.
+ */
+public final class NodeSelectorDivideSymbolParserToken extends NodeSelectorArithmeticSymbolParserToken {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorDivideSymbolParserToken.class);
+
+    static NodeSelectorDivideSymbolParserToken with(final String value, final String text) {
+        checkValue(value);
+        checkTextNullOrWhitespace(text);
+
+        return new NodeSelectorDivideSymbolParserToken(value, text);
+    }
+
+    private NodeSelectorDivideSymbolParserToken(final String value, final String text) {
+        super(value, text);
+    }
+
+    @Override
+    public NodeSelectorDivideSymbolParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorDivideSymbolParserToken replaceText(final String text) {
+        return new NodeSelectorDivideSymbolParserToken(this.value, text);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is..........................................................................................................
+
+    @Override
+    public boolean isDivideSymbol() {
+        return true;
+    }
+
+    @Override
+    public boolean isEqualsSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isMinusSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isModuloSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplySymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isPlusSymbol() {
+        return false;
+    }
+
+    // operator priority..................................................................................................
+
+    @Override
+    int operatorPriority() {
+        return MULTIPLY_DIVISION_PRIORITY;
+    }
+
+    @Override
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.division(tokens, text);
+    }
+
+    // Visitor................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    // Object................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorDivideSymbolParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorDivisionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorDivisionParserToken.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+/**
+ * Holds a division
+ */
+public final class NodeSelectorDivisionParserToken extends NodeSelectorArithmeticParserToken<NodeSelectorDivisionParserToken> {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorDivisionParserToken.class);
+
+    static NodeSelectorDivisionParserToken with(final List<ParserToken> value, final String text) {
+        return new NodeSelectorDivisionParserToken(copyAndCheckTokens(value),
+                checkTextNullOrWhitespace(text),
+                WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    private NodeSelectorDivisionParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
+        super(value, text, valueWithout);
+    }
+
+    @Override
+    public NodeSelectorDivisionParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorDivisionParserToken replaceText(final String text) {
+        return new NodeSelectorDivisionParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
+    }
+
+    @Override
+    public NodeSelectorDivisionParserToken setValue(final List<ParserToken> value) {
+        return this.setValue0(value).cast();
+    }
+
+    @Override
+    NodeSelectorParentParserToken replaceValue(final List<ParserToken> tokens, final List<ParserToken> without) {
+        return new NodeSelectorDivisionParserToken(tokens, this.text(), without);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is................................................................................................
+
+    @Override
+    public boolean isAddition() {
+        return false;
+    }
+
+    @Override
+    public boolean isDivision() {
+        return true;
+    }
+
+    @Override
+    public boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
+    public boolean isSubtraction() {
+        return false;
+    }
+
+    // Visitor........................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        if (Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
+    }
+
+    // Object........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorDivisionParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorEbnfParserCombinatorSyntaxTreeTransformer.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorEbnfParserCombinatorSyntaxTreeTransformer.java
@@ -20,13 +20,11 @@ package walkingkooka.text.cursor.parser.select;
 
 import walkingkooka.NeverError;
 import walkingkooka.collect.list.Lists;
-import walkingkooka.naming.Name;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserContext;
 import walkingkooka.text.cursor.parser.ParserReporters;
 import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.SequenceParserToken;
-import walkingkooka.text.cursor.parser.StringParserToken;
 import walkingkooka.text.cursor.parser.ebnf.EbnfAlternativeParserToken;
 import walkingkooka.text.cursor.parser.ebnf.EbnfConcatenationParserToken;
 import walkingkooka.text.cursor.parser.ebnf.EbnfExceptionParserToken;
@@ -41,7 +39,6 @@ import walkingkooka.text.cursor.parser.ebnf.combinator.EbnfParserCombinatorSynta
 
 import java.util.List;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 final class NodeSelectorEbnfParserCombinatorSyntaxTreeTransformer implements EbnfParserCombinatorSyntaxTreeTransformer {
 
@@ -51,12 +48,116 @@ final class NodeSelectorEbnfParserCombinatorSyntaxTreeTransformer implements Ebn
     }
 
     @Override
-    public Parser<ParserContext> concatenation(final EbnfConcatenationParserToken token, final Parser<ParserContext> parser) {
+    public Parser<ParserContext> concatenation(final EbnfConcatenationParserToken token, Parser<ParserContext> parser) {
         return parser.transform(this::concatenation);
     }
 
+    /**
+     * Special case for binary operators and operator priorities.
+     */
     private ParserToken concatenation(final ParserToken sequence, final ParserContext context) {
-        return SequenceParserToken.class.cast(sequence).flat();
+        return this.concatenation0(sequence.cast(), context);
+    }
+
+    private ParserToken concatenation0(final SequenceParserToken sequence, final ParserContext context) {
+        ParserToken result;
+
+        for (; ; ) {
+            final SequenceParserToken cleaned = sequence.flat();
+
+            final NodeSelectorParserToken first = cleaned.removeWhitespace()
+                    .value()
+                    .get(0)
+                    .cast();
+
+            if (first.isSymbol()) {
+                result = sequence;
+                break;
+            }
+
+            result = this.binaryOperandPrioritize(cleaned.value(), sequence);
+            break;
+        }
+
+        return result;
+    }
+
+    private ParserToken binaryOperandPrioritize(final List<ParserToken> tokens, final SequenceParserToken parent) {
+        List<ParserToken> prioritized = this.maybeExpandNegatives(tokens);
+
+        for (int priority = NodeSelectorParserToken.HIGHEST_PRIORITY; priority > NodeSelectorParserToken.LOWEST_PRIORITY; priority--) {
+            boolean changed;
+
+            do {
+                changed = false;
+                int i = 0;
+                for (ParserToken t : prioritized) {
+                    final NodeSelectorParserToken s = t.cast();
+                    if (s.operatorPriority() == priority) {
+                        changed = true;
+
+                        final int firstIndex = this.findNonWhitespaceSiblingToken(prioritized, i - 1, -1);
+                        final int lastIndex = this.findNonWhitespaceSiblingToken(prioritized, i + 1, +1);
+
+                        final List<ParserToken> binaryOperandTokens = Lists.array();
+                        binaryOperandTokens.addAll(prioritized.subList(firstIndex, lastIndex + 1));
+
+                        final List<ParserToken> replaced = Lists.array();
+                        replaced.addAll(prioritized.subList(0, firstIndex));
+                        replaced.add(s.binaryOperand(binaryOperandTokens, ParserToken.text(binaryOperandTokens)));
+                        replaced.addAll(prioritized.subList(lastIndex + 1, prioritized.size()));
+
+                        prioritized = replaced;
+                        break;
+                    }
+                    i++;
+                }
+            } while (changed && prioritized.size() > 1);
+        }
+
+        return prioritized.size() == 1 ?
+                prioritized.get(0) :
+                parent.setValue(prioritized);
+    }
+
+    /**
+     * Expands any {@link NodeSelectorNegativeParserToken} into its core components, only if it doesnt follow another symbol.
+     * This fixes the parsing "mistake" that converts any minus followed by a token into a {@link NodeSelectorNegativeParserToken}.
+     */
+    private List<ParserToken> maybeExpandNegatives(final List<ParserToken> tokens) {
+        final List<ParserToken> expanded = Lists.array();
+        boolean expand = false;
+
+        for (ParserToken t : tokens) {
+            final NodeSelectorParserToken s = t.cast();
+            if (s.isWhitespace()) {
+                expanded.add(t);
+                continue;
+            }
+
+            if (s.isNegative() && expand) {
+                final NodeSelectorNegativeParserToken negativeParserToken = s.cast();
+                expanded.addAll(negativeParserToken.value());
+                expand = true;
+                continue;
+            }
+            expand = !s.isSymbol();
+            expanded.add(s);
+        }
+
+        return expanded;
+    }
+
+    private int findNonWhitespaceSiblingToken(final List<ParserToken> tokens, final int startIndex, final int step) {
+        int i = startIndex;
+        for (; ; ) {
+            final NodeSelectorParserToken token = tokens.get(i).cast();
+            if (!token.isWhitespace()) {
+                break;
+            }
+            i = i + step;
+        }
+        return i;
     }
 
     @Override
@@ -72,8 +173,8 @@ final class NodeSelectorEbnfParserCombinatorSyntaxTreeTransformer implements Ebn
     @Override
     public Parser<ParserContext> identifier(final EbnfIdentifierParserToken token, final Parser<ParserContext> parser) {
         final EbnfIdentifierName name = token.value();
-        return name.equals(EQUALS_IDENTIFIER) ?
-                parser.transform(this::equalsParserToken) :
+        return name.equals(ATTRIBUTE_IDENTIFIER) ?
+                parser.transform(this::attribute) :
 
                 name.equals(NodeSelectorParsers.EXPRESSION_IDENTIFIER) ?
                         parser.transform(this::expression) :
@@ -81,41 +182,23 @@ final class NodeSelectorEbnfParserCombinatorSyntaxTreeTransformer implements Ebn
                         name.equals(FUNCTION_IDENTIFIER) ?
                                 parser.transform(this::function) :
 
-                                name.equals(GREATER_THAN_IDENTIFIER) ?
-                                        parser.transform(this::greaterThan) :
+                                name.equals(GROUP_IDENTIFIER) ?
+                                        parser.transform(this::group) :
 
-                                        name.equals(GREATER_THAN_EQUALS_IDENTIFIER) ?
-                                                parser.transform(this::greaterThanEquals) :
+                                        name.equals(NEGATIVE_IDENTIFIER) ?
+                                                parser.transform(this::negative) :
 
-                                                name.equals(LESS_THAN_IDENTIFIER) ?
-                                                        parser.transform(this::lessThan) :
+                                                name.equals(PREDICATE_IDENTIFIER) ?
+                                                        parser.transform(this::predicate) :
 
-                                                        name.equals(LESS_THAN_EQUALS_IDENTIFIER) ?
-                                                                parser.transform(this::lessThanEquals) :
-
-                                                                name.equals(NOT_EQUALS_IDENTIFIER) ?
-                                                                        parser.transform(this::notEquals) :
-
-                                                                        name.equals(PREDICATE_IDENTIFIER) ?
-                                                                                parser.transform(this::predicate) :
-
-                                                                                name.equals(NodeSelectorParsers.ATTRIBUTE_NAME_IDENTIFIER) ?
-                                                                                        parser.transform(this::attributeName) :
-
-                                                                                        name.equals(NodeSelectorParsers.FUNCTION_NAME_IDENTIFIER) ?
-                                                                                                parser.transform(this::functionName) :
-
-                                                                                                name.equals(NodeSelectorParsers.NODE_NAME_IDENTIFIER) ?
-                                                                                                        parser.transform(this::nodeName) :
-
-                                                                                                        requiredCheck(name, parser);
+                                                        requiredCheck(name, parser);
     }
 
-    private ParserToken equalsParserToken(final ParserToken token, final ParserContext context) {
-        return parent(token, NodeSelectorParserToken::equalsParserToken);
+    private ParserToken attribute(final ParserToken token, final ParserContext context) {
+        return parent(token, NodeSelectorParserToken::attribute);
     }
 
-    private static final EbnfIdentifierName EQUALS_IDENTIFIER = EbnfIdentifierName.with("CONDITION_EQUALS");
+    static final EbnfIdentifierName ATTRIBUTE_IDENTIFIER = EbnfIdentifierName.with("ATTRIBUTE");
 
     private ParserToken expression(final ParserToken token, final ParserContext context) {
         return parent(token, NodeSelectorParserToken::expression);
@@ -127,36 +210,22 @@ final class NodeSelectorEbnfParserCombinatorSyntaxTreeTransformer implements Ebn
 
     private static final EbnfIdentifierName FUNCTION_IDENTIFIER = EbnfIdentifierName.with("FUNCTION");
 
-    private ParserToken greaterThan(final ParserToken token, final ParserContext context) {
-        return parent(token, NodeSelectorParserToken::greaterThan);
+    private ParserToken group(final ParserToken token, final ParserContext context) {
+        return NodeSelectorParserToken.group(this.clean(token.cast()), token.text());
     }
 
-    private static final EbnfIdentifierName GREATER_THAN_IDENTIFIER = EbnfIdentifierName.with("CONDITION_GREATER_THAN");
+    private static final EbnfIdentifierName GROUP_IDENTIFIER = EbnfIdentifierName.with("GROUP");
 
-    private ParserToken greaterThanEquals(final ParserToken token, final ParserContext context) {
-        return parent(token, NodeSelectorParserToken::greaterThanEquals);
+    private List<ParserToken> clean(final SequenceParserToken token) {
+        return token.flat()
+                .value();
     }
 
-    private static final EbnfIdentifierName GREATER_THAN_EQUALS_IDENTIFIER = EbnfIdentifierName.with("CONDITION_GREATER_THAN_EQUALS");
-
-
-    private ParserToken lessThan(final ParserToken token, final ParserContext context) {
-        return parent(token, NodeSelectorParserToken::lessThan);
+    private ParserToken negative(final ParserToken token, final ParserContext context) {
+        return NodeSelectorParserToken.negative(this.clean(token.cast()), token.text());
     }
 
-    private static final EbnfIdentifierName LESS_THAN_IDENTIFIER = EbnfIdentifierName.with("CONDITION_LESS_THAN");
-
-    private ParserToken lessThanEquals(final ParserToken token, final ParserContext context) {
-        return parent(token, NodeSelectorParserToken::lessThanEquals);
-    }
-
-    private static final EbnfIdentifierName LESS_THAN_EQUALS_IDENTIFIER = EbnfIdentifierName.with("CONDITION_LESS_THAN_EQUALS");
-
-    private ParserToken notEquals(final ParserToken token, final ParserContext context) {
-        return parent(token, NodeSelectorParserToken::notEquals);
-    }
-
-    private static final EbnfIdentifierName NOT_EQUALS_IDENTIFIER = EbnfIdentifierName.with("CONDITION_NOT_EQUALS");
+    private static final EbnfIdentifierName NEGATIVE_IDENTIFIER = EbnfIdentifierName.with("NEGATIVE");
 
     // predicate .....................................................................................................
 
@@ -255,27 +324,6 @@ final class NodeSelectorEbnfParserCombinatorSyntaxTreeTransformer implements Ebn
                         SequenceParserToken.class.cast(token).value() :
                         Lists.of(token),
                 token.text());
-    }
-
-    // name factory methods .........................................................
-
-    private ParserToken attributeName(final ParserToken token, final ParserContext context) {
-        return name(token, NodeSelectorAttributeName::with, NodeSelectorParserToken::attributeName);
-    }
-
-    private ParserToken functionName(final ParserToken token, final ParserContext context) {
-        return name(token, NodeSelectorFunctionName::with, NodeSelectorParserToken::functionName);
-    }
-
-    private ParserToken nodeName(final ParserToken token, final ParserContext context) {
-        return name(token, NodeSelectorNodeName::with, NodeSelectorParserToken::nodeName);
-    }
-
-    private <N extends Name> ParserToken name(final ParserToken token,
-                                              final Function<String, N> nameFactory,
-                                              final BiFunction<N, String, ? extends NodeSelectorNonSymbolParserToken> parserTokenFactory) {
-        final StringParserToken stringParserToken = StringParserToken.class.cast(token);
-        return parserTokenFactory.apply(nameFactory.apply(stringParserToken.value()), stringParserToken.text());
     }
 
     private Parser<ParserContext> requiredCheck(final EbnfIdentifierName name, final Parser<ParserContext> parser) {

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorEqualsParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorEqualsParserToken.java
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * Parser token that represents an equals condition including parameters.
  */
-public final class NodeSelectorEqualsParserToken extends NodeSelectorConditionParserToken<NodeSelectorEqualsParserToken> {
+public final class NodeSelectorEqualsParserToken extends NodeSelectorComparisonParserToken<NodeSelectorEqualsParserToken> {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorEqualsParserToken.class);
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorEqualsSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorEqualsSymbolParserToken.java
@@ -17,12 +17,15 @@
  */
 package walkingkooka.text.cursor.parser.select;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
 
 /**
  * Represents an equals sign parser token.
  */
-public final class NodeSelectorEqualsSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorEqualsSymbolParserToken extends NodeSelectorComparisonSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorEqualsSymbolParserToken.class);
 
@@ -57,26 +60,6 @@ public final class NodeSelectorEqualsSymbolParserToken extends NodeSelectorSymbo
     // is..........................................................................................................
 
     @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isAtSignSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
     public boolean isEqualsSymbol() {
         return true;
     }
@@ -106,34 +89,11 @@ public final class NodeSelectorEqualsSymbolParserToken extends NodeSelectorSymbo
         return false;
     }
 
-    @Override
-    public boolean isOrSymbol() {
-        return false;
-    }
+    // operator priority................................................................................................
 
     @Override
-    public boolean isParameterSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isParenthesisOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isParenthesisCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isSlashSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isWhitespace() {
-        return false;
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.equalsParserToken(tokens, text);
     }
 
     // Visitor................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorExpressionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorExpressionParserToken.java
@@ -70,7 +70,22 @@ public final class NodeSelectorExpressionParserToken extends NodeSelectorParentP
     // is................................................................................................
 
     @Override
+    public boolean isAddition() {
+        return false;
+    }
+
+    @Override
     public boolean isAnd() {
+        return false;
+    }
+
+    @Override
+    public boolean isAttribute() {
+        return false;
+    }
+
+    @Override
+    public boolean isDivision() {
         return false;
     }
 
@@ -100,12 +115,32 @@ public final class NodeSelectorExpressionParserToken extends NodeSelectorParentP
     }
 
     @Override
+    public boolean isGroup() {
+        return false;
+    }
+
+    @Override
     public boolean isLessThan() {
         return false;
     }
 
     @Override
     public boolean isLessThanEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
+    public boolean isNegative() {
         return false;
     }
 
@@ -121,6 +156,11 @@ public final class NodeSelectorExpressionParserToken extends NodeSelectorParentP
 
     @Override
     public boolean isPredicate() {
+        return false;
+    }
+
+    @Override
+    public boolean isSubtraction() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorFunctionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorFunctionParserToken.java
@@ -95,7 +95,22 @@ public final class NodeSelectorFunctionParserToken extends NodeSelectorParentPar
     // is................................................................................................
 
     @Override
+    public boolean isAddition() {
+        return false;
+    }
+
+    @Override
     public boolean isAnd() {
+        return false;
+    }
+
+    @Override
+    public boolean isAttribute() {
+        return false;
+    }
+
+    @Override
+    public boolean isDivision() {
         return false;
     }
 
@@ -125,12 +140,32 @@ public final class NodeSelectorFunctionParserToken extends NodeSelectorParentPar
     }
 
     @Override
+    public boolean isGroup() {
+        return false;
+    }
+
+    @Override
     public boolean isLessThan() {
         return false;
     }
 
     @Override
     public boolean isLessThanEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
+    public boolean isNegative() {
         return false;
     }
 
@@ -146,6 +181,11 @@ public final class NodeSelectorFunctionParserToken extends NodeSelectorParentPar
 
     @Override
     public boolean isPredicate() {
+        return false;
+    }
+
+    @Override
+    public boolean isSubtraction() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGreaterThanEqualsParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGreaterThanEqualsParserToken.java
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * Parser token that represents an greater than equals condition including parameters.
  */
-public final class NodeSelectorGreaterThanEqualsParserToken extends NodeSelectorConditionParserToken<NodeSelectorGreaterThanEqualsParserToken> {
+public final class NodeSelectorGreaterThanEqualsParserToken extends NodeSelectorComparisonParserToken<NodeSelectorGreaterThanEqualsParserToken> {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorGreaterThanEqualsParserToken.class);
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGreaterThanEqualsSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGreaterThanEqualsSymbolParserToken.java
@@ -17,12 +17,15 @@
  */
 package walkingkooka.text.cursor.parser.select;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
 
 /**
  * Represents a greater than equals sign in a comparison parser token.
  */
-public final class NodeSelectorGreaterThanEqualsSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorGreaterThanEqualsSymbolParserToken extends NodeSelectorComparisonSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorGreaterThanEqualsSymbolParserToken.class);
 
@@ -57,26 +60,6 @@ public final class NodeSelectorGreaterThanEqualsSymbolParserToken extends NodeSe
     // is..........................................................................................................
 
     @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isAtSignSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
     public boolean isEqualsSymbol() {
         return false;
     }
@@ -106,34 +89,11 @@ public final class NodeSelectorGreaterThanEqualsSymbolParserToken extends NodeSe
         return false;
     }
 
-    @Override
-    public boolean isOrSymbol() {
-        return false;
-    }
+    // operator priority................................................................................................
 
     @Override
-    public boolean isParameterSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isParenthesisOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isParenthesisCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isSlashSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isWhitespace() {
-        return false;
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.greaterThanEquals(tokens, text);
     }
 
     // Visitor................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGreaterThanParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGreaterThanParserToken.java
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * Parser token that represents an greater than condition including parameters.
  */
-public final class NodeSelectorGreaterThanParserToken extends NodeSelectorConditionParserToken<NodeSelectorGreaterThanParserToken> {
+public final class NodeSelectorGreaterThanParserToken extends NodeSelectorComparisonParserToken<NodeSelectorGreaterThanParserToken> {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorGreaterThanParserToken.class);
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGreaterThanSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGreaterThanSymbolParserToken.java
@@ -17,12 +17,15 @@
  */
 package walkingkooka.text.cursor.parser.select;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
 
 /**
  * Represents a greater than equals sign in a comparison parser token.
  */
-public final class NodeSelectorGreaterThanSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorGreaterThanSymbolParserToken extends NodeSelectorComparisonSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorGreaterThanSymbolParserToken.class);
 
@@ -57,26 +60,6 @@ public final class NodeSelectorGreaterThanSymbolParserToken extends NodeSelector
     // is..........................................................................................................
 
     @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isAtSignSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
     public boolean isEqualsSymbol() {
         return false;
     }
@@ -106,34 +89,11 @@ public final class NodeSelectorGreaterThanSymbolParserToken extends NodeSelector
         return false;
     }
 
-    @Override
-    public boolean isOrSymbol() {
-        return false;
-    }
+    // operator priority................................................................................................
 
     @Override
-    public boolean isParameterSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isParenthesisOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isParenthesisCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isSlashSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isWhitespace() {
-        return false;
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.greaterThan(tokens, text);
     }
 
     // Visitor................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGroupParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorGroupParserToken.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+/**
+ * A group parser token.
+ */
+public final class NodeSelectorGroupParserToken extends NodeSelectorParentParserToken<NodeSelectorGroupParserToken> {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorGroupParserToken.class);
+
+    static NodeSelectorGroupParserToken with(final List<ParserToken> value, final String text) {
+        return new NodeSelectorGroupParserToken(copyAndCheckTokens(value),
+                checkTextNullOrWhitespace(text),
+                WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    private NodeSelectorGroupParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
+        super(value, text, valueWithout);
+    }
+
+    @Override
+    public NodeSelectorGroupParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorGroupParserToken replaceText(final String text) {
+        return new NodeSelectorGroupParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
+    }
+
+    @Override
+    public NodeSelectorGroupParserToken setValue(final List<ParserToken> value) {
+        return this.setValue0(value).cast();
+    }
+
+    @Override
+    NodeSelectorParentParserToken replaceValue(final List<ParserToken> tokens, final List<ParserToken> without) {
+        return new NodeSelectorGroupParserToken(tokens, this.text(), without);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is................................................................................................
+
+    @Override
+    public boolean isAddition() {
+        return false;
+    }
+
+    @Override
+    public boolean isAnd() {
+        return false;
+    }
+
+    @Override
+    public boolean isAttribute() {
+        return false;
+    }
+
+    @Override
+    public boolean isDivision() {
+        return false;
+    }
+
+    @Override
+    public boolean isEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isExpression() {
+        return false;
+    }
+
+    @Override
+    public boolean isFunction() {
+        return false;
+    }
+
+    @Override
+    public boolean isGreaterThan() {
+        return false;
+    }
+
+    @Override
+    public boolean isGreaterThanEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isGroup() {
+        return true;
+    }
+
+    @Override
+    public boolean isLessThan() {
+        return false;
+    }
+
+    @Override
+    public boolean isLessThanEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
+    public boolean isNegative() {
+        return false;
+    }
+
+    @Override
+    public boolean isNotEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isOr() {
+        return false;
+    }
+
+    @Override
+    public boolean isPredicate() {
+        return false;
+    }
+
+    @Override
+    public boolean isSubtraction() {
+        return false;
+    }
+
+    // Visitor........................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        if (Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
+    }
+
+    // Object........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorGroupParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLeafParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLeafParserToken.java
@@ -44,7 +44,22 @@ abstract class NodeSelectorLeafParserToken<T> extends NodeSelectorParserToken im
     // is..............................................................................................
 
     @Override
+    public final boolean isAddition() {
+        return false;
+    }
+
+    @Override
     public final boolean isAnd() {
+        return false;
+    }
+
+    @Override
+    public final boolean isAttribute() {
+        return false;
+    }
+
+    @Override
+    public final boolean isDivision() {
         return false;
     }
 
@@ -74,12 +89,32 @@ abstract class NodeSelectorLeafParserToken<T> extends NodeSelectorParserToken im
     }
 
     @Override
+    public final boolean isGroup() {
+        return false;
+    }
+
+    @Override
     public final boolean isLessThan() {
         return false;
     }
 
     @Override
     public final boolean isLessThanEquals() {
+        return false;
+    }
+
+    @Override
+    public final boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public final boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
+    public final boolean isNegative() {
         return false;
     }
 
@@ -95,6 +130,11 @@ abstract class NodeSelectorLeafParserToken<T> extends NodeSelectorParserToken im
 
     @Override
     public final boolean isPredicate() {
+        return false;
+    }
+
+    @Override
+    public final boolean isSubtraction() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLessThanEqualsParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLessThanEqualsParserToken.java
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * Parser token that represents an less than equals condition including parameters.
  */
-public final class NodeSelectorLessThanEqualsParserToken extends NodeSelectorConditionParserToken<NodeSelectorLessThanEqualsParserToken> {
+public final class NodeSelectorLessThanEqualsParserToken extends NodeSelectorComparisonParserToken<NodeSelectorLessThanEqualsParserToken> {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorLessThanEqualsParserToken.class);
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLessThanEqualsSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLessThanEqualsSymbolParserToken.java
@@ -17,12 +17,15 @@
  */
 package walkingkooka.text.cursor.parser.select;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
 
 /**
  * Represents a less than equals sign in a comparison parser token.
  */
-public final class NodeSelectorLessThanEqualsSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorLessThanEqualsSymbolParserToken extends NodeSelectorComparisonSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorLessThanEqualsSymbolParserToken.class);
 
@@ -57,26 +60,6 @@ public final class NodeSelectorLessThanEqualsSymbolParserToken extends NodeSelec
     // is..........................................................................................................
 
     @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isAtSignSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
     public boolean isEqualsSymbol() {
         return false;
     }
@@ -106,34 +89,11 @@ public final class NodeSelectorLessThanEqualsSymbolParserToken extends NodeSelec
         return false;
     }
 
-    @Override
-    public boolean isOrSymbol() {
-        return false;
-    }
+    // operator priority................................................................................................
 
     @Override
-    public boolean isParameterSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isParenthesisOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isParenthesisCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isSlashSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isWhitespace() {
-        return false;
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.lessThanEquals(tokens, text);
     }
 
     // Visitor................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLessThanParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLessThanParserToken.java
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * Parser token that represents an less than condition including parameters.
  */
-public final class NodeSelectorLessThanParserToken extends NodeSelectorConditionParserToken<NodeSelectorLessThanParserToken> {
+public final class NodeSelectorLessThanParserToken extends NodeSelectorComparisonParserToken<NodeSelectorLessThanParserToken> {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorLessThanParserToken.class);
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLessThanSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorLessThanSymbolParserToken.java
@@ -17,12 +17,15 @@
  */
 package walkingkooka.text.cursor.parser.select;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
 
 /**
  * Represents a less than equals sign in a comparison parser token.
  */
-public final class NodeSelectorLessThanSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorLessThanSymbolParserToken extends NodeSelectorComparisonSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorLessThanSymbolParserToken.class);
 
@@ -57,26 +60,6 @@ public final class NodeSelectorLessThanSymbolParserToken extends NodeSelectorSym
     // is..........................................................................................................
 
     @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isAtSignSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
     public boolean isEqualsSymbol() {
         return false;
     }
@@ -106,34 +89,11 @@ public final class NodeSelectorLessThanSymbolParserToken extends NodeSelectorSym
         return false;
     }
 
-    @Override
-    public boolean isOrSymbol() {
-        return false;
-    }
+    // operator priority................................................................................................
 
     @Override
-    public boolean isParameterSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isParenthesisOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isParenthesisCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isSlashSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isWhitespace() {
-        return false;
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.lessThan(tokens, text);
     }
 
     // Visitor................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorMinusSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorMinusSymbolParserToken.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
+
+/**
+ * Represents a minus symbol token.
+ */
+public final class NodeSelectorMinusSymbolParserToken extends NodeSelectorArithmeticSymbolParserToken {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorMinusSymbolParserToken.class);
+
+    static NodeSelectorMinusSymbolParserToken with(final String value, final String text) {
+        checkValue(value);
+        checkTextNullOrWhitespace(text);
+
+        return new NodeSelectorMinusSymbolParserToken(value, text);
+    }
+
+    private NodeSelectorMinusSymbolParserToken(final String value, final String text) {
+        super(value, text);
+    }
+
+    @Override
+    public NodeSelectorMinusSymbolParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorMinusSymbolParserToken replaceText(final String text) {
+        return new NodeSelectorMinusSymbolParserToken(this.value, text);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is..........................................................................................................
+
+    @Override
+    public boolean isDivideSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isEqualsSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isMinusSymbol() {
+        return true;
+    }
+
+    @Override
+    public boolean isModuloSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplySymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isPlusSymbol() {
+        return false;
+    }
+
+    // operator priority..................................................................................................
+
+    @Override
+    int operatorPriority() {
+        return ADDITION_SUBTRACTION_PRIORITY;
+    }
+
+    @Override
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.subtraction(tokens, text);
+    }
+
+    // Visitor................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    // Object................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorMinusSymbolParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorModuloParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorModuloParserToken.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+/**
+ * Holds an modulo operation
+ */
+public final class NodeSelectorModuloParserToken extends NodeSelectorArithmeticParserToken<NodeSelectorModuloParserToken> {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorModuloParserToken.class);
+
+    static NodeSelectorModuloParserToken with(final List<ParserToken> value, final String text) {
+        return new NodeSelectorModuloParserToken(copyAndCheckTokens(value),
+                checkTextNullOrWhitespace(text),
+                WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    private NodeSelectorModuloParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
+        super(value, text, valueWithout);
+    }
+
+    @Override
+    public NodeSelectorModuloParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorModuloParserToken replaceText(final String text) {
+        return new NodeSelectorModuloParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
+    }
+
+    @Override
+    public NodeSelectorModuloParserToken setValue(final List<ParserToken> value) {
+        return this.setValue0(value).cast();
+    }
+
+    @Override
+    NodeSelectorParentParserToken replaceValue(final List<ParserToken> tokens, final List<ParserToken> without) {
+        return new NodeSelectorModuloParserToken(tokens, this.text(), without);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is................................................................................................
+
+    @Override
+    public boolean isAddition() {
+        return false;
+    }
+
+    @Override
+    public boolean isDivision() {
+        return false;
+    }
+
+    @Override
+    public boolean isModulo() {
+        return true;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
+    public boolean isSubtraction() {
+        return false;
+    }
+
+    // Visitor........................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        if (Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
+    }
+
+    // Object........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorModuloParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorModuloSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorModuloSymbolParserToken.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
+
+/**
+ * Represents a MOD symbol token.
+ */
+public final class NodeSelectorModuloSymbolParserToken extends NodeSelectorArithmeticSymbolParserToken {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorModuloSymbolParserToken.class);
+
+    static NodeSelectorModuloSymbolParserToken with(final String value, final String text) {
+        checkValue(value);
+        checkTextNullOrWhitespace(text);
+
+        return new NodeSelectorModuloSymbolParserToken(value, text);
+    }
+
+    private NodeSelectorModuloSymbolParserToken(final String value, final String text) {
+        super(value, text);
+    }
+
+    @Override
+    public NodeSelectorModuloSymbolParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorModuloSymbolParserToken replaceText(final String text) {
+        return new NodeSelectorModuloSymbolParserToken(this.value, text);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is..........................................................................................................
+
+    @Override
+    public boolean isDivideSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isEqualsSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isMinusSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isModuloSymbol() {
+        return true;
+    }
+
+    @Override
+    public boolean isMultiplySymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isPlusSymbol() {
+        return false;
+    }
+
+    // operator priority..................................................................................................
+
+    @Override
+    int operatorPriority() {
+        return MOD_PRIORITY;
+    }
+
+    @Override
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.modulo(tokens, text);
+    }
+
+    // Visitor................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    // Object................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorModuloSymbolParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorMultiplicationParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorMultiplicationParserToken.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+/**
+ * Holds an multiplication
+ */
+public final class NodeSelectorMultiplicationParserToken extends NodeSelectorArithmeticParserToken<NodeSelectorMultiplicationParserToken> {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorMultiplicationParserToken.class);
+
+    static NodeSelectorMultiplicationParserToken with(final List<ParserToken> value, final String text) {
+        return new NodeSelectorMultiplicationParserToken(copyAndCheckTokens(value),
+                checkTextNullOrWhitespace(text),
+                WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    private NodeSelectorMultiplicationParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
+        super(value, text, valueWithout);
+    }
+
+    @Override
+    public NodeSelectorMultiplicationParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorMultiplicationParserToken replaceText(final String text) {
+        return new NodeSelectorMultiplicationParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
+    }
+
+    @Override
+    public NodeSelectorMultiplicationParserToken setValue(final List<ParserToken> value) {
+        return this.setValue0(value).cast();
+    }
+
+    @Override
+    NodeSelectorParentParserToken replaceValue(final List<ParserToken> tokens, final List<ParserToken> without) {
+        return new NodeSelectorMultiplicationParserToken(tokens, this.text(), without);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is................................................................................................
+
+    @Override
+    public boolean isAddition() {
+        return false;
+    }
+
+    @Override
+    public boolean isDivision() {
+        return false;
+    }
+
+    @Override
+    public boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return true;
+    }
+
+    @Override
+    public boolean isSubtraction() {
+        return false;
+    }
+
+    // Visitor........................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        if (Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
+    }
+
+    // Object........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorMultiplicationParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorMultiplySymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorMultiplySymbolParserToken.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
+
+/**
+ * Represents a MOD symbol token.
+ */
+public final class NodeSelectorMultiplySymbolParserToken extends NodeSelectorArithmeticSymbolParserToken {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorMultiplySymbolParserToken.class);
+
+    static NodeSelectorMultiplySymbolParserToken with(final String value, final String text) {
+        checkValue(value);
+        checkTextNullOrWhitespace(text);
+
+        return new NodeSelectorMultiplySymbolParserToken(value, text);
+    }
+
+    private NodeSelectorMultiplySymbolParserToken(final String value, final String text) {
+        super(value, text);
+    }
+
+    @Override
+    public NodeSelectorMultiplySymbolParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorMultiplySymbolParserToken replaceText(final String text) {
+        return new NodeSelectorMultiplySymbolParserToken(this.value, text);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is..........................................................................................................
+
+    @Override
+    public boolean isDivideSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isEqualsSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isMinusSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isModuloSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplySymbol() {
+        return true;
+    }
+
+    @Override
+    public boolean isPlusSymbol() {
+        return false;
+    }
+
+    // operator priority..................................................................................................
+
+    @Override
+    int operatorPriority() {
+        return MULTIPLY_DIVISION_PRIORITY;
+    }
+
+    @Override
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.multiplication(tokens, text);
+    }
+
+    // Visitor................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    // Object................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorMultiplySymbolParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNegativeParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNegativeParserToken.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.Cast;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+/**
+ * Holds a unary negative token with an argument such as a number or function.
+ */
+public final class NodeSelectorNegativeParserToken extends NodeSelectorParentParserToken<NodeSelectorNegativeParserToken> {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorNegativeParserToken.class);
+
+    static NodeSelectorNegativeParserToken with(final List<ParserToken> value, final String text) {
+        return new NodeSelectorNegativeParserToken(copyAndCheckTokens(value),
+                checkTextNullOrWhitespace(text),
+                WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    private NodeSelectorNegativeParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
+        super(value, text, valueWithout);
+
+        final List<ParserToken> without = Cast.to(NodeSelectorParentParserToken.class.cast(this.withoutSymbols().get()).value());
+        final int count = without.size();
+        if (1 != count) {
+            throw new IllegalArgumentException("Expected 1 tokens but got " + count + "=" + without);
+        }
+
+        this.parameter = without.get(0).cast();
+    }
+
+    public NodeSelectorParserToken parameter() {
+        return this.parameter;
+    }
+
+    private final NodeSelectorParserToken parameter;
+
+    @Override
+    public NodeSelectorNegativeParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorNegativeParserToken replaceText(final String text) {
+        return new NodeSelectorNegativeParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
+    }
+
+    @Override
+    public NodeSelectorNegativeParserToken setValue(final List<ParserToken> value) {
+        return this.setValue0(value).cast();
+    }
+
+    @Override
+    NodeSelectorParentParserToken replaceValue(final List<ParserToken> tokens, final List<ParserToken> without) {
+        return new NodeSelectorNegativeParserToken(tokens, this.text(), without);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is................................................................................................
+
+    @Override
+    public boolean isAddition() {
+        return false;
+    }
+
+    @Override
+    public boolean isAnd() {
+        return false;
+    }
+
+    @Override
+    public boolean isAttribute() {
+        return false;
+    }
+
+    @Override
+    public boolean isDivision() {
+        return false;
+    }
+
+    @Override
+    public boolean isEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isExpression() {
+        return false;
+    }
+
+    @Override
+    public boolean isFunction() {
+        return false;
+    }
+
+    @Override
+    public boolean isGreaterThan() {
+        return false;
+    }
+
+    @Override
+    public boolean isGreaterThanEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isGroup() {
+        return false;
+    }
+
+    @Override
+    public boolean isLessThan() {
+        return false;
+    }
+
+    @Override
+    public boolean isLessThanEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
+    public boolean isNegative() {
+        return true;
+    }
+
+    @Override
+    public boolean isNotEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isOr() {
+        return false;
+    }
+
+    @Override
+    public boolean isPredicate() {
+        return false;
+    }
+
+    @Override
+    public boolean isSubtraction() {
+        return false;
+    }
+
+    // Visitor........................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        if (Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
+    }
+
+    // Object........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorNegativeParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNonBinaryOperandSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNonBinaryOperandSymbolParserToken.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.List;
+
+/**
+ * Base class for all non binary operand symbols
+ */
+abstract class NodeSelectorNonBinaryOperandSymbolParserToken extends NodeSelectorSymbolParserToken {
+
+    NodeSelectorNonBinaryOperandSymbolParserToken(final String value, final String text) {
+        super(value, text);
+    }
+
+    // is..............................................................................................
+
+    @Override
+    public final boolean isAndSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isDivideSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isEqualsSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isGreaterThanSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isGreaterThanEqualsSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isLessThanSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isLessThanEqualsSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isMinusSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isModuloSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isMultiplySymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isNotEqualsSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isOrSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isPlusSymbol() {
+        return false;
+    }
+
+    // operator priority..................................................................................................
+
+    @Override
+    final int operatorPriority() {
+        return LOWEST_PRIORITY;
+    }
+
+    @Override
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNonSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNonSymbolParserToken.java
@@ -17,6 +17,9 @@
  */
 package walkingkooka.text.cursor.parser.select;
 
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -54,6 +57,11 @@ abstract class NodeSelectorNonSymbolParserToken<T> extends NodeSelectorLeafParse
     }
 
     @Override
+    public final boolean isDivideSymbol() {
+        return false;
+    }
+
+    @Override
     public final boolean isEqualsSymbol() {
         return false;
     }
@@ -79,6 +87,21 @@ abstract class NodeSelectorNonSymbolParserToken<T> extends NodeSelectorLeafParse
     }
 
     @Override
+    public final boolean isMinusSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isModuloSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isMultiplySymbol() {
+        return false;
+    }
+
+    @Override
     public final boolean isNotEqualsSymbol() {
         return false;
     }
@@ -90,6 +113,11 @@ abstract class NodeSelectorNonSymbolParserToken<T> extends NodeSelectorLeafParse
 
     @Override
     public final boolean isParenthesisCloseSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isPlusSymbol() {
         return false;
     }
 
@@ -116,5 +144,17 @@ abstract class NodeSelectorNonSymbolParserToken<T> extends NodeSelectorLeafParse
     @Override
     public final boolean isWhitespace() {
         return false;
+    }
+
+    // operator priority..................................................................................................
+
+    @Override
+    final int operatorPriority() {
+        return LOWEST_PRIORITY;
+    }
+
+    @Override
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNotEqualsParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNotEqualsParserToken.java
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * Parser token that represents an not equals condition including parameters.
  */
-public final class NodeSelectorNotEqualsParserToken extends NodeSelectorConditionParserToken<NodeSelectorNotEqualsParserToken> {
+public final class NodeSelectorNotEqualsParserToken extends NodeSelectorComparisonParserToken<NodeSelectorNotEqualsParserToken> {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorNotEqualsParserToken.class);
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNotEqualsSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorNotEqualsSymbolParserToken.java
@@ -17,12 +17,15 @@
  */
 package walkingkooka.text.cursor.parser.select;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
 
 /**
  * Represents a NE comparison parser token.
  */
-public final class NodeSelectorNotEqualsSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorNotEqualsSymbolParserToken extends NodeSelectorComparisonSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorNotEqualsSymbolParserToken.class);
 
@@ -57,26 +60,6 @@ public final class NodeSelectorNotEqualsSymbolParserToken extends NodeSelectorSy
     // is..........................................................................................................
 
     @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isAtSignSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
     public boolean isEqualsSymbol() {
         return false;
     }
@@ -106,34 +89,11 @@ public final class NodeSelectorNotEqualsSymbolParserToken extends NodeSelectorSy
         return true;
     }
 
-    @Override
-    public boolean isOrSymbol() {
-        return false;
-    }
+    // operator priority................................................................................................
 
     @Override
-    public boolean isParameterSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isParenthesisOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isParenthesisCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isSlashSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isWhitespace() {
-        return false;
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.notEquals(tokens, text);
     }
 
     // Visitor................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorOrParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorOrParserToken.java
@@ -70,7 +70,17 @@ public final class NodeSelectorOrParserToken extends NodeSelectorBinaryParserTok
     // is................................................................................................
 
     @Override
+    public boolean isAddition() {
+        return false;
+    }
+
+    @Override
     public boolean isAnd() {
+        return false;
+    }
+
+    @Override
+    public boolean isDivision() {
         return false;
     }
 
@@ -100,6 +110,16 @@ public final class NodeSelectorOrParserToken extends NodeSelectorBinaryParserTok
     }
 
     @Override
+    public boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
     public boolean isNotEquals() {
         return false;
     }
@@ -107,6 +127,11 @@ public final class NodeSelectorOrParserToken extends NodeSelectorBinaryParserTok
     @Override
     public boolean isOr() {
         return true;
+    }
+
+    @Override
+    public boolean isSubtraction() {
+        return false;
     }
 
     // Visitor........................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorOrSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorOrSymbolParserToken.java
@@ -17,12 +17,15 @@
  */
 package walkingkooka.text.cursor.parser.select;
 
+import walkingkooka.text.cursor.parser.ParserToken;
 import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
 
 /**
  * Represents or symbol token.
  */
-public final class NodeSelectorOrSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorOrSymbolParserToken extends NodeSelectorBinaryOperandSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorOrSymbolParserToken.class);
 
@@ -62,17 +65,7 @@ public final class NodeSelectorOrSymbolParserToken extends NodeSelectorSymbolPar
     }
 
     @Override
-    public boolean isAtSignSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketOpenSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isBracketCloseSymbol() {
+    public boolean isDivideSymbol() {
         return false;
     }
 
@@ -102,6 +95,21 @@ public final class NodeSelectorOrSymbolParserToken extends NodeSelectorSymbolPar
     }
 
     @Override
+    public boolean isMinusSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isModuloSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplySymbol() {
+        return false;
+    }
+
+    @Override
     public boolean isNotEqualsSymbol() {
         return false;
     }
@@ -112,28 +120,20 @@ public final class NodeSelectorOrSymbolParserToken extends NodeSelectorSymbolPar
     }
 
     @Override
-    public boolean isParameterSeparatorSymbol() {
+    public boolean isPlusSymbol() {
         return false;
     }
 
+    // operator priority..................................................................................................
+
     @Override
-    public boolean isParenthesisOpenSymbol() {
-        return false;
+    int operatorPriority() {
+        return LOWEST_PRIORITY;
     }
 
     @Override
-    public boolean isParenthesisCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isSlashSeparatorSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isWhitespace() {
-        return false;
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.or(tokens, text);
     }
 
     // Visitor................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParameterSeparatorSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParameterSeparatorSymbolParserToken.java
@@ -22,7 +22,7 @@ import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 /**
  * Represents the separator between elements or key/value pairs belonging to arrays and objects.
  */
-public final class NodeSelectorParameterSeparatorSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorParameterSeparatorSymbolParserToken extends NodeSelectorNonBinaryOperandSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorParameterSeparatorSymbolParserToken.class);
 
@@ -47,6 +47,11 @@ public final class NodeSelectorParameterSeparatorSymbolParserToken extends NodeS
         return new NodeSelectorParameterSeparatorSymbolParserToken(this.value, text);
     }
 
+    @Override
+    void checkText(final String text) {
+        checkTextNullOrWhitespace(text);
+    }
+
     // name................................................................................................
 
     @Override
@@ -55,11 +60,6 @@ public final class NodeSelectorParameterSeparatorSymbolParserToken extends NodeS
     }
 
     // is..........................................................................................................
-
-    @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
 
     @Override
     public boolean isAtSignSymbol() {
@@ -73,41 +73,6 @@ public final class NodeSelectorParameterSeparatorSymbolParserToken extends NodeS
 
     @Override
     public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isNotEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isOrSymbol() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParentParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParentParserToken.java
@@ -150,6 +150,11 @@ abstract class NodeSelectorParentParserToken<T extends NodeSelectorParentParserT
     }
 
     @Override
+    public final boolean isDivideSymbol() {
+        return false;
+    }
+
+    @Override
     public final boolean isEqualsSymbol() {
         return false;
     }
@@ -200,6 +205,21 @@ abstract class NodeSelectorParentParserToken<T extends NodeSelectorParentParserT
     }
 
     @Override
+    public final boolean isMinusSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isModuloSymbol() {
+        return false;
+    }
+
+    @Override
+    public final boolean isMultiplySymbol() {
+        return false;
+    }
+
+    @Override
     public final boolean isNodeName() {
         return false;
     }
@@ -236,6 +256,11 @@ abstract class NodeSelectorParentParserToken<T extends NodeSelectorParentParserT
 
     @Override
     public final boolean isParentOf() {
+        return false;
+    }
+
+    @Override
+    public final boolean isPlusSymbol() {
         return false;
     }
 
@@ -277,6 +302,18 @@ abstract class NodeSelectorParentParserToken<T extends NodeSelectorParentParserT
     @Override
     public final boolean isWildcard() {
         return false;
+    }
+
+    // operator priority..................................................................................................
+
+    @Override
+    final int operatorPriority() {
+        return LOWEST_PRIORITY;
+    }
+
+    @Override
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        throw new UnsupportedOperationException();
     }
 
     // Visitor................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParenthesisCloseSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParenthesisCloseSymbolParserToken.java
@@ -22,7 +22,7 @@ import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 /**
  * Represents a close object (parens) symbol token.
  */
-public final class NodeSelectorParenthesisCloseSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorParenthesisCloseSymbolParserToken extends NodeSelectorNonBinaryOperandSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorParenthesisCloseSymbolParserToken.class);
 
@@ -47,6 +47,11 @@ public final class NodeSelectorParenthesisCloseSymbolParserToken extends NodeSel
         return new NodeSelectorParenthesisCloseSymbolParserToken(this.value, text);
     }
 
+    @Override
+    void checkText(final String text) {
+        checkTextNullOrEmpty(text);
+    }
+
     // name................................................................................................
 
     @Override
@@ -55,11 +60,6 @@ public final class NodeSelectorParenthesisCloseSymbolParserToken extends NodeSel
     }
 
     // is................................................................................................
-
-    @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
 
     @Override
     public boolean isAtSignSymbol() {
@@ -73,41 +73,6 @@ public final class NodeSelectorParenthesisCloseSymbolParserToken extends NodeSel
 
     @Override
     public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isNotEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isOrSymbol() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParenthesisOpenSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParenthesisOpenSymbolParserToken.java
@@ -22,7 +22,7 @@ import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 /**
  * Represents a open object (parens) symbol token.
  */
-public final class NodeSelectorParenthesisOpenSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorParenthesisOpenSymbolParserToken extends NodeSelectorNonBinaryOperandSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorParenthesisOpenSymbolParserToken.class);
 
@@ -47,6 +47,11 @@ public final class NodeSelectorParenthesisOpenSymbolParserToken extends NodeSele
         return new NodeSelectorParenthesisOpenSymbolParserToken(this.value, text);
     }
 
+    @Override
+    void checkText(final String text) {
+        checkTextNullOrEmpty(text);
+    }
+
     // name................................................................................................
 
     @Override
@@ -55,11 +60,6 @@ public final class NodeSelectorParenthesisOpenSymbolParserToken extends NodeSele
     }
 
     // is..........................................................................................................
-
-    @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
 
     @Override
     public boolean isAtSignSymbol() {
@@ -73,41 +73,6 @@ public final class NodeSelectorParenthesisOpenSymbolParserToken extends NodeSele
 
     @Override
     public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isNotEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isOrSymbol() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParserToken.java
@@ -51,6 +51,13 @@ public abstract class NodeSelectorParserToken implements ParserToken {
     }
 
     /**
+     * {@see NodeSelectorAdditionParserToken}
+     */
+    public static NodeSelectorAdditionParserToken addition(final List<ParserToken> value, final String text) {
+        return NodeSelectorAdditionParserToken.with(value, text);
+    }
+
+    /**
      * {@see NodeSelectorAncestorParserToken}
      */
     public static NodeSelectorAncestorParserToken ancestor(final String value, final String text) {
@@ -83,6 +90,13 @@ public abstract class NodeSelectorParserToken implements ParserToken {
      */
     public static NodeSelectorAtSignSymbolParserToken atSignSymbol(final String value, final String text) {
         return NodeSelectorAtSignSymbolParserToken.with(value, text);
+    }
+
+    /**
+     * {@see NodeSelectorAttributeParserToken}
+     */
+    public static NodeSelectorAttributeParserToken attribute(final List<ParserToken> value, final String text) {
+        return NodeSelectorAttributeParserToken.with(value, text);
     }
 
     /**
@@ -125,6 +139,20 @@ public abstract class NodeSelectorParserToken implements ParserToken {
      */
     public static NodeSelectorDescendantOrSelfParserToken descendantOrSelf(final String value, final String text) {
         return NodeSelectorDescendantOrSelfParserToken.with(value, text);
+    }
+
+    /**
+     * {@see NodeSelectorDivideSymbolParserToken}
+     */
+    public static NodeSelectorDivideSymbolParserToken divideSymbol(final String value, final String text) {
+        return NodeSelectorDivideSymbolParserToken.with(value, text);
+    }
+
+    /**
+     * {@see NodeSelectorDivisionParserToken}
+     */
+    public static NodeSelectorDivisionParserToken division(final List<ParserToken> value, final String text) {
+        return NodeSelectorDivisionParserToken.with(value, text);
     }
 
     /**
@@ -212,6 +240,13 @@ public abstract class NodeSelectorParserToken implements ParserToken {
     }
 
     /**
+     * {@see NodeSelectorGroupParserToken}
+     */
+    public static NodeSelectorGroupParserToken group(final List<ParserToken> value, final String text) {
+        return NodeSelectorGroupParserToken.with(value, text);
+    }
+
+    /**
      * {@see NodeSelectorLastChildParserToken}
      */
     public static NodeSelectorLastChildParserToken lastChild(final String value, final String text) {
@@ -244,6 +279,48 @@ public abstract class NodeSelectorParserToken implements ParserToken {
      */
     public static NodeSelectorLessThanEqualsSymbolParserToken lessThanEqualsSymbol(final String value, final String text) {
         return NodeSelectorLessThanEqualsSymbolParserToken.with(value, text);
+    }
+
+    /**
+     * {@see NodeSelectorMinusSymbolParserToken}
+     */
+    public static NodeSelectorMinusSymbolParserToken minusSymbol(final String value, final String text) {
+        return NodeSelectorMinusSymbolParserToken.with(value, text);
+    }
+
+    /**
+     * {@see NodeSelectorModuloParserToken}
+     */
+    public static NodeSelectorModuloParserToken modulo(final List<ParserToken> value, final String text) {
+        return NodeSelectorModuloParserToken.with(value, text);
+    }
+
+    /**
+     * {@see NodeSelectorModuloSymbolParserToken}
+     */
+    public static NodeSelectorModuloSymbolParserToken moduloSymbol(final String value, final String text) {
+        return NodeSelectorModuloSymbolParserToken.with(value, text);
+    }
+
+    /**
+     * {@see NodeSelectorMultiplicationParserToken}
+     */
+    public static NodeSelectorMultiplicationParserToken multiplication(final List<ParserToken> value, final String text) {
+        return NodeSelectorMultiplicationParserToken.with(value, text);
+    }
+
+    /**
+     * {@see NodeSelectorMultiplySymbolParserToken}
+     */
+    public static NodeSelectorMultiplySymbolParserToken multiplySymbol(final String value, final String text) {
+        return NodeSelectorMultiplySymbolParserToken.with(value, text);
+    }
+
+    /**
+     * {@see NodeSelectorNegativeParserToken}
+     */
+    public static NodeSelectorNegativeParserToken negative(final List<ParserToken> value, final String text) {
+        return NodeSelectorNegativeParserToken.with(value, text);
     }
 
     /**
@@ -317,6 +394,13 @@ public abstract class NodeSelectorParserToken implements ParserToken {
     }
 
     /**
+     * {@see NodeSelectorPlusSymbolParserToken}
+     */
+    public static NodeSelectorPlusSymbolParserToken plusSymbol(final String value, final String text) {
+        return NodeSelectorPlusSymbolParserToken.with(value, text);
+    }
+
+    /**
      * {@see NodeSelectorPrecedingParserToken}
      */
     public static NodeSelectorPrecedingParserToken preceding(final String value, final String text) {
@@ -356,6 +440,13 @@ public abstract class NodeSelectorParserToken implements ParserToken {
      */
     public static NodeSelectorSlashSeparatorSymbolParserToken slashSeparatorSymbol(final String value, final String text) {
         return NodeSelectorSlashSeparatorSymbolParserToken.with(value, text);
+    }
+
+    /**
+     * {@see NodeSelectorSubtractionParserToken}
+     */
+    public static NodeSelectorSubtractionParserToken subtraction(final List<ParserToken> value, final String text) {
+        return NodeSelectorSubtractionParserToken.with(value, text);
     }
 
     /**
@@ -426,6 +517,11 @@ public abstract class NodeSelectorParserToken implements ParserToken {
     public abstract boolean isAbsolute();
 
     /**
+     * Only {@link NodeSelectorAdditionParserToken} return true
+     */
+    public abstract boolean isAddition();
+
+    /**
      * Only {@link NodeSelectorAncestorParserToken} return true
      */
     public abstract boolean isAncestor();
@@ -449,6 +545,11 @@ public abstract class NodeSelectorParserToken implements ParserToken {
      * Only {@link NodeSelectorAtSignSymbolParserToken} return true
      */
     public abstract boolean isAtSignSymbol();
+
+    /**
+     * Only {@link NodeSelectorAttributeParserToken} return true
+     */
+    public abstract boolean isAttribute();
 
     /**
      * Only {@link NodeSelectorAttributeNameParserToken} return true
@@ -479,6 +580,16 @@ public abstract class NodeSelectorParserToken implements ParserToken {
      * Only {@link NodeSelectorDescendantOrSelfParserToken} return true
      */
     public abstract boolean isDescendantOrSelf();
+
+    /**
+     * Only {@link NodeSelectorDivideSymbolParserToken} return true
+     */
+    public abstract boolean isDivideSymbol();
+
+    /**
+     * Only {@link NodeSelectorDivisionParserToken} return true
+     */
+    public abstract boolean isDivision();
 
     /**
      * Only {@link NodeSelectorEqualsParserToken} return true
@@ -541,6 +652,11 @@ public abstract class NodeSelectorParserToken implements ParserToken {
     public abstract boolean isGreaterThanEqualsSymbol();
 
     /**
+     * Only {@link NodeSelectorGroupParserToken} return true
+     */
+    public abstract boolean isGroup();
+
+    /**
      * Only {@link NodeSelectorLastChildParserToken} return true
      */
     public abstract boolean isLastChild();
@@ -564,6 +680,36 @@ public abstract class NodeSelectorParserToken implements ParserToken {
      * Only {@link NodeSelectorLessThanEqualsSymbolParserToken} return true
      */
     public abstract boolean isLessThanEqualsSymbol();
+
+    /**
+     * Only {@link NodeSelectorMinusSymbolParserToken} return true
+     */
+    public abstract boolean isMinusSymbol();
+
+    /**
+     * Only {@link NodeSelectorModuloParserToken} return true
+     */
+    public abstract boolean isModulo();
+
+    /**
+     * Only {@link NodeSelectorModuloSymbolParserToken} return true
+     */
+    public abstract boolean isModuloSymbol();
+
+    /**
+     * Only {@link NodeSelectorMultiplicationParserToken} return true
+     */
+    public abstract boolean isMultiplication();
+
+    /**
+     * Only {@link NodeSelectorMultiplySymbolParserToken} return true
+     */
+    public abstract boolean isMultiplySymbol();
+
+    /**
+     * Only {@link NodeSelectorNegativeParserToken} return true
+     */
+    public abstract boolean isNegative();
 
     /**
      * Only {@link NodeSelectorNodeNameParserToken} return true
@@ -616,6 +762,11 @@ public abstract class NodeSelectorParserToken implements ParserToken {
     public abstract boolean isParentOf();
 
     /**
+     * Only {@link NodeSelectorPlusSymbolParserToken} return true
+     */
+    public abstract boolean isPlusSymbol();
+
+    /**
      * Only {@link NodeSelectorPrecedingParserToken} return true
      */
     public abstract boolean isPreceding();
@@ -646,6 +797,11 @@ public abstract class NodeSelectorParserToken implements ParserToken {
     public abstract boolean isSlashSeparatorSymbol();
 
     /**
+     * Only {@link NodeSelectorSubtractionParserToken} return true
+     */
+    public abstract boolean isSubtraction();
+
+    /**
      * Only {@link NodeSelectorSymbolParserToken} return true
      */
     public abstract boolean isSymbol();
@@ -654,6 +810,23 @@ public abstract class NodeSelectorParserToken implements ParserToken {
      * Only {@link NodeSelectorWildcardParserToken} return true
      */
     public abstract boolean isWildcard();
+
+    /**
+     * The priority of this token, tokens with a value of zero are left in their original position.
+     */
+    abstract int operatorPriority();
+
+    final static int LOWEST_PRIORITY = 0;
+    final static int COMPARISON_PRIORITY = LOWEST_PRIORITY + 1;
+    final static int ADDITION_SUBTRACTION_PRIORITY = COMPARISON_PRIORITY + 1;
+    final static int MULTIPLY_DIVISION_PRIORITY = ADDITION_SUBTRACTION_PRIORITY + 1;
+    final static int MOD_PRIORITY = MULTIPLY_DIVISION_PRIORITY + 1;
+    final static int HIGHEST_PRIORITY = MOD_PRIORITY;
+
+    /**
+     * Factory that creates the {@link NodeSelectorBinaryParserToken} sub class using the provided tokens and text.
+     */
+    abstract NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text);
 
     // Visitor ......................................................................................................
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParserTokenVisitor.java
@@ -24,6 +24,16 @@ import walkingkooka.tree.visit.Visiting;
 
 public abstract class NodeSelectorParserTokenVisitor extends ParserTokenVisitor {
 
+    // NodeSelectorAdditionParserToken....................................................................................
+
+    protected Visiting startVisit(final NodeSelectorAdditionParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final NodeSelectorAdditionParserToken token) {
+        // nop
+    }
+    
     // NodeSelectorAndParserToken....................................................................................
 
     protected Visiting startVisit(final NodeSelectorAndParserToken token) {
@@ -31,6 +41,26 @@ public abstract class NodeSelectorParserTokenVisitor extends ParserTokenVisitor 
     }
 
     protected void endVisit(final NodeSelectorAndParserToken token) {
+        // nop
+    }
+
+    // NodeSelectorAttributeParserToken....................................................................................
+
+    protected Visiting startVisit(final NodeSelectorAttributeParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final NodeSelectorAttributeParserToken token) {
+        // nop
+    }
+
+    // NodeSelectorDivisionParserToken....................................................................................
+
+    protected Visiting startVisit(final NodeSelectorDivisionParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final NodeSelectorDivisionParserToken token) {
         // nop
     }
 
@@ -64,7 +94,7 @@ public abstract class NodeSelectorParserTokenVisitor extends ParserTokenVisitor 
         // nop
     }
 
-// NodeSelectorGreaterThanParserToken....................................................................................
+    // NodeSelectorGreaterThanParserToken....................................................................................
 
     protected Visiting startVisit(final NodeSelectorGreaterThanParserToken token) {
         return Visiting.CONTINUE;
@@ -81,6 +111,16 @@ public abstract class NodeSelectorParserTokenVisitor extends ParserTokenVisitor 
     }
 
     protected void endVisit(final NodeSelectorGreaterThanEqualsParserToken token) {
+        // nop
+    }
+
+    // NodeSelectorGroupParserToken....................................................................................
+
+    protected Visiting startVisit(final NodeSelectorGroupParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final NodeSelectorGroupParserToken token) {
         // nop
     }
 
@@ -104,6 +144,36 @@ public abstract class NodeSelectorParserTokenVisitor extends ParserTokenVisitor 
         // nop
     }
 
+    // NodeSelectorModuloParserToken....................................................................................
+
+    protected Visiting startVisit(final NodeSelectorModuloParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final NodeSelectorModuloParserToken token) {
+        // nop
+    }
+
+    // NodeSelectorMultiplicationParserToken....................................................................................
+
+    protected Visiting startVisit(final NodeSelectorMultiplicationParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final NodeSelectorMultiplicationParserToken token) {
+        // nop
+    }
+
+    // NodeSelectorNegativeParserToken....................................................................................
+
+    protected Visiting startVisit(final NodeSelectorNegativeParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final NodeSelectorNegativeParserToken token) {
+        // nop
+    }
+    
     // NodeSelectorNotEqualsParserToken....................................................................................
 
     protected Visiting startVisit(final NodeSelectorNotEqualsParserToken token) {
@@ -113,6 +183,7 @@ public abstract class NodeSelectorParserTokenVisitor extends ParserTokenVisitor 
     protected void endVisit(final NodeSelectorNotEqualsParserToken token) {
         // nop
     }
+
     // NodeSelectorOrParserToken....................................................................................
 
     protected Visiting startVisit(final NodeSelectorOrParserToken token) {
@@ -133,6 +204,16 @@ public abstract class NodeSelectorParserTokenVisitor extends ParserTokenVisitor 
         // nop
     }
 
+    // NodeSelectorSubtractionParserToken....................................................................................
+
+    protected Visiting startVisit(final NodeSelectorSubtractionParserToken token) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final NodeSelectorSubtractionParserToken token) {
+        // nop
+    }
+    
     // NodeSelectorLeafParserToken ..........................................................................
 
     protected void visit(final NodeSelectorAbsoluteParserToken token) {
@@ -179,6 +260,10 @@ public abstract class NodeSelectorParserTokenVisitor extends ParserTokenVisitor 
         // nop
     }
 
+    protected void visit(final NodeSelectorDivideSymbolParserToken token) {
+        // nop
+    }
+
     protected void visit(final NodeSelectorEqualsSymbolParserToken token) {
         // nop
     }
@@ -219,6 +304,18 @@ public abstract class NodeSelectorParserTokenVisitor extends ParserTokenVisitor 
         // nop
     }
 
+    protected void visit(final NodeSelectorMinusSymbolParserToken token) {
+        // nop
+    }
+
+    protected void visit(final NodeSelectorModuloSymbolParserToken token) {
+        // nop
+    }
+
+    protected void visit(final NodeSelectorMultiplySymbolParserToken token) {
+        // nop
+    }
+
     protected void visit(final NodeSelectorNodeNameParserToken token) {
         // nop
     }
@@ -248,6 +345,10 @@ public abstract class NodeSelectorParserTokenVisitor extends ParserTokenVisitor 
     }
 
     protected void visit(final NodeSelectorParentOfParserToken token) {
+        // nop
+    }
+
+    protected void visit(final NodeSelectorPlusSymbolParserToken token) {
         // nop
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParsers.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorParsers.java
@@ -273,6 +273,12 @@ public final class NodeSelectorParsers implements PublicStaticHelper {
      * Registers parsers for all conditions and their symbols.
      */
     private static void condition(final Map<EbnfIdentifierName, Parser<ParserContext>> predefined) {
+        predefined.put(PLUS_IDENTIFIER, PLUS_PARSER);
+        predefined.put(MINUS_IDENTIFIER, MINUS_PARSER);
+        predefined.put(MULTIPLY_IDENTIFIER, MULTIPLY_PARSER);
+        predefined.put(DIVIDE_IDENTIFIER, DIVIDE_PARSER);
+        predefined.put(MODULO_IDENTIFIER, MODULO_PARSER);
+
         predefined.put(EQUALS_IDENTIFIER, EQUALS_PARSER);
         predefined.put(GREATER_THAN_IDENTIFIER, GREATER_THAN_PARSER);
         predefined.put(GREATER_THAN_EQUALS_IDENTIFIER, GREATER_THAN_EQUALS_PARSER);
@@ -281,6 +287,31 @@ public final class NodeSelectorParsers implements PublicStaticHelper {
         predefined.put(NOT_EQUALS_IDENTIFIER, NOT_EQUALS_PARSER);
     }
 
+    private static final EbnfIdentifierName PLUS_IDENTIFIER = EbnfIdentifierName.with("PLUS");
+    private static final Parser<ParserContext> PLUS_PARSER = literal('+',
+            NodeSelectorParserToken::plusSymbol,
+            NodeSelectorPlusSymbolParserToken.class);
+
+    private static final EbnfIdentifierName MINUS_IDENTIFIER = EbnfIdentifierName.with("MINUS");
+    private static final Parser<ParserContext> MINUS_PARSER = literal('-',
+            NodeSelectorParserToken::minusSymbol,
+            NodeSelectorMinusSymbolParserToken.class);
+
+    private static final EbnfIdentifierName MULTIPLY_IDENTIFIER = EbnfIdentifierName.with("MULTIPLY");
+    private static final Parser<ParserContext> MULTIPLY_PARSER = literal('*',
+            NodeSelectorParserToken::multiplySymbol,
+            NodeSelectorMultiplySymbolParserToken.class);
+
+    private static final EbnfIdentifierName DIVIDE_IDENTIFIER = EbnfIdentifierName.with("DIVIDE");
+    private static final Parser<ParserContext> DIVIDE_PARSER = literal("div",
+            NodeSelectorParserToken::divideSymbol,
+            NodeSelectorDivideSymbolParserToken.class);
+
+    private static final EbnfIdentifierName MODULO_IDENTIFIER = EbnfIdentifierName.with("MODULO");
+    private static final Parser<ParserContext> MODULO_PARSER = literal("mod",
+            NodeSelectorParserToken::moduloSymbol,
+            NodeSelectorModuloSymbolParserToken.class);
+    
     private static final EbnfIdentifierName EQUALS_IDENTIFIER = EbnfIdentifierName.with("EQUALS");
     private static final Parser<ParserContext> EQUALS_PARSER = literal('=',
             NodeSelectorParserToken::equalsSymbol,
@@ -333,7 +364,7 @@ public final class NodeSelectorParsers implements PublicStaticHelper {
     private final static Parser<ParserContext> ATSIGN_SYMBOL_PARSER = literal('@',
             NodeSelectorParserToken::atSignSymbol,
             NodeSelectorAtSignSymbolParserToken.class);
-
+    
     static final EbnfIdentifierName ATTRIBUTE_NAME_IDENTIFIER = EbnfIdentifierName.with("ATTRIBUTE_NAME");
     private final static Parser<ParserContext> ATTRIBUTE_NAME_PARSER = name(NodeSelectorAttributeName.INITIAL,
             NodeSelectorAttributeName.PART,

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorPlusSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorPlusSymbolParserToken.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+
+import java.util.List;
+
+/**
+ * Represents a plus symbol token.
+ */
+public final class NodeSelectorPlusSymbolParserToken extends NodeSelectorArithmeticSymbolParserToken {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorPlusSymbolParserToken.class);
+
+    static NodeSelectorPlusSymbolParserToken with(final String value, final String text) {
+        checkValue(value);
+        checkTextNullOrWhitespace(text);
+
+        return new NodeSelectorPlusSymbolParserToken(value, text);
+    }
+
+    private NodeSelectorPlusSymbolParserToken(final String value, final String text) {
+        super(value, text);
+    }
+
+    @Override
+    public NodeSelectorPlusSymbolParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorPlusSymbolParserToken replaceText(final String text) {
+        return new NodeSelectorPlusSymbolParserToken(this.value, text);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is..........................................................................................................
+
+
+    @Override
+    public boolean isDivideSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isEqualsSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isMinusSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isModuloSymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplySymbol() {
+        return false;
+    }
+
+    @Override
+    public boolean isPlusSymbol() {
+        return true;
+    }
+
+    // operator priority..................................................................................................
+
+    @Override
+    int operatorPriority() {
+        return ADDITION_SUBTRACTION_PRIORITY;
+    }
+
+    @Override
+    final NodeSelectorBinaryParserToken binaryOperand(final List<ParserToken> tokens, final String text) {
+        return NodeSelectorParserToken.addition(tokens, text);
+    }
+
+    // Visitor................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    // Object................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorPlusSymbolParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorPredicateParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorPredicateParserToken.java
@@ -70,7 +70,22 @@ public final class NodeSelectorPredicateParserToken extends NodeSelectorParentPa
     // is................................................................................................
 
     @Override
+    public boolean isAddition() {
+        return false;
+    }
+
+    @Override
     public boolean isAnd() {
+        return false;
+    }
+
+    @Override
+    public boolean isAttribute() {
+        return false;
+    }
+
+    @Override
+    public boolean isDivision() {
         return false;
     }
 
@@ -100,12 +115,32 @@ public final class NodeSelectorPredicateParserToken extends NodeSelectorParentPa
     }
 
     @Override
+    public boolean isGroup() {
+        return false;
+    }
+
+    @Override
     public boolean isLessThan() {
         return false;
     }
 
     @Override
     public boolean isLessThanEquals() {
+        return false;
+    }
+
+    @Override
+    public boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
+    public boolean isNegative() {
         return false;
     }
 
@@ -122,6 +157,11 @@ public final class NodeSelectorPredicateParserToken extends NodeSelectorParentPa
     @Override
     public boolean isPredicate() {
         return true;
+    }
+
+    @Override
+    public boolean isSubtraction() {
+        return false;
     }
 
     // Visitor........................................................................................................

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorSlashSeparatorSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorSlashSeparatorSymbolParserToken.java
@@ -22,7 +22,7 @@ import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 /**
  * Represents a slash which often separates components.
  */
-public final class NodeSelectorSlashSeparatorSymbolParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorSlashSeparatorSymbolParserToken extends NodeSelectorNonBinaryOperandSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorSlashSeparatorSymbolParserToken.class);
 
@@ -47,6 +47,11 @@ public final class NodeSelectorSlashSeparatorSymbolParserToken extends NodeSelec
         return new NodeSelectorSlashSeparatorSymbolParserToken(this.value, text);
     }
 
+    @Override
+    void checkText(final String text) {
+        checkTextNullOrEmpty(text);
+    }
+
     // name................................................................................................
 
     @Override
@@ -55,11 +60,6 @@ public final class NodeSelectorSlashSeparatorSymbolParserToken extends NodeSelec
     }
 
     // is..........................................................................................................
-
-    @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
 
     @Override
     public boolean isAtSignSymbol() {
@@ -73,41 +73,6 @@ public final class NodeSelectorSlashSeparatorSymbolParserToken extends NodeSelec
 
     @Override
     public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isNotEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isOrSymbol() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorSubtractionParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorSubtractionParserToken.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.ParserTokenNodeName;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+/**
+ * Holds an subtraction operation.
+ */
+public final class NodeSelectorSubtractionParserToken extends NodeSelectorArithmeticParserToken<NodeSelectorSubtractionParserToken> {
+
+    public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorSubtractionParserToken.class);
+
+    static NodeSelectorSubtractionParserToken with(final List<ParserToken> value, final String text) {
+        return new NodeSelectorSubtractionParserToken(copyAndCheckTokens(value),
+                checkTextNullOrWhitespace(text),
+                WITHOUT_COMPUTE_REQUIRED);
+    }
+
+    private NodeSelectorSubtractionParserToken(final List<ParserToken> value, final String text, final List<ParserToken> valueWithout) {
+        super(value, text, valueWithout);
+    }
+
+    @Override
+    public NodeSelectorSubtractionParserToken setText(final String text) {
+        return this.setText0(text).cast();
+    }
+
+    @Override
+    NodeSelectorSubtractionParserToken replaceText(final String text) {
+        return new NodeSelectorSubtractionParserToken(this.value, text, this.valueIfWithoutSymbolsOrNull());
+    }
+
+    @Override
+    public NodeSelectorSubtractionParserToken setValue(final List<ParserToken> value) {
+        return this.setValue0(value).cast();
+    }
+
+    @Override
+    NodeSelectorParentParserToken replaceValue(final List<ParserToken> tokens, final List<ParserToken> without) {
+        return new NodeSelectorSubtractionParserToken(tokens, this.text(), without);
+    }
+
+    // name................................................................................................
+
+    @Override
+    public ParserTokenNodeName name() {
+        return NAME;
+    }
+
+    // is................................................................................................
+
+    @Override
+    public boolean isAddition() {
+        return false;
+    }
+
+    @Override
+    public boolean isDivision() {
+        return false;
+    }
+
+    @Override
+    public boolean isModulo() {
+        return false;
+    }
+
+    @Override
+    public boolean isMultiplication() {
+        return false;
+    }
+
+    @Override
+    public boolean isSubtraction() {
+        return true;
+    }
+
+    // Visitor........................................................................................................
+
+    @Override
+    public void accept(final NodeSelectorParserTokenVisitor visitor) {
+        if (Visiting.CONTINUE == visitor.startVisit(this)) {
+            this.acceptValues(visitor);
+        }
+        visitor.endVisit(this);
+    }
+
+    // Object........................................................................................................
+
+    @Override
+    boolean canBeEqual(final Object other) {
+        return other instanceof NodeSelectorSubtractionParserToken;
+    }
+}

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorSymbolParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorSymbolParserToken.java
@@ -29,11 +29,6 @@ abstract class NodeSelectorSymbolParserToken extends NodeSelectorLeafParserToken
     }
 
     @Override
-    void checkText(final String text) {
-        checkTextNullOrWhitespace(text);
-    }
-
-    @Override
     public final Optional<NodeSelectorParserToken> withoutSymbols() {
         return Optional.empty();
     }

--- a/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorWhitespaceParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/select/NodeSelectorWhitespaceParserToken.java
@@ -22,7 +22,7 @@ import walkingkooka.text.cursor.parser.ParserTokenNodeName;
 /**
  * Holds the combination any whitespace that may appear within a selector.
  */
-public final class NodeSelectorWhitespaceParserToken extends NodeSelectorSymbolParserToken {
+public final class NodeSelectorWhitespaceParserToken extends NodeSelectorNonBinaryOperandSymbolParserToken {
 
     public final static ParserTokenNodeName NAME = parserTokenNodeName(NodeSelectorWhitespaceParserToken.class);
 
@@ -62,11 +62,6 @@ public final class NodeSelectorWhitespaceParserToken extends NodeSelectorSymbolP
     // is................................................................................................
 
     @Override
-    public boolean isAndSymbol() {
-        return false;
-    }
-
-    @Override
     public boolean isAtSignSymbol() {
         return false;
     }
@@ -78,41 +73,6 @@ public final class NodeSelectorWhitespaceParserToken extends NodeSelectorSymbolP
 
     @Override
     public boolean isBracketCloseSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isGreaterThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isLessThanEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isNotEqualsSymbol() {
-        return false;
-    }
-
-    @Override
-    public boolean isOrSymbol() {
         return false;
     }
 

--- a/src/main/java/walkingkooka/tree/select/ExpressionNodeSelectorNodeSelectorParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/tree/select/ExpressionNodeSelectorNodeSelectorParserTokenVisitor.java
@@ -22,15 +22,21 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.stack.Stack;
 import walkingkooka.collect.stack.Stacks;
 import walkingkooka.text.CharSequences;
+import walkingkooka.text.cursor.parser.select.NodeSelectorAdditionParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorAndParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorAttributeNameParserToken;
+import walkingkooka.text.cursor.parser.select.NodeSelectorDivisionParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorEqualsParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorFunctionNameParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorFunctionParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorGreaterThanEqualsParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorGreaterThanParserToken;
+import walkingkooka.text.cursor.parser.select.NodeSelectorGroupParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorLessThanEqualsParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorLessThanParserToken;
+import walkingkooka.text.cursor.parser.select.NodeSelectorModuloParserToken;
+import walkingkooka.text.cursor.parser.select.NodeSelectorMultiplicationParserToken;
+import walkingkooka.text.cursor.parser.select.NodeSelectorNegativeParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorNotEqualsParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorNumberParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorOrParserToken;
@@ -38,6 +44,7 @@ import walkingkooka.text.cursor.parser.select.NodeSelectorParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorParserTokenVisitor;
 import walkingkooka.text.cursor.parser.select.NodeSelectorPredicateParserToken;
 import walkingkooka.text.cursor.parser.select.NodeSelectorQuotedTextParserToken;
+import walkingkooka.text.cursor.parser.select.NodeSelectorSubtractionParserToken;
 import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.expression.ExpressionNodeName;
 import walkingkooka.tree.expression.ExpressionReference;
@@ -80,6 +87,17 @@ final class ExpressionNodeSelectorNodeSelectorParserTokenVisitor extends NodeSel
     }
 
     @Override
+    protected Visiting startVisit(final NodeSelectorAdditionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorAdditionParserToken token) {
+        this.exitBinary(ExpressionNode::addition, token);
+    }
+
+    @Override
     protected Visiting startVisit(final NodeSelectorAndParserToken token) {
         this.enter();
         return super.startVisit(token);
@@ -88,6 +106,17 @@ final class ExpressionNodeSelectorNodeSelectorParserTokenVisitor extends NodeSel
     @Override
     protected void endVisit(final NodeSelectorAndParserToken token) {
         this.exitBinary(ExpressionNode::and, token);
+    }
+    
+    @Override
+    protected Visiting startVisit(final NodeSelectorDivisionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorDivisionParserToken token) {
+        this.exitBinary(ExpressionNode::division, token);
     }
 
     @Override
@@ -146,6 +175,17 @@ final class ExpressionNodeSelectorNodeSelectorParserTokenVisitor extends NodeSel
     }
 
     @Override
+    protected Visiting startVisit(final NodeSelectorGroupParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorGroupParserToken token) {
+        this.exitBinary(ExpressionNode::addition, token);
+    }
+
+    @Override
     protected Visiting startVisit(final NodeSelectorLessThanParserToken token) {
         this.enter();
         return super.startVisit(token);
@@ -168,6 +208,41 @@ final class ExpressionNodeSelectorNodeSelectorParserTokenVisitor extends NodeSel
     }
 
     @Override
+    protected Visiting startVisit(final NodeSelectorModuloParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorModuloParserToken token) {
+        this.exitBinary(ExpressionNode::modulo, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorMultiplicationParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorMultiplicationParserToken token) {
+        this.exitBinary(ExpressionNode::multiplication, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorNegativeParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorNegativeParserToken token) {
+        final ExpressionNode parameter = this.children.get(0);
+        this.exit();
+        this.add(ExpressionNode.negative(parameter), token);
+    }
+
+    @Override
     protected Visiting startVisit(final NodeSelectorNotEqualsParserToken token) {
         this.enter();
         return super.startVisit(token);
@@ -187,6 +262,17 @@ final class ExpressionNodeSelectorNodeSelectorParserTokenVisitor extends NodeSel
     @Override
     protected void endVisit(final NodeSelectorOrParserToken token) {
         this.exitBinary(ExpressionNode::or, token);
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorSubtractionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorSubtractionParserToken token) {
+        this.exitBinary(ExpressionNode::subtraction, token);
     }
 
     // Leaf................................................................................................

--- a/src/main/resources/walkingkooka/text/cursor/parser/select/node-selector-parsers.grammar
+++ b/src/main/resources/walkingkooka/text/cursor/parser/select/node-selector-parsers.grammar
@@ -21,74 +21,45 @@ AXIS                         = ANCESTOR | ANCESTOR_OR_SELF | CHILD | DESCENDANT 
 (* node .............................................................................................................*)
 NODE                         = NODE_NAME | WILDCARD;
 
-
+(* attribute ........................................................................................................*)
+ATTRIBUTE                    = ATSIGN, ATTRIBUTE_NAME;
 
 (* predicate .......................................................................................................*)
-PREDICATE                    = PREDICATE2,
-                               [ { AND_OR, PREDICATE2 } ],
-                               [ WHITESPACE ];
-
-PREDICATE2                   = [ WHITESPACE ],
-                               ( CONDITION | NUMBER | QUOTED_TEXT | FUNCTION );
-
-AND_OR                       = [ WHITESPACE ],
-                               ( AND | OR );
+PREDICATE                    = [ WHITESPACE ], VALUE, [ WHITESPACE ],
+                               [ { AND_OR, [ WHITESPACE ], VALUE, [ WHITESPACE ]} ];
 
 
-(* condition [@attribute="string-value"] .........................................................................*)
-CONDITION                    = CONDITION_EQUALS | CONDITION_GREATER_THAN_EQUALS | CONDITION_GREATER_THAN |
-                               CONDITION_LESS_THAN_EQUALS | CONDITION_LESS_THAN | CONDITION_NOT_EQUALS;
+AND_OR                       = ( AND | OR );
 
-CONDITION_EQUALS             = CONDITION_VALUE,
-                               [ WHITESPACE ],
-                               EQUALS,
-                               CONDITION_VALUE_REQUIRED;
-                                    
-CONDITION_GREATER_THAN        = CONDITION_VALUE,
-                               [ WHITESPACE ],
-                               GREATER_THAN,
-                               CONDITION_VALUE_REQUIRED;
 
-CONDITION_GREATER_THAN_EQUALS = CONDITION_VALUE,
-                               [ WHITESPACE ],
-                               GREATER_THAN_EQUALS,
-                               CONDITION_VALUE_REQUIRED;
-                                    
-CONDITION_LESS_THAN          = CONDITION_VALUE,
-                               [ WHITESPACE ],
-                               LESS_THAN,
-                               [ WHITESPACE ],
-                               CONDITION_VALUE_REQUIRED;
+(* arithmetic/comparisons .......................................................................................................*)
 
-CONDITION_LESS_THAN_EQUALS   = CONDITION_VALUE,
-                               [ WHITESPACE ],
-                               LESS_THAN_EQUALS,
-                               CONDITION_VALUE_REQUIRED;
-                                    
-CONDITION_NOT_EQUALS         = CONDITION_VALUE,
-                               [ WHITESPACE ],
-                               NOT_EQUALS,
-                               CONDITION_VALUE_REQUIRED;
+BINARY_EXPRESSION              = BINARY_SUB_EXPRESSION, {[ WHITESPACE ], BINARY_OPERATOR, [ WHITESPACE ], BINARY_SUB_EXPRESSION_REQUIRED};
+BINARY_OPERATOR                = PLUS | MINUS | MODULO | MULTIPLY | DIVIDE | EQUALS | NOT_EQUALS | GREATER_THAN_EQUALS | GREATER_THAN | LESS_THAN_EQUALS | LESS_THAN;
+BINARY_SUB_EXPRESSION          = NEGATIVE | GROUP | QUOTED_TEXT | ATTRIBUTE | FUNCTION | NUMBER;
+BINARY_SUB_EXPRESSION_REQUIRED = BINARY_SUB_EXPRESSION;
 
-CONDITION_VALUE              = [ WHITESPACE ],
-                               ( FUNCTION | NAME | NUMBER | QUOTED_TEXT );
 
-CONDITION_VALUE_REQUIRED     = CONDITION_VALUE;
+GROUP 			               = PARENS_OPEN, [ WHITESPACE ], VALUE_REQUIRED, [ WHITESPACE ], PARENS_CLOSE;
+
+
+(* NEGATIVE ........................................................................................................ *)
+NEGATIVE_REQUIRED   = [ WHITESPACE ],
+                      ( GROUP | BINARY_EXPRESSION | QUOTED_TEXT | ATTRIBUTE | FUNCTION | NUMBER );
+NEGATIVE		    = MINUS, [ WHITESPACE ], NEGATIVE_REQUIRED;
+
 
 (* [starts-with(@attribute, "string-value") ..........................................................................*)
-FUNCTION                     = FUNCTION_NAME, PARENS_OPEN, [ WHITESPACE ], [ FUNCTION_PARAMETERS ], [ WHITESPACE ], PARENS_CLOSE;
+FUNCTION                  = FUNCTION_NAME, PARENS_OPEN, [ WHITESPACE ], [ FUNCTION_PARAMETERS ], [ WHITESPACE ], PARENS_CLOSE;
 
-FUNCTION_PARAMETERS          = [ VALUE, [{ FUNCTION_PARAMETER_OTHERS }]];
+FUNCTION_PARAMETERS       = [ VALUE, [{ FUNCTION_PARAMETER_OTHERS }]];
 
-FUNCTION_PARAMETER_OTHERS    = [ WHITESPACE ],
-                               PARAMETER_SEPARATOR,
-                               VALUE_REQUIRED;
+FUNCTION_PARAMETER_OTHERS = [ WHITESPACE ],
+                            PARAMETER_SEPARATOR,
+                            [ WHITESPACE ],
+                            VALUE_REQUIRED;
 
-NAME                         = ( ATSIGN, ATTRIBUTE_NAME ) |
-                               NODE_NAME;
 
-VALUE                        = [ WHITESPACE ],
-                               ( FUNCTION | NAME | CONDITION | NUMBER | QUOTED_TEXT );
-
-VALUE_REQUIRED               = VALUE;
-
+(* values .............................................................................................................*)
+VALUE          = NEGATIVE | BINARY_EXPRESSION | GROUP | QUOTED_TEXT | ATTRIBUTE | FUNCTION | NUMBER;
+VALUE_REQUIRED = VALUE;

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorAdditionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorAdditionParserTokenTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorAdditionParserTokenTest extends NodeSelectorBinaryParserTokenTestCase<NodeSelectorAdditionParserToken> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final NodeSelectorAdditionParserToken add = this.createToken();
+
+        final NodeSelectorNodeNameParserToken nodeName = add.value().get(0).cast();
+        final NodeSelectorPlusSymbolParserToken addSymbol = add.value().get(1).cast();
+        final NodeSelectorWildcardParserToken wildcard = add.value().get(2).cast();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken n) {
+                b.append("1");
+                visited.add(n);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken n) {
+                b.append("2");
+                visited.add(n);
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorAdditionParserToken t) {
+                assertSame(add, t);
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorAdditionParserToken t) {
+                assertSame(add, t);
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorNodeNameParserToken t) {
+                assertSame(nodeName, t);
+                b.append("5");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorPlusSymbolParserToken t) {
+                assertSame(addSymbol, t);
+                b.append("6");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorWildcardParserToken t) {
+                assertSame(wildcard, t);
+                b.append("7");
+                visited.add(t);
+            }
+
+        }.accept(add);
+        assertEquals("1315216217242", b.toString());
+        assertEquals(Lists.<Object>of(add, add,
+                nodeName, nodeName, nodeName,
+                addSymbol, addSymbol, addSymbol,
+                wildcard, wildcard, wildcard,
+                add, add),
+                visited,
+                "visited");
+    }
+
+    @Override
+    NodeSelectorAdditionParserToken createToken(final String text, final List<ParserToken> tokens) {
+        return NodeSelectorAdditionParserToken.with(tokens, text);
+    }
+
+    @Override
+    NodeSelectorParserToken operatorSymbol() {
+        return plusSymbol();
+    }
+
+    @Override
+    public Class<NodeSelectorAdditionParserToken> type() {
+        return NodeSelectorAdditionParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorArithmeticParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorArithmeticParserTokenTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.Cast;
+import walkingkooka.test.ClassTesting2;
+import walkingkooka.type.MemberVisibility;
+
+public final class NodeSelectorArithmeticParserTokenTest implements ClassTesting2<NodeSelectorArithmeticParserToken<?>> {
+
+    @Override
+    public Class<NodeSelectorArithmeticParserToken<?>> type() {
+        return Cast.to(NodeSelectorArithmeticParserToken.class);
+    }
+
+    @Override
+    public MemberVisibility typeVisibility() {
+        return MemberVisibility.PUBLIC;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorArithmeticSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorArithmeticSymbolParserTokenTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.Cast;
+import walkingkooka.test.ClassTesting2;
+import walkingkooka.type.MemberVisibility;
+
+public final class NodeSelectorArithmeticSymbolParserTokenTest implements ClassTesting2<NodeSelectorArithmeticSymbolParserToken> {
+
+    @Override
+    public Class<NodeSelectorArithmeticSymbolParserToken> type() {
+        return Cast.to(NodeSelectorArithmeticSymbolParserToken.class);
+    }
+
+    @Override
+    public MemberVisibility typeVisibility() {
+        return MemberVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorAttributeParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorAttributeParserTokenTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorAttributeParserTokenTest extends NodeSelectorParentParserTokenTestCase<NodeSelectorAttributeParserToken> {
+
+    // @id
+
+    @Test
+    public void testWithoutSymbols() {
+        final NodeSelectorAttributeParserToken attribute = this.createToken();
+        final NodeSelectorAttributeParserToken without = attribute.withoutSymbols().get().cast();
+        assertEquals(Lists.of(attributeName()), without.value(), "value");
+
+        this.checkAttributeName(this.createToken());
+        this.checkAttributeName(without);
+    }
+
+    @Test
+    public void testAttributeName() {
+        this.checkAttributeName(this.createToken());
+    }
+
+    private void checkAttributeName(final NodeSelectorAttributeParserToken token) {
+        assertEquals(attributeName().value(), token.attributeName(), "attributeName");
+    }
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final NodeSelectorAttributeParserToken attribute = this.createToken();
+        final NodeSelectorAtSignSymbolParserToken atSign = attribute.value().get(0).cast();
+        final NodeSelectorAttributeNameParserToken name = attribute.value().get(1).cast();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken n) {
+                b.append("1");
+                visited.add(n);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken n) {
+                b.append("2");
+                visited.add(n);
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorAttributeParserToken t) {
+                assertSame(attribute, t);
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorAttributeParserToken t) {
+                assertSame(attribute, t);
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorAtSignSymbolParserToken t) {
+                assertSame(atSign, t);
+                b.append("5");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorAttributeNameParserToken t) {
+                assertSame(name, t);
+                b.append("6");
+                visited.add(t);
+            }
+        }.accept(attribute);
+
+        assertEquals("1315216242", b.toString());
+        assertEquals(Lists.<Object>of(attribute, attribute,
+                atSign, atSign, atSign,
+                name, name, name,
+                attribute, attribute),
+                visited,
+                "visited");
+    }
+
+    @Override
+    NodeSelectorAttributeParserToken createToken(final String text, final List<ParserToken> tokens) {
+        return NodeSelectorAttributeParserToken.with(tokens, text);
+    }
+
+    @Override
+    public String text() {
+        return "@" + attributeName();
+    }
+
+    @Override
+    List<ParserToken> tokens() {
+        return Lists.of(atSign(), attributeName());
+    }
+
+    @Override
+    public NodeSelectorAttributeParserToken createDifferentToken() {
+        return attribute(atSign(), attributeName2());
+    }
+
+    @Override
+    public Class<NodeSelectorAttributeParserToken> type() {
+        return NodeSelectorAttributeParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorBinaryOperandSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorBinaryOperandSymbolParserTokenTest.java
@@ -22,14 +22,15 @@ import walkingkooka.Cast;
 import walkingkooka.test.ClassTesting2;
 import walkingkooka.type.MemberVisibility;
 
-public final class NodeSelectorConditionParserTokenTest implements ClassTesting2<NodeSelectorConditionParserToken<?>> {
+public final class NodeSelectorBinaryOperandSymbolParserTokenTest implements ClassTesting2<NodeSelectorBinaryOperandSymbolParserToken> {
 
     @Override
-    public Class<NodeSelectorConditionParserToken<?>> type() {
-        return Cast.to(NodeSelectorConditionParserToken.class);
+    public Class<NodeSelectorBinaryOperandSymbolParserToken> type() {
+        return Cast.to(NodeSelectorBinaryOperandSymbolParserToken.class);
     }
 
-    @Override public MemberVisibility typeVisibility() {
-        return MemberVisibility.PUBLIC;
+    @Override
+    public MemberVisibility typeVisibility() {
+        return MemberVisibility.PACKAGE_PRIVATE;
     }
 }

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorComparisonParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorComparisonParserTokenTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.Cast;
+import walkingkooka.test.ClassTesting2;
+import walkingkooka.type.MemberVisibility;
+
+public final class NodeSelectorComparisonParserTokenTest implements ClassTesting2<NodeSelectorComparisonParserToken<?>> {
+
+    @Override
+    public Class<NodeSelectorComparisonParserToken<?>> type() {
+        return Cast.to(NodeSelectorComparisonParserToken.class);
+    }
+
+    @Override public MemberVisibility typeVisibility() {
+        return MemberVisibility.PUBLIC;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorComparisonSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorComparisonSymbolParserTokenTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.Cast;
+import walkingkooka.test.ClassTesting2;
+import walkingkooka.type.MemberVisibility;
+
+public final class NodeSelectorComparisonSymbolParserTokenTest implements ClassTesting2<NodeSelectorComparisonSymbolParserToken> {
+
+    @Override
+    public Class<NodeSelectorComparisonSymbolParserToken> type() {
+        return Cast.to(NodeSelectorComparisonSymbolParserToken.class);
+    }
+
+    @Override
+    public MemberVisibility typeVisibility() {
+        return MemberVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorDivideSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorDivideSymbolParserTokenTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorDivideSymbolParserTokenTest extends NodeSelectorSymbolParserTokenTestCase<NodeSelectorDivideSymbolParserToken, String> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final NodeSelectorSymbolParserToken token = this.createToken();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final NodeSelectorDivideSymbolParserToken t) {
+                assertSame(token, t);
+                b.append("5");
+            }
+        }.accept(token);
+        assertEquals("13542", b.toString());
+    }
+
+    @Override
+    public String text() {
+        return "div";
+    }
+
+    @Override
+    String value() {
+        return this.text();
+    }
+
+    @Override
+    NodeSelectorDivideSymbolParserToken createToken(final String value, final String text) {
+        return NodeSelectorDivideSymbolParserToken.with(value, text);
+    }
+
+    @Override
+    public NodeSelectorDivideSymbolParserToken createDifferentToken() {
+        return NodeSelectorDivideSymbolParserToken.with(this.text(), "different");
+    }
+
+    @Override
+    public Class<NodeSelectorDivideSymbolParserToken> type() {
+        return NodeSelectorDivideSymbolParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorDivisionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorDivisionParserTokenTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorDivisionParserTokenTest extends NodeSelectorBinaryParserTokenTestCase<NodeSelectorDivisionParserToken> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final NodeSelectorDivisionParserToken division = this.createToken();
+
+        final NodeSelectorNodeNameParserToken nodeName = division.value().get(0).cast();
+        final NodeSelectorDivideSymbolParserToken divide = division.value().get(1).cast();
+        final NodeSelectorWildcardParserToken wildcard = division.value().get(2).cast();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken n) {
+                b.append("1");
+                visited.add(n);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken n) {
+                b.append("2");
+                visited.add(n);
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorDivisionParserToken t) {
+                assertSame(division, t);
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorDivisionParserToken t) {
+                assertSame(division, t);
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorNodeNameParserToken t) {
+                assertSame(nodeName, t);
+                b.append("5");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorDivideSymbolParserToken t) {
+                assertSame(divide, t);
+                b.append("6");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorWildcardParserToken t) {
+                assertSame(wildcard, t);
+                b.append("7");
+                visited.add(t);
+            }
+
+        }.accept(division);
+        assertEquals("1315216217242", b.toString());
+        assertEquals(Lists.<Object>of(division, division,
+                nodeName, nodeName, nodeName,
+                divide, divide, divide,
+                wildcard, wildcard, wildcard,
+                division, division),
+                visited,
+                "visited");
+    }
+
+    @Override
+    NodeSelectorDivisionParserToken createToken(final String text, final List<ParserToken> tokens) {
+        return NodeSelectorDivisionParserToken.with(tokens, text);
+    }
+
+    @Override
+    NodeSelectorParserToken operatorSymbol() {
+        return divideSymbol();
+    }
+
+    @Override
+    public Class<NodeSelectorDivisionParserToken> type() {
+        return NodeSelectorDivisionParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorGroupParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorGroupParserTokenTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorGroupParserTokenTest extends NodeSelectorParentParserTokenTestCase<NodeSelectorGroupParserToken> {
+
+    // (1)
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final NodeSelectorGroupParserToken expression = this.createToken();
+
+        final NodeSelectorParenthesisOpenSymbolParserToken open = expression.value().get(0).cast();
+        final NodeSelectorNumberParserToken number = expression.value().get(1).cast();
+        final NodeSelectorParenthesisCloseSymbolParserToken close = expression.value().get(2).cast();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken n) {
+                b.append("1");
+                visited.add(n);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken n) {
+                b.append("2");
+                visited.add(n);
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorGroupParserToken t) {
+                assertSame(expression, t);
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorGroupParserToken t) {
+                assertSame(expression, t);
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorParenthesisOpenSymbolParserToken t) {
+                assertSame(open, t);
+                b.append("5");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorNumberParserToken t) {
+                assertSame(number, t);
+                b.append("6");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorParenthesisCloseSymbolParserToken t) {
+                assertSame(close, t);
+                b.append("7");
+                visited.add(t);
+            }
+        }.accept(expression);
+        assertEquals("1315216217242", b.toString());
+        assertEquals(Lists.of(expression, expression,
+                open, open, open, number, number, number, close, close, close,
+                expression, expression),
+                visited,
+                "visited");
+    }
+
+    @Test
+    public void testWithoutSymbolsExpressionWhitespace() {
+        final NodeSelectorGroupParserToken expression = this.createToken();
+        final NodeSelectorGroupParserToken without = expression.withoutSymbols().get().cast();
+        assertEquals(Lists.of(number()), without.value(), "value");
+    }
+
+    @Override
+    NodeSelectorGroupParserToken createToken(final String text, final List<ParserToken> tokens) {
+        return NodeSelectorGroupParserToken.with(tokens, text);
+    }
+
+    @Override
+    public String text() {
+        return "(1)";
+    }
+
+    @Override
+    List<ParserToken> tokens() {
+        return Lists.of(parenthesisOpen(), number(), parenthesisClose());
+    }
+
+    @Override
+    public NodeSelectorGroupParserToken createDifferentToken() {
+        return group(parenthesisOpen(), this.number(), this.plusSymbol(), this.number2(), parenthesisClose());
+    }
+
+    @Override
+    public Class<NodeSelectorGroupParserToken> type() {
+        return NodeSelectorGroupParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorMinusSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorMinusSymbolParserTokenTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorMinusSymbolParserTokenTest extends NodeSelectorSymbolParserTokenTestCase<NodeSelectorMinusSymbolParserToken, String> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final NodeSelectorSymbolParserToken token = this.createToken();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final NodeSelectorMinusSymbolParserToken t) {
+                assertSame(token, t);
+                b.append("5");
+            }
+        }.accept(token);
+        assertEquals("13542", b.toString());
+    }
+
+    @Override
+    public String text() {
+        return "-";
+    }
+
+    @Override
+    String value() {
+        return this.text();
+    }
+
+    @Override
+    NodeSelectorMinusSymbolParserToken createToken(final String value, final String text) {
+        return NodeSelectorMinusSymbolParserToken.with(value, text);
+    }
+
+    @Override
+    public NodeSelectorMinusSymbolParserToken createDifferentToken() {
+        return NodeSelectorMinusSymbolParserToken.with(this.text(), "different");
+    }
+
+    @Override
+    public Class<NodeSelectorMinusSymbolParserToken> type() {
+        return NodeSelectorMinusSymbolParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorModuloParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorModuloParserTokenTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorModuloParserTokenTest extends NodeSelectorBinaryParserTokenTestCase<NodeSelectorModuloParserToken> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final NodeSelectorModuloParserToken modulo = this.createToken();
+
+        final NodeSelectorNodeNameParserToken nodeName = modulo.value().get(0).cast();
+        final NodeSelectorModuloSymbolParserToken moduloSymbol = modulo.value().get(1).cast();
+        final NodeSelectorWildcardParserToken wildcard = modulo.value().get(2).cast();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken n) {
+                b.append("1");
+                visited.add(n);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken n) {
+                b.append("2");
+                visited.add(n);
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorModuloParserToken t) {
+                assertSame(modulo, t);
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorModuloParserToken t) {
+                assertSame(modulo, t);
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorNodeNameParserToken t) {
+                assertSame(nodeName, t);
+                b.append("5");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorModuloSymbolParserToken t) {
+                assertSame(moduloSymbol, t);
+                b.append("6");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorWildcardParserToken t) {
+                assertSame(wildcard, t);
+                b.append("7");
+                visited.add(t);
+            }
+
+        }.accept(modulo);
+        assertEquals("1315216217242", b.toString());
+        assertEquals(Lists.<Object>of(modulo, modulo,
+                nodeName, nodeName, nodeName,
+                moduloSymbol, moduloSymbol, moduloSymbol,
+                wildcard, wildcard, wildcard,
+                modulo, modulo),
+                visited,
+                "visited");
+    }
+
+    @Override
+    NodeSelectorModuloParserToken createToken(final String text, final List<ParserToken> tokens) {
+        return NodeSelectorModuloParserToken.with(tokens, text);
+    }
+
+    @Override
+    NodeSelectorParserToken operatorSymbol() {
+        return moduloSymbol();
+    }
+
+    @Override
+    public Class<NodeSelectorModuloParserToken> type() {
+        return NodeSelectorModuloParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorModuloSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorModuloSymbolParserTokenTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorModuloSymbolParserTokenTest extends NodeSelectorSymbolParserTokenTestCase<NodeSelectorModuloSymbolParserToken, String> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final NodeSelectorSymbolParserToken token = this.createToken();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final NodeSelectorModuloSymbolParserToken t) {
+                assertSame(token, t);
+                b.append("5");
+            }
+        }.accept(token);
+        assertEquals("13542", b.toString());
+    }
+
+    @Override
+    public String text() {
+        return "mod";
+    }
+
+    @Override
+    String value() {
+        return this.text();
+    }
+
+    @Override
+    NodeSelectorModuloSymbolParserToken createToken(final String value, final String text) {
+        return NodeSelectorModuloSymbolParserToken.with(value, text);
+    }
+
+    @Override
+    public NodeSelectorModuloSymbolParserToken createDifferentToken() {
+        return NodeSelectorModuloSymbolParserToken.with(this.text(), "different");
+    }
+
+    @Override
+    public Class<NodeSelectorModuloSymbolParserToken> type() {
+        return NodeSelectorModuloSymbolParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorMultiplicationParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorMultiplicationParserTokenTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorMultiplicationParserTokenTest extends NodeSelectorBinaryParserTokenTestCase<NodeSelectorMultiplicationParserToken> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final NodeSelectorMultiplicationParserToken multiply = this.createToken();
+
+        final NodeSelectorNodeNameParserToken nodeName = multiply.value().get(0).cast();
+        final NodeSelectorMultiplySymbolParserToken multiplySymbol = multiply.value().get(1).cast();
+        final NodeSelectorWildcardParserToken wildcard = multiply.value().get(2).cast();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken n) {
+                b.append("1");
+                visited.add(n);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken n) {
+                b.append("2");
+                visited.add(n);
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorMultiplicationParserToken t) {
+                assertSame(multiply, t);
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorMultiplicationParserToken t) {
+                assertSame(multiply, t);
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorNodeNameParserToken t) {
+                assertSame(nodeName, t);
+                b.append("5");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorMultiplySymbolParserToken t) {
+                assertSame(multiplySymbol, t);
+                b.append("6");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorWildcardParserToken t) {
+                assertSame(wildcard, t);
+                b.append("7");
+                visited.add(t);
+            }
+
+        }.accept(multiply);
+        assertEquals("1315216217242", b.toString());
+        assertEquals(Lists.<Object>of(multiply, multiply,
+                nodeName, nodeName, nodeName,
+                multiplySymbol, multiplySymbol, multiplySymbol,
+                wildcard, wildcard, wildcard,
+                multiply, multiply),
+                visited,
+                "visited");
+    }
+
+    @Override
+    NodeSelectorMultiplicationParserToken createToken(final String text, final List<ParserToken> tokens) {
+        return NodeSelectorMultiplicationParserToken.with(tokens, text);
+    }
+
+    @Override
+    NodeSelectorParserToken operatorSymbol() {
+        return multiplySymbol();
+    }
+
+    @Override
+    public Class<NodeSelectorMultiplicationParserToken> type() {
+        return NodeSelectorMultiplicationParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorMultiplySymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorMultiplySymbolParserTokenTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorMultiplySymbolParserTokenTest extends NodeSelectorSymbolParserTokenTestCase<NodeSelectorMultiplySymbolParserToken, String> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final NodeSelectorSymbolParserToken token = this.createToken();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final NodeSelectorMultiplySymbolParserToken t) {
+                assertSame(token, t);
+                b.append("5");
+            }
+        }.accept(token);
+        assertEquals("13542", b.toString());
+    }
+
+    @Override
+    public String text() {
+        return "*";
+    }
+
+    @Override
+    String value() {
+        return this.text();
+    }
+
+    @Override
+    NodeSelectorMultiplySymbolParserToken createToken(final String value, final String text) {
+        return NodeSelectorMultiplySymbolParserToken.with(value, text);
+    }
+
+    @Override
+    public NodeSelectorMultiplySymbolParserToken createDifferentToken() {
+        return NodeSelectorMultiplySymbolParserToken.with(this.text(), "different");
+    }
+
+    @Override
+    public Class<NodeSelectorMultiplySymbolParserToken> type() {
+        return NodeSelectorMultiplySymbolParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorNegativeParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorNegativeParserTokenTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorNegativeParserTokenTest extends NodeSelectorParentParserTokenTestCase<NodeSelectorNegativeParserToken> {
+
+    // -123
+
+    @Test
+    public void testWithoutSymbols() {
+        final NodeSelectorNegativeParserToken negative = this.createToken();
+        final NodeSelectorNegativeParserToken without = negative.withoutSymbols().get().cast();
+        assertEquals(Lists.of(number()), without.value(), "value");
+    }
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final NodeSelectorNegativeParserToken negative = this.createToken();
+        final NodeSelectorMinusSymbolParserToken minus = negative.value().get(0).cast();
+        final NodeSelectorNumberParserToken number = negative.value().get(1).cast();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken n) {
+                b.append("1");
+                visited.add(n);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken n) {
+                b.append("2");
+                visited.add(n);
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorNegativeParserToken t) {
+                assertSame(negative, t);
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorNegativeParserToken t) {
+                assertSame(negative, t);
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorMinusSymbolParserToken t) {
+                assertSame(minus, t);
+                b.append("5");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorNumberParserToken t) {
+                assertSame(number, t);
+                b.append("6");
+                visited.add(t);
+            }
+        }.accept(negative);
+
+        assertEquals("1315216242", b.toString());
+        assertEquals(Lists.<Object>of(negative, negative,
+                minus, minus, minus,
+                number, number, number,
+                negative, negative),
+                visited,
+                "visited");
+    }
+
+    @Override
+    NodeSelectorNegativeParserToken createToken(final String text, final List<ParserToken> tokens) {
+        return NodeSelectorNegativeParserToken.with(tokens, text);
+    }
+
+    @Override
+    public String text() {
+        return "-1";
+    }
+
+    @Override
+    List<ParserToken> tokens() {
+        return Lists.of(minusSymbol(), number());
+    }
+
+    @Override
+    public NodeSelectorNegativeParserToken createDifferentToken() {
+        return negative(minusSymbol(), number2());
+    }
+
+    @Override
+    public Class<NodeSelectorNegativeParserToken> type() {
+        return NodeSelectorNegativeParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorNonBinaryOperandSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorNonBinaryOperandSymbolParserTokenTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import walkingkooka.Cast;
+import walkingkooka.test.ClassTesting2;
+import walkingkooka.type.MemberVisibility;
+
+public final class NodeSelectorNonBinaryOperandSymbolParserTokenTest implements ClassTesting2<NodeSelectorNonBinaryOperandSymbolParserToken> {
+
+    @Override
+    public Class<NodeSelectorNonBinaryOperandSymbolParserToken> type() {
+        return Cast.to(NodeSelectorNonBinaryOperandSymbolParserToken.class);
+    }
+
+    @Override
+    public MemberVisibility typeVisibility() {
+        return MemberVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorParserPrettyNodeSelectorParserTokenVisitor.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorParserPrettyNodeSelectorParserTokenVisitor.java
@@ -67,6 +67,17 @@ final class NodeSelectorParserPrettyNodeSelectorParserTokenVisitor extends NodeS
     }
 
     @Override
+    protected Visiting startVisit(final NodeSelectorAdditionParserToken token) {
+        this.printer.enter(token);
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorAdditionParserToken token) {
+        this.printer.exit(token);
+    }
+
+    @Override
     protected Visiting startVisit(final NodeSelectorAndParserToken token) {
         this.printer.enter(token);
         return super.startVisit(token);
@@ -74,6 +85,28 @@ final class NodeSelectorParserPrettyNodeSelectorParserTokenVisitor extends NodeS
 
     @Override
     protected void endVisit(final NodeSelectorAndParserToken token) {
+        this.printer.exit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorAttributeParserToken token) {
+        this.printer.enter(token);
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorAttributeParserToken token) {
+        this.printer.exit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorDivisionParserToken token) {
+        this.printer.enter(token);
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorDivisionParserToken token) {
         this.printer.exit(token);
     }
 
@@ -128,6 +161,17 @@ final class NodeSelectorParserPrettyNodeSelectorParserTokenVisitor extends NodeS
     }
 
     @Override
+    protected Visiting startVisit(final NodeSelectorGroupParserToken token) {
+        this.printer.enter(token);
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorGroupParserToken token) {
+        this.printer.exit(token);
+    }
+
+    @Override
     protected void endVisit(final NodeSelectorGreaterThanEqualsParserToken token) {
         this.printer.exit(token);
     }
@@ -151,6 +195,28 @@ final class NodeSelectorParserPrettyNodeSelectorParserTokenVisitor extends NodeS
 
     @Override
     protected void endVisit(final NodeSelectorLessThanEqualsParserToken token) {
+        this.printer.exit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorModuloParserToken token) {
+        this.printer.enter(token);
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorModuloParserToken token) {
+        this.printer.exit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorMultiplicationParserToken token) {
+        this.printer.enter(token);
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorMultiplicationParserToken token) {
         this.printer.exit(token);
     }
 
@@ -184,6 +250,17 @@ final class NodeSelectorParserPrettyNodeSelectorParserTokenVisitor extends NodeS
 
     @Override
     protected void endVisit(final NodeSelectorPredicateParserToken token) {
+        this.printer.exit(token);
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorSubtractionParserToken token) {
+        this.printer.enter(token);
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorSubtractionParserToken token) {
         this.printer.exit(token);
     }
 

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorParserTokenTestCase.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorParserTokenTestCase.java
@@ -57,6 +57,10 @@ public abstract class NodeSelectorParserTokenTestCase<T extends NodeSelectorPars
         return NodeSelectorParserToken.absolute("/", "/");
     }
 
+    final NodeSelectorAdditionParserToken addition(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.addition(Lists.of(tokens), text(tokens));
+    }
+
     final NodeSelectorParserToken ancestor() {
         return NodeSelectorParserToken.ancestor("ancestor::", "ancestor::");
     }
@@ -65,7 +69,7 @@ public abstract class NodeSelectorParserTokenTestCase<T extends NodeSelectorPars
         return NodeSelectorParserToken.ancestorOrSelf("ancestor-or-self::", "ancestor-or-self::");
     }
 
-    final NodeSelectorAndParserToken and(final NodeSelectorParserToken... tokens) {
+    final NodeSelectorParserToken and(final NodeSelectorParserToken... tokens) {
         return NodeSelectorParserToken.and(Lists.of(tokens), text(tokens));
     }
 
@@ -77,15 +81,19 @@ public abstract class NodeSelectorParserTokenTestCase<T extends NodeSelectorPars
         return NodeSelectorParserToken.atSignSymbol("@", "@");
     }
 
-    final NodeSelectorParserToken attributeName() {
+    final NodeSelectorAttributeParserToken attribute(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.attribute(Lists.of(tokens), text(tokens));
+    }
+
+    final NodeSelectorAttributeNameParserToken attributeName() {
         return attributeName("attribute1");
     }
 
-    final NodeSelectorParserToken attributeName2() {
+    final NodeSelectorAttributeNameParserToken attributeName2() {
         return attributeName("attribute2");
     }
 
-    final NodeSelectorParserToken attributeName(final String name) {
+    final NodeSelectorAttributeNameParserToken attributeName(final String name) {
         return NodeSelectorParserToken.attributeName(NodeSelectorAttributeName.with(name), name);
     }
 
@@ -115,6 +123,14 @@ public abstract class NodeSelectorParserTokenTestCase<T extends NodeSelectorPars
 
     final NodeSelectorParserToken descendantOrSelfSlashSlash() {
         return NodeSelectorParserToken.descendantOrSelf("//", "//");
+    }
+
+    final NodeSelectorParserToken divideSymbol() {
+        return NodeSelectorParserToken.divideSymbol("div", "div");
+    }
+
+    final NodeSelectorParserToken division(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.division(Lists.of(tokens), text(tokens));
     }
 
     final NodeSelectorEqualsParserToken equalsParserToken(final NodeSelectorParserToken... tokens) {
@@ -177,6 +193,10 @@ public abstract class NodeSelectorParserTokenTestCase<T extends NodeSelectorPars
         return NodeSelectorParserToken.greaterThanEqualsSymbol(">=", ">=");
     }
 
+    final NodeSelectorGroupParserToken group(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.group(Lists.of(tokens), text(tokens));
+    }
+
     final NodeSelectorLessThanParserToken lessThan(final NodeSelectorParserToken... tokens) {
         return NodeSelectorParserToken.lessThan(Lists.of(tokens), text(tokens));
     }
@@ -195,6 +215,30 @@ public abstract class NodeSelectorParserTokenTestCase<T extends NodeSelectorPars
 
     final NodeSelectorParserToken lastChild() {
         return NodeSelectorParserToken.lastChild("last-child::", "last-child::");
+    }
+
+    final NodeSelectorParserToken minusSymbol() {
+        return NodeSelectorParserToken.minusSymbol("-", "-");
+    }
+
+    final NodeSelectorParserToken modulo(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.modulo(Lists.of(tokens), text(tokens));
+    }
+
+    final NodeSelectorParserToken moduloSymbol() {
+        return NodeSelectorParserToken.moduloSymbol("mod", "mod");
+    }
+
+    final NodeSelectorMultiplicationParserToken multiplication(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.multiplication(Lists.of(tokens), text(tokens));
+    }
+
+    final NodeSelectorParserToken multiplySymbol() {
+        return NodeSelectorParserToken.multiplySymbol("*", "*");
+    }
+
+    final NodeSelectorNegativeParserToken negative(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.negative(Lists.of(tokens), text(tokens));
     }
 
     final NodeSelectorParserToken nodeName() {
@@ -253,6 +297,10 @@ public abstract class NodeSelectorParserTokenTestCase<T extends NodeSelectorPars
         return NodeSelectorParserToken.parentOf("..", "..");
     }
 
+    final NodeSelectorParserToken plusSymbol() {
+        return NodeSelectorParserToken.plusSymbol("+", "+");
+    }
+
     final NodeSelectorParserToken preceding() {
         return NodeSelectorParserToken.preceding("preceding::", "preceding::");
     }
@@ -287,6 +335,10 @@ public abstract class NodeSelectorParserTokenTestCase<T extends NodeSelectorPars
 
     final NodeSelectorParserToken slash() {
         return NodeSelectorParserToken.slashSeparatorSymbol("/", "/");
+    }
+
+    final NodeSelectorSubtractionParserToken subtraction(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.subtraction(Lists.of(tokens), text(tokens));
     }
 
     final NodeSelectorParserToken whitespace() {

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorParsersTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorParsersTest.java
@@ -239,6 +239,92 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 bracketClose());
     }
 
+    // absolute nodeName predicate number.....................................................................
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenNumberBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        number()),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenWhitespaceNumberWhitespaceBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        whitespace(), number(), whitespace()),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenNegativeNumberBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        negative(
+                                minusSymbol(),
+                                number()
+                        )
+                ),
+                bracketClose());
+    }
+
+    // absolute nodeName predicate quoted text.....................................................................
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenQuotedTextBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        quotedText()
+                ),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenWhitespaceQuotedTextWhitespaceBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        whitespace(), quotedText(), whitespace()
+                ),
+                bracketClose());
+    }
+
+    // absolute nodeName predicate attribute.....................................................................
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenAttributeBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        attribute(atSign(), attributeName())
+                ),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenWhitespaceAttributeWhitespaceBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        whitespace(),
+                        attribute(atSign(), attributeName()),
+                        whitespace()
+                ),
+                bracketClose());
+    }
+
     // absolute nodeName predicate function.....................................................................
 
     // /nodeName [
@@ -247,7 +333,13 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
-                predicate(function(functionName(), parenthesisOpen(), parenthesisClose())),
+                predicate(
+                        function(
+                                functionName(),
+                                parenthesisOpen(),
+                                parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
@@ -257,7 +349,13 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        function(functionName(), parenthesisOpen(), whitespace(), parenthesisClose())),
+                        function(
+                                functionName(),
+                                parenthesisOpen(),
+                                    whitespace(),
+                                parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
@@ -266,8 +364,13 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
-                predicate(whitespace(), function(
-                        functionName(), parenthesisOpen(), whitespace(), parenthesisClose()),
+                predicate(whitespace(),
+                        function(
+                            functionName(),
+                                parenthesisOpen(),
+                                    whitespace(),
+                                parenthesisClose()
+                        ),
                         whitespace()),
                 bracketClose());
     }
@@ -278,7 +381,13 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        function(functionName(), parenthesisOpen(), number(), parenthesisClose())),
+                        function(
+                                functionName(),
+                                parenthesisOpen(),
+                                    number(),
+                                parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
@@ -288,7 +397,13 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        function(functionName(), parenthesisOpen(), number(), comma(), number2(), parenthesisClose())),
+                        function(
+                                functionName(),
+                                parenthesisOpen(),
+                                    number(), comma(), number2(),
+                                parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
@@ -298,7 +413,13 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        function(functionName(), parenthesisOpen(), number(), comma(), number2(), comma(), number(3), parenthesisClose())),
+                        function(
+                                functionName(),
+                                parenthesisOpen(),
+                                    number(), comma(), number2(), comma(), number(3),
+                                parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
@@ -308,7 +429,13 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        function(functionName(), parenthesisOpen(), quotedText(), parenthesisClose())),
+                        function(
+                                functionName(),
+                                parenthesisOpen(),
+                                    quotedText(),
+                                parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
@@ -324,7 +451,7 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 bracketClose());
     }
 
-    // absolute nodeName predicate condition.....................................................................
+    // absolute nodeName predicate EQ.....................................................................
 
     @Test
     public void testAbsoluteNodeNameBracketOpenNumberEqualsNumberBracketClose() {
@@ -332,7 +459,69 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        equalsParserToken(number(), equalsSymbol(), number2())),
+                        equalsParserToken(
+                                number(),
+                                equalsSymbol(),
+                                number2()
+                        )
+                ),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenNegativeNumberEqualsNumberBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        equalsParserToken(
+                                negative(
+                                        minusSymbol(),
+                                        number()
+                                ),
+                                equalsSymbol(),
+                                number2()
+                        )
+                ),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenNumberEqualsNegativeNumberBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        equalsParserToken(
+                                number(),
+                                equalsSymbol(),
+                                negative(
+                                        minusSymbol(),
+                                        number2()
+                                )
+                        )
+                ),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenNegativeNumberEqualsNegativeNumberBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        equalsParserToken(
+                                negative(
+                                        minusSymbol(),
+                                        number()
+                                ),
+                                equalsSymbol(),
+                                negative(
+                                        minusSymbol(),
+                                        number2()
+                                )
+                        )
+                ),
                 bracketClose());
     }
 
@@ -347,6 +536,40 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
     }
 
     @Test
+    public void testAbsoluteNodeNameBracketOpenFunctionEqualsNumberBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        equalsParserToken(
+                                function(functionName(), parenthesisOpen(), parenthesisClose()),
+                                equalsSymbol(),
+                                number()
+                        )
+                ),
+                bracketClose());
+    }
+
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenNegativeFunctionEqualsNumberBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        equalsParserToken(
+                                negative(
+                                        minusSymbol(),
+                                        function(functionName(), parenthesisOpen(), parenthesisClose())
+                                ),
+                                equalsSymbol(),
+                                number()
+                        )
+                ),
+                bracketClose());
+    }
+
+    @Test
     public void testAbsoluteNodeNameBracketOpenFunctionEqualsFunctionBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
@@ -355,7 +578,9 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                         equalsParserToken(
                                 function(functionName(), parenthesisOpen(), parenthesisClose()),
                                 equalsSymbol(),
-                                function(functionName(), parenthesisOpen(), quotedText(), parenthesisClose()))),
+                                function(functionName(), parenthesisOpen(), quotedText(), parenthesisClose())
+                        )
+                ),
                 bracketClose());
     }
 
@@ -365,7 +590,72 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        equalsParserToken(atSign(), attributeName(), equalsSymbol(), atSign(), attributeName2())),
+                        equalsParserToken(
+                                attribute(atSign(), attributeName()),
+                                equalsSymbol(),
+                                attribute(atSign(), attributeName2())
+                        )
+                ),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteWildcardBracketOpenAttributeNameLessThanNumberBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        lessThan(
+                                attribute(atSign(), attributeName()),
+                                lessThanSymbol(),
+                                number())),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteWildcardBracketOpenAttributeNameLessThanMinusNumberBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        lessThan(
+                                attribute(atSign(), attributeName()),
+                                lessThanSymbol(),
+                                negative(
+                                        minusSymbol(),
+                                        number()
+                                )
+                        )
+                ),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenAttributeNameEqualsNumberBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        equalsParserToken(
+                                attribute(atSign(), attributeName()),
+                                equalsSymbol(),
+                                number())),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteNodeNameBracketOpenAttributeNameEqualsMinusNumberBracketClose() {
+        this.parseAndCheck2(absolute(),
+                nodeName(),
+                bracketOpen(),
+                predicate(
+                        equalsParserToken(
+                                attribute(atSign(), attributeName()),
+                                equalsSymbol(),
+                                negative(
+                                        minusSymbol(),
+                                        number()
+                                ))),
                 bracketClose());
     }
 
@@ -375,27 +665,41 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        equalsParserToken(atSign(), attributeName(), equalsSymbol(), quotedText())),
+                        equalsParserToken(
+                                attribute(atSign(), attributeName()),
+                                equalsSymbol(),
+                                quotedText())),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteNodeNameBracketOpenNodeNameEqualsNodeNameBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberEqualsNegativeAttributeBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        equalsParserToken(nodeName(), equalsSymbol(), nodeName2())),
+                        equalsParserToken(
+                                number(),
+                                equalsSymbol(),
+                                negative(
+                                        minusSymbol(),
+                                        attribute(
+                                                atSign(),
+                                                attributeName()
+                                        )
+                                )
+                        )
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteNodeNameBracketOpenNodeNameEqualsQuotedTextBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberEqualsQuotedTextBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        equalsParserToken(nodeName(), equalsSymbol(), quotedText())),
+                        equalsParserToken(number(), equalsSymbol(), quotedText())),
                 bracketClose());
     }
 
@@ -410,173 +714,50 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 bracketClose());
     }
 
+    // absolute nodeName predicate GT.....................................................................
+
     @Test
     public void testAbsoluteNodeNameBracketOpenNumberGreaterThanNumberBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        greaterThan(number(), greaterThanSymbol(), number2())),
+                        greaterThan(number(), greaterThanSymbol(), number2())
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteNodeNameBracketOpenQuotedTextGreaterThanQuotedTextBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        greaterThan(quotedText(), greaterThanSymbol(), quotedText2())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenFunctionGreaterThanFunctionBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberGreaterThanMinusNumberBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
                         greaterThan(
-                                function(functionName(), parenthesisOpen(), parenthesisClose()),
+                                number(),
                                 greaterThanSymbol(),
-                                function(functionName(), parenthesisOpen(), quotedText(), parenthesisClose()))),
+                                negative(
+                                        minusSymbol(),
+                                        number2()
+                                ))
+                ),
                 bracketClose());
     }
 
+    // absolute nodeName predicate GTE.....................................................................
+
     @Test
-    public void testAbsoluteNodeNameBracketOpenAttributeNameGreaterThanAttributeNameBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberGreaterThanEqualNumberBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        greaterThan(atSign(), attributeName(), greaterThanSymbol(), atSign(), attributeName2())),
+                        greaterThanEquals(number(), greaterThanEqualsSymbol(), number2())
+                ),
                 bracketClose());
     }
 
-    @Test
-    public void testAbsoluteNodeNameBracketOpenAttributeNameGreaterThanQuotedTextBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        greaterThan(atSign(), attributeName(), greaterThanSymbol(), quotedText())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenNodeNameGreaterThanNodeNameBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        greaterThan(nodeName(), greaterThanSymbol(), nodeName2())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenNodeNameGreaterThanQuotedTextBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        greaterThan(nodeName(), greaterThanSymbol(), quotedText())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenWhitespaceNumberWhitespaceGreaterThanWhitespaceNumberWhitespaceBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        greaterThan(number(), whitespace(), greaterThanSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenNumberGreaterThanEqualsNumberBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        greaterThanEquals(number(), greaterThanEqualsSymbol(), number2())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenQuotedTextGreaterThanEqualsQuotedTextBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        greaterThanEquals(quotedText(), greaterThanEqualsSymbol(), quotedText2())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenFunctionGreaterThanEqualsFunctionBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        greaterThanEquals(
-                                function(functionName(), parenthesisOpen(), parenthesisClose()),
-                                greaterThanEqualsSymbol(),
-                                function(functionName(), parenthesisOpen(), quotedText(), parenthesisClose()))),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenAttributeNameGreaterThanEqualsAttributeNameBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        greaterThanEquals(atSign(), attributeName(), greaterThanEqualsSymbol(), atSign(), attributeName2())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenAttributeNameGreaterThanEqualsQuotedTextBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        greaterThanEquals(atSign(), attributeName(), greaterThanEqualsSymbol(), quotedText())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenNodeNameGreaterThanEqualsNodeNameBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        greaterThanEquals(nodeName(), greaterThanEqualsSymbol(), nodeName2())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenNodeNameGreaterThanEqualsQuotedTextBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        greaterThanEquals(nodeName(), greaterThanEqualsSymbol(), quotedText())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenWhitespaceNumberWhitespaceGreaterThanEqualsWhitespaceNumberWhitespaceBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        greaterThanEquals(number(), whitespace(), greaterThanEqualsSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose());
-    }
+    // absolute nodeName predicate LT.....................................................................
 
     @Test
     public void testAbsoluteNodeNameBracketOpenNumberLessThanNumberBracketClose() {
@@ -584,347 +765,265 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThan(number(), lessThanSymbol(), number2())),
+                        lessThan(number(), lessThanSymbol(), number2())
+                ),
                 bracketClose());
     }
 
+    // absolute nodeName predicate LTE.....................................................................
+
     @Test
-    public void testAbsoluteNodeNameBracketOpenQuotedTextLessThanQuotedTextBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberLessThanEqualNumberBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThan(quotedText(), lessThanSymbol(), quotedText2())),
+                        lessThanEquals(number(), lessThanEqualsSymbol(), number2())
+                ),
                 bracketClose());
     }
 
+    // absolute nodeName predicate NE.....................................................................
+
     @Test
-    public void testAbsoluteNodeNameBracketOpenFunctionLessThanFunctionBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberNotEqualNumberBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThan(
-                                function(functionName(), parenthesisOpen(), parenthesisClose()),
-                                lessThanSymbol(),
-                                function(functionName(), parenthesisOpen(), quotedText(), parenthesisClose()))),
+                        notEquals(number(), notEqualsSymbol(), number2())
+                ),
                 bracketClose());
     }
 
+    // absolute nodeName predicate ADD.....................................................................
+
     @Test
-    public void testAbsoluteNodeNameBracketOpenAttributeNameLessThanAttributeNameBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberAdditionNumberBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThan(atSign(), attributeName(), lessThanSymbol(), atSign(), attributeName2())),
+                        addition(number(), plusSymbol(), number2())
+                ),
                 bracketClose());
     }
 
+    // absolute nodeName predicate DIVIDE.....................................................................
+
     @Test
-    public void testAbsoluteNodeNameBracketOpenAttributeNameLessThanQuotedTextBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberDivisionNumberBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThan(atSign(), attributeName(), lessThanSymbol(), quotedText())),
+                        division(number(), divideSymbol(), number2())
+                ),
                 bracketClose());
     }
 
+    // absolute nodeName predicate MODULO.....................................................................
+
     @Test
-    public void testAbsoluteNodeNameBracketOpenNodeNameLessThanNodeNameBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberModuloNumberBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThan(nodeName(), lessThanSymbol(), nodeName2())),
+                        modulo(number(), moduloSymbol(), number2())),
                 bracketClose());
     }
 
+    // absolute nodeName predicate MULTIPLY.....................................................................
+
     @Test
-    public void testAbsoluteNodeNameBracketOpenNodeNameLessThanQuotedTextBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberMultiplyNumberBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThan(nodeName(), lessThanSymbol(), quotedText())),
+                        multiplication(number(), multiplySymbol(), number2())
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteNodeNameBracketOpenWhitespaceNumberWhitespaceLessThanWhitespaceNumberWhitespaceBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        lessThan(number(), whitespace(), lessThanSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenNumberLessThanEqualsNumberBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberMultiplyNumberAddNumberBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThanEquals(number(), lessThanEqualsSymbol(), number2())),
+                        multiplication(
+                                number(),
+                                multiplySymbol(),
+                                addition(
+                                        number2(),
+                                        plusSymbol(),
+                                        number3()
+                                )
+                        )
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteNodeNameBracketOpenQuotedTextLessThanEqualsQuotedTextBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberMultiplyNumberAddNumberSubtractNumberBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThanEquals(quotedText(), lessThanEqualsSymbol(), quotedText2())),
+                        multiplication(
+                                number(),
+                                multiplySymbol(),
+                                addition(
+                                        number2(),
+                                        plusSymbol(),
+                                        subtraction(
+                                                number3(),
+                                                minusSymbol(),
+                                                number4()
+                                        )
+                                )
+                        )
+                ),
                 bracketClose());
     }
 
+    // absolute nodeName predicate GROUP.....................................................................
+
     @Test
-    public void testAbsoluteNodeNameBracketOpenFunctionLessThanEqualsFunctionBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenParenOpenNumberParenCloseBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThanEquals(
-                                function(functionName(), parenthesisOpen(), parenthesisClose()),
-                                lessThanEqualsSymbol(),
-                                function(functionName(), parenthesisOpen(), quotedText(), parenthesisClose()))),
+                        group(
+                                parenthesisOpen(), number(), parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteNodeNameBracketOpenAttributeNameLessThanEqualsAttributeNameBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenParenOpenNegativeNumberParenCloseBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThanEquals(atSign(), attributeName(), lessThanEqualsSymbol(), atSign(), attributeName2())),
+                        group(
+                                parenthesisOpen(),
+                                    negative(
+                                            minusSymbol(),
+                                            number()
+                                    ),
+                                parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteNodeNameBracketOpenAttributeNameLessThanEqualsQuotedTextBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenParenOpenQuotedTextParenCloseBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThanEquals(atSign(), attributeName(), lessThanEqualsSymbol(), quotedText())),
+                        group(
+                                parenthesisOpen(), quotedText(), parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteNodeNameBracketOpenNodeNameLessThanEqualsNodeNameBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenParenOpenFunctionParenCloseBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThanEquals(nodeName(), lessThanEqualsSymbol(), nodeName2())),
+                        group(
+                                parenthesisOpen(),
+                                function(
+                                        functionName(), parenthesisOpen(), number(), parenthesisClose()
+                                ),
+                                parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteNodeNameBracketOpenNodeNameLessThanEqualsQuotedTextBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenParenOpenNumberGreaterThanNumberParenCloseBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        lessThanEquals(nodeName(), lessThanEqualsSymbol(), quotedText())),
+                        group(
+                                parenthesisOpen(),
+                                greaterThan(number(), greaterThanSymbol(), number2()),
+                                parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteNodeNameBracketOpenWhitespaceNumberWhitespaceLessThanEqualsWhitespaceNumberWhitespaceBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        lessThanEquals(number(), whitespace(), lessThanEqualsSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenNumberNotEqualsNumberBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenParenOpenParenOpenNumberGreaterThanNumberParenCloseParenCloseBracketClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        notEquals(number(), notEqualsSymbol(), number2())),
+                        group(
+                                parenthesisOpen(),
+                                group(
+                                        parenthesisOpen(),
+                                            greaterThan(
+                                                    number(),
+                                                    greaterThanSymbol(),
+                                                    number2()),
+                                        parenthesisClose()
+                                ),
+                                parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteNodeNameBracketOpenQuotedTextNotEqualsQuotedTextBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenParenNumberParensCloseGreaterThanNumberParenClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        notEquals(quotedText(), notEqualsSymbol(), quotedText2())),
+                        greaterThan(
+                                group(
+                                        parenthesisOpen(),
+                                            number(),
+                                        parenthesisClose()
+                                ),
+                                greaterThanSymbol(),
+                                number2()
+                        )
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteNodeNameBracketOpenAttributeNameNotEqualsAttributeNameBracketClose() {
+    public void testAbsoluteNodeNameBracketOpenNumberBracketGreaterThanParenOpenNumberParensCloseParenClose() {
         this.parseAndCheck2(absolute(),
                 nodeName(),
                 bracketOpen(),
                 predicate(
-                        notEquals(atSign(), attributeName(), notEqualsSymbol(), atSign(), attributeName2())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenAttributeNameNotEqualsQuotedTextBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        notEquals(atSign(), attributeName(), notEqualsSymbol(), quotedText())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenNodeNameNotEqualsNodeNameBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        notEquals(nodeName(), notEqualsSymbol(), nodeName2())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenNodeNameNotEqualsQuotedTextBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        notEquals(nodeName(), notEqualsSymbol(), quotedText())),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenFunctionNotEqualsFunctionBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(
-                        notEquals(
-                                function(functionName(), parenthesisOpen(), parenthesisClose()),
-                                notEqualsSymbol(),
-                                function(functionName(), parenthesisOpen(), quotedText(), parenthesisClose()))),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenWhitespaceNumberWhitespaceNotEqualsWhitespaceNumberWhitespaceBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        notEquals(number(), whitespace(), notEqualsSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose());
-    }
-
-    // absolute node name, predicate, predicate .......................................................................
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenWhitespaceNumberWhitespaceEqualsWhitespaceNumberWhitespaceBracketCloseBracketOpenWhitespaceNumberWhitespaceEqualsWhitespaceNumberWhitespaceBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        equalsParserToken(number(), whitespace(), equalsSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        equalsParserToken(number(), whitespace(), equalsSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenWhitespaceNumberWhitespaceGreaterThanWhitespaceNumberWhitespaceBracketCloseBracketOpenWhitespaceNumberWhitespaceGreaterThanWhitespaceNumberWhitespaceBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        greaterThan(number(), whitespace(), greaterThanSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        greaterThan(number(), whitespace(), greaterThanSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenWhitespaceNumberWhitespaceGreaterThanEqualsWhitespaceNumberWhitespaceBracketCloseBracketOpenWhitespaceNumberWhitespaceGreaterThanEqualsWhitespaceNumberWhitespaceBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        greaterThanEquals(number(), whitespace(), greaterThanEqualsSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        greaterThanEquals(number(), whitespace(), greaterThanEqualsSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenWhitespaceNumberWhitespaceLessThanWhitespaceNumberWhitespaceBracketCloseBracketOpenWhitespaceNumberWhitespaceLessThanWhitespaceNumberWhitespaceBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        lessThan(number(), whitespace(), lessThanSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        lessThan(number(), whitespace(), lessThanSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenWhitespaceNumberWhitespaceLessThanEqualsWhitespaceNumberWhitespaceBracketCloseBracketOpenWhitespaceNumberWhitespaceLessThanEqualsWhitespaceNumberWhitespaceBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        lessThanEquals(number(), whitespace(), lessThanEqualsSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        lessThanEquals(number(), whitespace(), lessThanEqualsSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose());
-    }
-
-    @Test
-    public void testAbsoluteNodeNameBracketOpenWhitespaceNumberWhitespaceNotEqualsWhitespaceNumberWhitespaceBracketCloseBracketOpenWhitespaceNumberWhitespaceNotEqualsWhitespaceNumberWhitespaceBracketClose() {
-        this.parseAndCheck2(absolute(),
-                nodeName(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        notEquals(number(), whitespace(), notEqualsSymbol(), whitespace(), number2()),
-                        whitespace()),
-                bracketClose(),
-                bracketOpen(),
-                predicate(whitespace(),
-                        notEquals(number(), whitespace(), notEqualsSymbol(), whitespace(), number2()),
-                        whitespace()),
+                        greaterThan(
+                                number(),
+                                greaterThanSymbol(),
+                                group(
+                                        parenthesisOpen(),
+                                            number2(),
+                                        parenthesisClose()
+                                )
+                        )
+                ),
                 bracketClose());
     }
 
@@ -1012,7 +1111,7 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         this.parseAndCheck2(absolute(), self(), wildcard());
     }
 
-    // absolute wildcard predicate child index ..........................................................................
+    // absolute wildcard predicate ...................................................................................
 
     @Test
     public void testIndexMissingNumberFails() {
@@ -1064,7 +1163,8 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 wildcard(),
                 bracketOpen(),
                 predicate(
-                        function(functionName(), parenthesisOpen(), parenthesisClose())),
+                        functionWithoutArguments()
+                ),
                 bracketClose());
     }
 
@@ -1074,7 +1174,10 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 wildcard(),
                 bracketOpen(),
                 predicate(
-                        function(functionName(), parenthesisOpen(), whitespace(), parenthesisClose())),
+                        function(
+                                functionName(), parenthesisOpen(), whitespace(), parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
@@ -1083,8 +1186,10 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         this.parseAndCheck2(absolute(),
                 wildcard(),
                 bracketOpen(),
-                predicate(whitespace(), function(
-                        functionName(), parenthesisOpen(), whitespace(), parenthesisClose()),
+                predicate(whitespace(),
+                        function(
+                                functionName(), parenthesisOpen(), whitespace(), parenthesisClose()
+                        ),
                         whitespace()),
                 bracketClose());
     }
@@ -1095,28 +1200,62 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 wildcard(),
                 bracketOpen(),
                 predicate(
-                        function(functionName(), parenthesisOpen(), number(), parenthesisClose())
-                        ),
+                        function(
+                                functionName(), parenthesisOpen(), number(), parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteWildcardBracketOpenFunctionNameParenOpenNumberNumberParenCloseBracketClose() {
+    public void testAbsoluteWildcardBracketOpenFunctionNameParenOpenNumberCommaNumberParenCloseBracketClose() {
         this.parseAndCheck2(absolute(),
                 wildcard(),
                 bracketOpen(),
                 predicate(
-                        function(functionName(), parenthesisOpen(), number(), comma(), number2(), parenthesisClose())),
+                        function(
+                                functionName(), parenthesisOpen(), number(), comma(), number2(), parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
     @Test
-    public void testAbsoluteWildcardBracketOpenFunctionNameParenOpenNumberNumberNumberParenCloseBracketClose() {
+    public void testAbsoluteWildcardBracketOpenFunctionNameParenOpenNumberCommaNumberCommaNumberParenCloseBracketClose() {
         this.parseAndCheck2(absolute(),
                 wildcard(),
                 bracketOpen(),
                 predicate(
-                        function(functionName(), parenthesisOpen(), number(), comma(), number2(), comma(), number(3), parenthesisClose())),
+                        function(
+                                functionName(), parenthesisOpen(), number(), comma(), number2(), comma(), number3(), parenthesisClose()
+                        )
+                ),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteWildcardBracketOpenFunctionNameParenOpenNumberWhitespaceCommaNumberParenCloseBracketClose() {
+        this.parseAndCheck2(absolute(),
+                wildcard(),
+                bracketOpen(),
+                predicate(
+                        function(
+                                functionName(), parenthesisOpen(), number(), whitespace(), comma(), number2(), parenthesisClose()
+                        )
+                ),
+                bracketClose());
+    }
+
+    @Test
+    public void testAbsoluteWildcardBracketOpenFunctionNameParenOpenNumberCommaWhitespaceNumberParenCloseBracketClose() {
+        this.parseAndCheck2(absolute(),
+                wildcard(),
+                bracketOpen(),
+                predicate(
+                        function(
+                                functionName(), parenthesisOpen(), number(), comma(), whitespace(), number2(), parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
@@ -1126,7 +1265,10 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 wildcard(),
                 bracketOpen(),
                 predicate(
-                        function(functionName(), parenthesisOpen(), quotedText(), parenthesisClose())),
+                        function(
+                                functionName(), parenthesisOpen(), quotedText(), parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
@@ -1136,9 +1278,14 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 wildcard(),
                 bracketOpen(),
                 predicate(
-                        function(functionName(), parenthesisOpen(),
-                                function(functionName("f2"), parenthesisOpen(), quotedText(), parenthesisClose()),
-                                parenthesisClose())),
+                        function(
+                                functionName(), parenthesisOpen(),
+                                function(
+                                        functionName("f2"), parenthesisOpen(), quotedText(), parenthesisClose()
+                                ),
+                                parenthesisClose()
+                        )
+                ),
                 bracketClose());
     }
 
@@ -1696,6 +1843,7 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
 
         if (null != predicate) {
             final String predicateText = predicate.text();
+
             this.parseAndCheck(NodeSelectorParsers.predicate(),
                     predicateText,
                     predicate,
@@ -1720,33 +1868,14 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
                 ParserToken.text(Lists.of(tokens)));
     }
 
-    private void parsePredicateAndCheck(final NodeSelectorParserToken... tokens) {
-        final List<ParserToken> list = Lists.of(tokens);
-        final String text = ParserToken.text(list);
-
-        assertEquals(text, text, "text should be all upper case");
-
-        final Parser<NodeSelectorParserContext> parser = NodeSelectorParsers.predicate();
-        this.parseAndCheck(parser,
-                text,
-                NodeSelectorParserToken.predicate(list, text),
-                text);
-
-        final List<ParserToken> lower = Arrays.stream(tokens)
-                .map(t -> NodeSelectorParsersTestNodeSelectorParserTokenVisitor.toUpper(t))
-                .collect(Collectors.toList());
-        final String textUpper = ParserToken.text(lower);
-
-        this.parseAndCheck(parser,
-                textUpper,
-                NodeSelectorParserToken.predicate(lower, textUpper),
-                textUpper);
-    }
-
     // token factories...............................................................................
 
     final NodeSelectorParserToken absolute() {
         return NodeSelectorParserToken.absolute("/", "/");
+    }
+
+    final NodeSelectorParserToken addition(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.addition(Lists.of(tokens), text(tokens));
     }
 
     final NodeSelectorParserToken ancestor() {
@@ -1757,7 +1886,7 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         return NodeSelectorParserToken.ancestorOrSelf("ancestor-or-self::", "ancestor-or-self::");
     }
 
-    final NodeSelectorAndParserToken and(final NodeSelectorParserToken... tokens) {
+    final NodeSelectorParserToken and(final NodeSelectorParserToken... tokens) {
         return NodeSelectorParserToken.and(Lists.of(tokens), text(tokens));
     }
 
@@ -1767,6 +1896,10 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
 
     final NodeSelectorParserToken atSign() {
         return NodeSelectorParserToken.atSignSymbol("@", "@");
+    }
+
+    final NodeSelectorParserToken attribute(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.attribute(Lists.of(tokens), text(tokens));
     }
 
     final NodeSelectorParserToken attributeName() {
@@ -1809,7 +1942,15 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         return NodeSelectorParserToken.descendantOrSelf("//", "//");
     }
 
-    final NodeSelectorEqualsParserToken equalsParserToken(final NodeSelectorParserToken... tokens) {
+    final NodeSelectorParserToken divideSymbol() {
+        return NodeSelectorParserToken.divideSymbol(" div ", " div ");
+    }
+
+    final NodeSelectorParserToken division(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.division(Lists.of(tokens), text(tokens));
+    }
+
+    final NodeSelectorParserToken equalsParserToken(final NodeSelectorParserToken... tokens) {
         return NodeSelectorParserToken.equalsParserToken(Lists.of(tokens), text(tokens));
     }
 
@@ -1817,7 +1958,7 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         return NodeSelectorParserToken.equalsSymbol("=", "=");
     }
 
-    final NodeSelectorExpressionParserToken expression(final NodeSelectorParserToken... tokens) {
+    final NodeSelectorParserToken expression(final NodeSelectorParserToken... tokens) {
         return NodeSelectorParserToken.expression(Lists.of(tokens), text(tokens));
     }
 
@@ -1833,15 +1974,15 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         return NodeSelectorParserToken.followingSibling("following-sibling::", "following-sibling::");
     }
 
-    final NodeSelectorFunctionParserToken function(final NodeSelectorParserToken... tokens) {
+    final NodeSelectorParserToken function(final NodeSelectorParserToken... tokens) {
         return NodeSelectorParserToken.function(Lists.of(tokens), text(tokens));
     }
 
-    final NodeSelectorFunctionParserToken functionWithoutArguments() {
+    final NodeSelectorParserToken functionWithoutArguments() {
         return function(functionName(), parenthesisOpen(), parenthesisClose());
     }
 
-    final NodeSelectorFunctionParserToken functionWithArguments() {
+    final NodeSelectorParserToken functionWithArguments() {
         return function(functionName(), parenthesisOpen(), number(), comma(), quotedText(), parenthesisClose());
     }
 
@@ -1853,7 +1994,7 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         return NodeSelectorParserToken.functionName(NodeSelectorFunctionName.with(text), text);
     }
 
-    final NodeSelectorGreaterThanParserToken greaterThan(final NodeSelectorParserToken... tokens) {
+    final NodeSelectorParserToken greaterThan(final NodeSelectorParserToken... tokens) {
         return NodeSelectorParserToken.greaterThan(Lists.of(tokens), text(tokens));
     }
 
@@ -1861,7 +2002,7 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         return NodeSelectorParserToken.greaterThanSymbol(">", ">");
     }
 
-    final NodeSelectorGreaterThanEqualsParserToken greaterThanEquals(final NodeSelectorParserToken... tokens) {
+    final NodeSelectorParserToken greaterThanEquals(final NodeSelectorParserToken... tokens) {
         return NodeSelectorParserToken.greaterThanEquals(Lists.of(tokens), text(tokens));
     }
 
@@ -1869,7 +2010,11 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         return NodeSelectorParserToken.greaterThanEqualsSymbol(">=", ">=");
     }
 
-    final NodeSelectorLessThanParserToken lessThan(final NodeSelectorParserToken... tokens) {
+    final NodeSelectorParserToken group(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.group(Lists.of(tokens), text(tokens));
+    }
+
+    final NodeSelectorParserToken lessThan(final NodeSelectorParserToken... tokens) {
         return NodeSelectorParserToken.lessThan(Lists.of(tokens), text(tokens));
     }
 
@@ -1877,7 +2022,7 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         return NodeSelectorParserToken.lessThanSymbol("<", "<");
     }
 
-    final NodeSelectorLessThanEqualsParserToken lessThanEquals(final NodeSelectorParserToken... tokens) {
+    final NodeSelectorParserToken lessThanEquals(final NodeSelectorParserToken... tokens) {
         return NodeSelectorParserToken.lessThanEquals(Lists.of(tokens), text(tokens));
     }
 
@@ -1889,6 +2034,30 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         return NodeSelectorParserToken.lastChild("last-child::", "last-child::");
     }
 
+    final NodeSelectorParserToken minusSymbol() {
+        return NodeSelectorParserToken.minusSymbol("-", "-");
+    }
+
+    final NodeSelectorParserToken modulo(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.modulo(Lists.of(tokens), text(tokens));
+    }
+
+    final NodeSelectorParserToken moduloSymbol() {
+        return NodeSelectorParserToken.moduloSymbol(" mod ", " mod ");
+    }
+
+    final NodeSelectorParserToken multiplication(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.multiplication(Lists.of(tokens), text(tokens));
+    }
+
+    final NodeSelectorParserToken multiplySymbol() {
+        return NodeSelectorParserToken.multiplySymbol("*", "*");
+    }
+
+    final NodeSelectorParserToken negative(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.negative(Lists.of(tokens), text(tokens));
+    }
+
     final NodeSelectorParserToken nodeName() {
         return nodeName("Node1");
     }
@@ -1897,11 +2066,15 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         return nodeName("Node22");
     }
 
+    final NodeSelectorParserToken nodeName3() {
+        return nodeName("Node333");
+    }
+
     final NodeSelectorParserToken nodeName(final String name) {
         return NodeSelectorParserToken.nodeName(NodeSelectorNodeName.with(name), name);
     }
 
-    final NodeSelectorNotEqualsParserToken notEquals(final NodeSelectorParserToken... tokens) {
+    final NodeSelectorParserToken notEquals(final NodeSelectorParserToken... tokens) {
         return NodeSelectorParserToken.notEquals(Lists.of(tokens), text(tokens));
     }
 
@@ -1915,6 +2088,14 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
 
     final NodeSelectorParserToken number2() {
         return number(23);
+    }
+
+    final NodeSelectorParserToken number3() {
+        return number(345);
+    }
+
+    final NodeSelectorParserToken number4() {
+        return number(4567);
     }
 
     final NodeSelectorParserToken number(final int value) {
@@ -1945,6 +2126,10 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         return NodeSelectorParserToken.parentOf("..", "..");
     }
 
+    final NodeSelectorParserToken plusSymbol() {
+        return NodeSelectorParserToken.plusSymbol("+", "+");
+    }
+
     final NodeSelectorParserToken preceding() {
         return NodeSelectorParserToken.preceding("preceding::", "preceding::");
     }
@@ -1953,7 +2138,7 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
         return NodeSelectorParserToken.precedingSibling("preceding-sibling::", "preceding-sibling::");
     }
 
-    final NodeSelectorPredicateParserToken predicate(final NodeSelectorParserToken... tokens) {
+    final NodeSelectorParserToken predicate(final NodeSelectorParserToken... tokens) {
         return NodeSelectorParserToken.predicate(Lists.of(tokens), text(tokens));
     }
 
@@ -1979,6 +2164,10 @@ public final class NodeSelectorParsersTest implements ParserTesting<Parser<NodeS
 
     final NodeSelectorParserToken slash() {
         return NodeSelectorParserToken.slashSeparatorSymbol("/", "/");
+    }
+
+    final NodeSelectorParserToken subtraction(final NodeSelectorParserToken... tokens) {
+        return NodeSelectorParserToken.subtraction(Lists.of(tokens), text(tokens));
     }
 
     final NodeSelectorParserToken whitespace() {

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorParsersTestNodeSelectorParserTokenVisitor.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorParsersTestNodeSelectorParserTokenVisitor.java
@@ -45,6 +45,17 @@ final class NodeSelectorParsersTestNodeSelectorParserTokenVisitor extends NodeSe
     }
 
     @Override
+    protected Visiting startVisit(final NodeSelectorAdditionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorAdditionParserToken token) {
+        this.exit(NodeSelectorParserToken::addition);
+    }
+
+    @Override
     protected Visiting startVisit(final NodeSelectorAndParserToken token) {
         this.enter();
         return super.startVisit(token);
@@ -55,6 +66,28 @@ final class NodeSelectorParsersTestNodeSelectorParserTokenVisitor extends NodeSe
         this.exit(NodeSelectorParserToken::and);
     }
 
+    @Override
+    protected Visiting startVisit(final NodeSelectorAttributeParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorAttributeParserToken token) {
+        this.exit(NodeSelectorParserToken::attribute);
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorDivisionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorDivisionParserToken token) {
+        this.exit(NodeSelectorParserToken::division);
+    }
+    
     @Override
     protected Visiting startVisit(final NodeSelectorEqualsParserToken token) {
         this.enter();
@@ -111,6 +144,17 @@ final class NodeSelectorParsersTestNodeSelectorParserTokenVisitor extends NodeSe
     }
 
     @Override
+    protected Visiting startVisit(final NodeSelectorGroupParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorGroupParserToken token) {
+        this.exit(NodeSelectorParserToken::group);
+    }
+
+    @Override
     protected Visiting startVisit(final NodeSelectorLessThanParserToken token) {
         this.enter();
         return super.startVisit(token);
@@ -139,6 +183,28 @@ final class NodeSelectorParsersTestNodeSelectorParserTokenVisitor extends NodeSe
     }
 
     @Override
+    protected Visiting startVisit(final NodeSelectorModuloParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorModuloParserToken token) {
+        this.exit(NodeSelectorParserToken::modulo);
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorMultiplicationParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorMultiplicationParserToken token) {
+        this.exit(NodeSelectorParserToken::multiplication);
+    }
+    
+    @Override
     protected void endVisit(final NodeSelectorNotEqualsParserToken token) {
         this.exit(NodeSelectorParserToken::notEquals);
     }
@@ -163,6 +229,17 @@ final class NodeSelectorParsersTestNodeSelectorParserTokenVisitor extends NodeSe
     @Override
     protected void endVisit(final NodeSelectorPredicateParserToken token) {
         this.exit(NodeSelectorParserToken::predicate);
+    }
+
+    @Override
+    protected Visiting startVisit(final NodeSelectorSubtractionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected void endVisit(final NodeSelectorSubtractionParserToken token) {
+        this.exit(NodeSelectorParserToken::subtraction);
     }
 
     @Override
@@ -221,6 +298,11 @@ final class NodeSelectorParsersTestNodeSelectorParserTokenVisitor extends NodeSe
     }
 
     @Override
+    protected void visit(final NodeSelectorDivideSymbolParserToken token) {
+        this.add(token);
+    }
+
+    @Override
     protected void visit(final NodeSelectorEqualsSymbolParserToken token) {
         this.add(token);
     }
@@ -268,6 +350,21 @@ final class NodeSelectorParsersTestNodeSelectorParserTokenVisitor extends NodeSe
     @Override
     protected void visit(final NodeSelectorLastChildParserToken token) {
         this.add(token, NodeSelectorParserToken::lastChild);
+    }
+
+    @Override
+    protected void visit(final NodeSelectorMinusSymbolParserToken token) {
+        this.add(token);
+    }
+
+    @Override
+    protected void visit(final NodeSelectorModuloSymbolParserToken token) {
+        this.add(token);
+    }
+
+    @Override
+    protected void visit(final NodeSelectorMultiplySymbolParserToken token) {
+        this.add(token);
     }
 
     @Override

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorPlusSymbolParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorPlusSymbolParserTokenTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorPlusSymbolParserTokenTest extends NodeSelectorSymbolParserTokenTestCase<NodeSelectorPlusSymbolParserToken, String> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final NodeSelectorSymbolParserToken token = this.createToken();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ParserToken t) {
+                assertSame(token, t);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken t) {
+                assertSame(token, t);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken t) {
+                assertSame(token, t);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final NodeSelectorPlusSymbolParserToken t) {
+                assertSame(token, t);
+                b.append("5");
+            }
+        }.accept(token);
+        assertEquals("13542", b.toString());
+    }
+
+    @Override
+    public String text() {
+        return "+";
+    }
+
+    @Override
+    String value() {
+        return this.text();
+    }
+
+    @Override
+    NodeSelectorPlusSymbolParserToken createToken(final String value, final String text) {
+        return NodeSelectorPlusSymbolParserToken.with(value, text);
+    }
+
+    @Override
+    public NodeSelectorPlusSymbolParserToken createDifferentToken() {
+        return NodeSelectorPlusSymbolParserToken.with(this.text(), "different");
+    }
+
+    @Override
+    public Class<NodeSelectorPlusSymbolParserToken> type() {
+        return NodeSelectorPlusSymbolParserToken.class;
+    }
+}

--- a/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorSubtractionParserTokenTest.java
+++ b/src/test/java/walkingkooka/text/cursor/parser/select/NodeSelectorSubtractionParserTokenTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package walkingkooka.text.cursor.parser.select;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class NodeSelectorSubtractionParserTokenTest extends NodeSelectorBinaryParserTokenTestCase<NodeSelectorSubtractionParserToken> {
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final List<ParserToken> visited = Lists.array();
+
+        final NodeSelectorSubtractionParserToken and = this.createToken();
+
+        final NodeSelectorNodeNameParserToken nodeName = and.value().get(0).cast();
+        final NodeSelectorMinusSymbolParserToken minusSymbol = and.value().get(1).cast();
+        final NodeSelectorWildcardParserToken wildcard = and.value().get(2).cast();
+
+        new FakeNodeSelectorParserTokenVisitor() {
+            @Override
+            protected Visiting startVisit(final NodeSelectorParserToken n) {
+                b.append("1");
+                visited.add(n);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorParserToken n) {
+                b.append("2");
+                visited.add(n);
+            }
+
+            @Override
+            protected Visiting startVisit(final NodeSelectorSubtractionParserToken t) {
+                assertSame(and, t);
+                b.append("3");
+                visited.add(t);
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final NodeSelectorSubtractionParserToken t) {
+                assertSame(and, t);
+                b.append("4");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorNodeNameParserToken t) {
+                assertSame(nodeName, t);
+                b.append("5");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorMinusSymbolParserToken t) {
+                assertSame(minusSymbol, t);
+                b.append("6");
+                visited.add(t);
+            }
+
+            @Override
+            protected void visit(final NodeSelectorWildcardParserToken t) {
+                assertSame(wildcard, t);
+                b.append("7");
+                visited.add(t);
+            }
+
+        }.accept(and);
+        assertEquals("1315216217242", b.toString());
+        assertEquals(Lists.<Object>of(and, and,
+                nodeName, nodeName, nodeName,
+                minusSymbol, minusSymbol, minusSymbol,
+                wildcard, wildcard, wildcard,
+                and, and),
+                visited,
+                "visited");
+    }
+
+    @Override
+    NodeSelectorSubtractionParserToken createToken(final String text, final List<ParserToken> tokens) {
+        return NodeSelectorSubtractionParserToken.with(tokens, text);
+    }
+
+    @Override
+    NodeSelectorParserToken operatorSymbol() {
+        return minusSymbol();
+    }
+
+    @Override
+    public Class<NodeSelectorSubtractionParserToken> type() {
+        return NodeSelectorSubtractionParserToken.class;
+    }
+}


### PR DESCRIPTION
- Introduced a few sub classes of NodeSelectorSymbolParserToken to share common methods.
- Removed node name support within predicate expressions.