### PR TITLE
NodeSelectorNodeAttributeXXXPredicate.toString attribute fix.

### DIFF
--- a/src/main/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueContainsPredicate.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueContainsPredicate.java
@@ -52,6 +52,6 @@ final class NodeSelectorNodeAttributeValueContainsPredicate<N extends Node<N, NA
     @Override
     String toString0(final ANAME name, final AVALUE value) {
         // //a[contains(@href, '://')]
-        return "contains(@" + name + "," + CharSequences.quoteIfChars(value) + ")";
+        return "contains(@" + name.value() + "," + CharSequences.quoteIfChars(value) + ")";
     }
 }

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueEndsWithPredicate.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueEndsWithPredicate.java
@@ -52,6 +52,6 @@ final class NodeSelectorNodeAttributeValueEndsWithPredicate<N extends Node<N, NA
     @Override
     String toString0(final ANAME name, final AVALUE value) {
         //[ends-with(@href, '/')]
-        return "ends-with(@" + name + "," + CharSequences.quoteIfChars(value) + ")";
+        return "ends-with(@" + name.value() + "," + CharSequences.quoteIfChars(value) + ")";
     }
 }

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueEqualsPredicate.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueEqualsPredicate.java
@@ -52,6 +52,6 @@ final class NodeSelectorNodeAttributeValueEqualsPredicate<N extends Node<N, NAME
     @Override
     String toString0(final ANAME name, final AVALUE value) {
         //[@for="xyz"]
-        return "@" + name + "=" + CharSequences.quoteIfChars(value);
+        return "@" + name.value() + "=" + CharSequences.quoteIfChars(value);
     }
 }

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueStartsWithPredicate.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueStartsWithPredicate.java
@@ -52,6 +52,6 @@ final class NodeSelectorNodeAttributeValueStartsWithPredicate<N extends Node<N, 
     @Override
     String toString0(final ANAME name, final AVALUE value) {
         //[starts-with(@href, '/')]
-        return "starts-with(@" + name + "," + CharSequences.quoteIfChars(value) + ")";
+        return "starts-with(@" + name.value() + "," + CharSequences.quoteIfChars(value) + ")";
     }
 }

--- a/src/test/java/walkingkooka/tree/select/NamedNodeSelectorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NamedNodeSelectorTest.java
@@ -290,7 +290,7 @@ final public class NamedNodeSelectorTest extends
         this.toStringAndCheck(TestNode.relativeNodeSelector()
                         .named(Names.string("ABC"))
                         .attributeValueStartsWith(Names.string("DEF"), "V1"),
-                "ABC[starts-with(@\"DEF\",\"V1\")]");
+                "ABC[starts-with(@DEF,\"V1\")]");
     }
 
     @Test
@@ -307,7 +307,7 @@ final public class NamedNodeSelectorTest extends
                         .children()
                         .named(Names.string("ABC"))
                         .attributeValueStartsWith(Names.string("DEF"), "V1"),
-                "child::ABC[starts-with(@\"DEF\",\"V1\")]");
+                "child::ABC[starts-with(@DEF,\"V1\")]");
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueContainsPredicateTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueContainsPredicateTest.java
@@ -39,7 +39,7 @@ public class NodeSelectorNodeAttributeValueContainsPredicateTest
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createPredicate(), "contains(@\"attribute-1\",\"123\")");
+        this.toStringAndCheck(this.createPredicate(), "contains(@attribute-1,\"123\")");
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueEndsWithPredicateTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueEndsWithPredicateTest.java
@@ -41,7 +41,7 @@ public class NodeSelectorNodeAttributeValueEndsWithPredicateTest
 
     @Test
     public void testToString() {
-        assertEquals("ends-with(@\"attribute-1\",\"123\")", this.createPredicate().toString());
+        assertEquals("ends-with(@attribute-1,\"123\")", this.createPredicate().toString());
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueEqualsPredicateTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueEqualsPredicateTest.java
@@ -39,7 +39,7 @@ public class NodeSelectorNodeAttributeValueEqualsPredicateTest
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createPredicate(), "@\"attribute-1\"=\"123\"");
+        this.toStringAndCheck(this.createPredicate(), "@attribute-1=\"123\"");
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueStartsWithPredicateTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeAttributeValueStartsWithPredicateTest.java
@@ -39,7 +39,7 @@ public class NodeSelectorNodeAttributeValueStartsWithPredicateTest
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createPredicate(), "starts-with(@\"attribute-1\",\"123\")");
+        this.toStringAndCheck(this.createPredicate(), "starts-with(@attribute-1,\"123\")");
     }
 
     @Override


### PR DESCRIPTION
- Include string value and not Name.toString.