### PR TITLE
NodeSelectorContext.setNode

### DIFF
--- a/src/main/java/walkingkooka/tree/select/BasicNodeSelectorContext.java
+++ b/src/main/java/walkingkooka/tree/select/BasicNodeSelectorContext.java
@@ -94,8 +94,6 @@ final class BasicNodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>, NAM
 
     @Override
     public boolean test(final N node) {
-        // $current must be set here, so ExpressionNodeSelector can execute functions that require the current node.
-        this.current = node;
         return this.filter.test(node);
     }
 
@@ -104,6 +102,14 @@ final class BasicNodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>, NAM
      * an {@link RuntimeException} to abort a long running select.
      */
     private final Predicate<N> filter;
+
+    /**
+     * Saves the current node for that predicates and expressions that may need it.
+     */
+    @Override
+    public void setNode(final N node) {
+        this.current = node;
+    }
 
     @Override
     public N selected(final N node) {

--- a/src/main/java/walkingkooka/tree/select/ExpressionNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/ExpressionNodeSelector.java
@@ -76,6 +76,7 @@ final class ExpressionNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NAME 
         N result = node;
 
         try {
+            context.setNode(node);
             if (context.nodePositionTest(this.expressionNode.toValue(ExpressionNodeSelectorExpressionEvaluationContext.with(node, context)))) {
                 result = this.select(node, context);
             }

--- a/src/main/java/walkingkooka/tree/select/FakeNodeSelectorContext.java
+++ b/src/main/java/walkingkooka/tree/select/FakeNodeSelectorContext.java
@@ -41,6 +41,11 @@ public class FakeNodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>,
     }
 
     @Override
+    public void setNode(final N node) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public N selected(final N node) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/tree/select/NodePredicateNodeSelector.java
+++ b/src/main/java/walkingkooka/tree/select/NodePredicateNodeSelector.java
@@ -61,6 +61,8 @@ final class NodePredicateNodeSelector<N extends Node<N, NAME, ANAME, AVALUE>, NA
 
     @Override
     N apply1(final N node, final NodeSelectorContext2<N, NAME, ANAME, AVALUE> context) {
+        context.setNode(node);
+
         return this.predicate.test(node) ?
                 this.select(node, context) :
                 node;

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorContext.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorContext.java
@@ -38,6 +38,12 @@ public interface NodeSelectorContext<N extends Node<N, NAME, ANAME, AVALUE>, NAM
     boolean test(final N node);
 
     /**
+     * Sets the current {@link Node}, in preparation for predicates or functions that read attributes or other values from
+     * on the current {@link Node}.
+     */
+    void setNode(final N node);
+
+    /**
      * Invoked with each and every selected {@link Node node}.
      */
     N selected(final N node);

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorContext2.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorContext2.java
@@ -65,6 +65,11 @@ abstract class NodeSelectorContext2<N extends Node<N, NAME, ANAME, AVALUE>, NAME
     }
 
     @Override
+    public void setNode(final N node) {
+        this.context.setNode(node);
+    }
+
+    @Override
     public final boolean test(final N node) {
         return this.context.test(node);
     }

--- a/src/main/java/walkingkooka/tree/select/NodeSelectorTesting.java
+++ b/src/main/java/walkingkooka/tree/select/NodeSelectorTesting.java
@@ -79,6 +79,11 @@ public interface NodeSelectorTesting<N extends Node<N, NAME, ANAME, AVALUE>,
             }
 
             @Override
+            public void setNode(final N node) {
+                // nop
+            }
+
+            @Override
             public boolean test(final N node) {
                 potential.accept(node);
                 return true;
@@ -88,6 +93,11 @@ public interface NodeSelectorTesting<N extends Node<N, NAME, ANAME, AVALUE>,
             public N selected(final N node) {
                 selected.accept(node);
                 return node;
+            }
+
+            @Override
+            public String toString() {
+                return "selected: " + selected;
             }
         };
     }

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorNodeSelectorParserTokenVisitorTest.java
@@ -1992,8 +1992,12 @@ public final class NodeSelectorNodeSelectorParserTokenVisitorTest implements Nod
 
                     @Override
                     public boolean test(final TestNode node) {
-                        this.node = node;
                         return true;
+                    }
+
+                    @Override
+                    public void setNode(final TestNode node) {
+                        this.node = node;
                     }
 
                     private TestNode node;

--- a/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase4.java
+++ b/src/test/java/walkingkooka/tree/select/NodeSelectorTestCase4.java
@@ -401,6 +401,12 @@ abstract public class NodeSelectorTestCase4<S extends NodeSelector<TestNode, Str
             }
 
             @Override
+            public void setNode(final TestNode node) {
+                this.finisherGuardCheck();
+                context.setNode(node);
+            }
+
+            @Override
             public TestNode selected(final TestNode node) {
                 this.finisherGuardCheck();
                 return context.selected(node);


### PR DESCRIPTION
- allows ExpressionNodeSelector & PredicateNodeSelector to set "current" Node prior to executing predicate or expression.

Closes #1376 