### PR TITLE
ParserToken.text() removed because redundant

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ParserToken.java
@@ -42,11 +42,6 @@ public interface ParserToken extends HasText, HasSearchNode {
     }
 
     /**
-     * Returns the raw text that produced the token.
-     */
-    String text();
-
-    /**
      * Only returns true for noise tokens like whitespace.
      */
     default boolean isNoise() {


### PR DESCRIPTION
- ParserToken already implements HasText