### PR TITLE
HeaderParser comment support.

### DIFF
--- a/src/main/java/walkingkooka/net/header/CacheControlDirectiveHeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/CacheControlDirectiveHeaderParser.java
@@ -102,8 +102,11 @@ final class CacheControlDirectiveHeaderParser extends HeaderParser {
         }
         this.parameterValue = this.directiveName.toValue(this.quotedText(ASCII, ESCAPING_SUPPORTED));
         this.expectsParameterValue = false;
+    }
 
-        //this.addParameter();
+    @Override
+    void comment() {
+        this.commentText(); // consume and ignore comment text itself.
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ETagHeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/ETagHeaderParser.java
@@ -70,6 +70,14 @@ abstract class ETagHeaderParser extends HeaderParser {
         this.requireValue = false;
     }
 
+    /**
+     * Comments are not allowed within ETAGS.
+     */
+    @Override
+    final void comment() {
+        this.failInvalidCharacter();
+    }
+
     @Override
     void token() {
         if ('W' != this.character()) {

--- a/src/main/java/walkingkooka/net/header/EncodedTextHeaderValueConverterHeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/EncodedTextHeaderValueConverterHeaderParser.java
@@ -71,6 +71,11 @@ final class EncodedTextHeaderValueConverterHeaderParser extends HeaderParser {
     }
 
     @Override
+    void comment() {
+        this.failInvalidCharacter();
+    }
+
+    @Override
     void token() {
         this.encodedText = this.encodedText();
     }

--- a/src/main/java/walkingkooka/net/header/HeaderParserWithParameters.java
+++ b/src/main/java/walkingkooka/net/header/HeaderParserWithParameters.java
@@ -101,6 +101,11 @@ abstract class HeaderParserWithParameters<V extends HeaderValueWithParameters<N>
         this.failInvalidCharacter();
     }
 
+    @Override
+    final void comment() {
+        this.commentText(); // consume and ignore comment text itself.
+    }
+
     /**
      * Handles parsing a token.
      */

--- a/src/main/java/walkingkooka/net/header/LinkRelationHeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/LinkRelationHeaderParser.java
@@ -150,6 +150,11 @@ final class LinkRelationHeaderParser extends HeaderParser {
 
     final static CharPredicate QUOTED_PARAMETER_VALUE = ASCII;
 
+    @Override
+    void comment() {
+        this.commentText(); // consume and ignore comment text itself.
+    }
+
     /**
      * <pre>
      * relation-types = relation-type

--- a/src/test/java/walkingkooka/net/header/AcceptCharsetHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptCharsetHeaderParserTest.java
@@ -90,6 +90,16 @@ public final class AcceptCharsetHeaderParserTest extends HeaderParserWithParamet
     }
 
     @Test
+    public void testCommentWildcard() {
+        this.parseAndCheck("(comment)*", CharsetHeaderValue.WILDCARD_VALUE);
+    }
+
+    @Test
+    public void testWildcardComment() {
+        this.parseAndCheck("*(comment)", CharsetHeaderValue.WILDCARD_VALUE);
+    }
+
+    @Test
     public void testWildcardInvalidFails() {
         this.parseInvalidCharacterFails("*1");
     }
@@ -266,6 +276,16 @@ public final class AcceptCharsetHeaderParserTest extends HeaderParserWithParamet
         this.parseAndCheck("UTF-8;b= \t \tc",
                 "UTF-8",
                 "b", "c");
+    }
+
+    @Test
+    public void testCharsetComment() {
+        this.parseAndCheck("utf-16(comment123)", "utf-16");
+    }
+
+    @Test
+    public void testCharsetWhitespaceComment() {
+        this.parseAndCheck("utf-16 (comment123)", "utf-16");
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/CacheControlDirectiveHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/CacheControlDirectiveHeaderParserTest.java
@@ -134,6 +134,11 @@ public final class CacheControlDirectiveHeaderParserTest extends HeaderParserTes
         this.parseInvalidCharacterFails(text, text.indexOf('2') - 1);
     }
 
+    @Test
+    public void testDirectiveCommentKeyValueSeparatorParameterNumericValue() {
+        this.parseAndCheck2("(abc)A=1", "A", 1L);
+    }
+
     // max-age.....................................................
 
     @Test

--- a/src/test/java/walkingkooka/net/header/ContentDispositionHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentDispositionHeaderParserTest.java
@@ -516,6 +516,14 @@ public final class ContentDispositionHeaderParserTest extends HeaderParserWithPa
                 123L);
     }
 
+    @Test
+    public void testSizeComment() {
+        this.parseAndCheck("attachment; size=123(comment-123)",
+                "attachment",
+                "size",
+                123L);
+    }
+
     // helpers...................................................................................................
 
     @Override

--- a/src/test/java/walkingkooka/net/header/ETagHeaderParserTestCase.java
+++ b/src/test/java/walkingkooka/net/header/ETagHeaderParserTestCase.java
@@ -45,6 +45,11 @@ public abstract class ETagHeaderParserTestCase<P extends ETagHeaderParser>
     }
 
     @Test
+    public final void testCommentFails() {
+        this.parseInvalidCharacterFails("(comment-abc123)", 0);
+    }
+
+    @Test
     public final void testInvalidInitialFails2() {
         this.parseInvalidCharacterFails("w");
     }
@@ -132,6 +137,11 @@ public abstract class ETagHeaderParserTestCase<P extends ETagHeaderParser>
     @Test
     public final void testWeakValue3() {
         this.parseAndCheck("W/\"0123456789ABCDEF\"", "0123456789ABCDEF", ETagValidator.WEAK);
+    }
+
+    @Test
+    public final void testValueCommentFails() {
+        this.parseInvalidCharacterFails("*(comment-abc123)", 1);
     }
 
     final void parseAndCheck(final String text, final String value) {

--- a/src/test/java/walkingkooka/net/header/EncodedTextHeaderValueConverterHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/EncodedTextHeaderValueConverterHeaderParserTest.java
@@ -88,6 +88,13 @@ public final class EncodedTextHeaderValueConverterHeaderParserTest extends Heade
         });
     }
 
+    @Test
+    public void testComment() {
+        assertThrows(HeaderValueException.class, () -> {
+            this.createHeaderParser().comment();
+        });
+    }
+
     private EncodedTextHeaderValueConverterHeaderParser createHeaderParser() {
         return new EncodedTextHeaderValueConverterHeaderParser("text", LABEL);
     }

--- a/src/test/java/walkingkooka/net/header/LanguageTagOneHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/LanguageTagOneHeaderParserTest.java
@@ -27,6 +27,16 @@ public final class LanguageTagOneHeaderParserTest extends LanguageTagHeaderParse
         this.parseInvalidCharacterFails("en,");
     }
 
+    @Test
+    public void testCommentLanguageTag() {
+        this.parseAndCheck2("(comment-123)en", LanguageTag.with(LanguageTagName.with("en")));
+    }
+
+    @Test
+    public void testLanguageTagComment() {
+        this.parseAndCheck2("en(comment-123)", LanguageTag.with(LanguageTagName.with("en")));
+    }
+
     @Override
     void parseAndCheck2(final String text, final LanguageTag expected) {
         this.parseAndCheck(text, expected);

--- a/src/test/java/walkingkooka/net/header/MediaTypeOneHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeOneHeaderParserTest.java
@@ -39,6 +39,22 @@ public final class MediaTypeOneHeaderParserTest extends MediaTypeHeaderParserTes
         this.parseInvalidCharacterFails("type/subtype;p=v,");
     }
 
+    @Test
+    public void testCommentMediaType() {
+        this.parseAndCheck("(comment-123)text/plain-text",
+                "text",
+                "plain-text",
+                MediaType.NO_PARAMETERS);
+    }
+
+    @Test
+    public void testMediaTypeComment() {
+        this.parseAndCheck("text/plain-text(comment-123)",
+                "text",
+                "plain-text",
+                MediaType.NO_PARAMETERS);
+    }
+
     @Override
     final void parseAndCheck(final String text,
                              final String type,


### PR DESCRIPTION
- calls comment() when opening '(' encountered.
- commentText consumes entire comment text without surrounding parens.

Implements #1394 