### PR TITLE
TextProperties.replace keeps parent fix.

### DIFF
--- a/src/main/java/walkingkooka/tree/text/EmptyTextProperties.java
+++ b/src/main/java/walkingkooka/tree/text/EmptyTextProperties.java
@@ -31,9 +31,16 @@ import java.util.Optional;
 final class EmptyTextProperties extends TextProperties {
 
     /**
-     * Singleton
+     * Singleton necessary to avoid race conditions to a init'd static field
      */
-    final static EmptyTextProperties INSTANCE = new EmptyTextProperties();
+    final static EmptyTextProperties instance() {
+        if (null == instance) {
+            instance = new EmptyTextProperties();
+        }
+        return instance;
+    }
+
+    private static EmptyTextProperties instance;
 
     /**
      * Private ctor

--- a/src/main/java/walkingkooka/tree/text/TextLeafNode.java
+++ b/src/main/java/walkingkooka/tree/text/TextLeafNode.java
@@ -55,8 +55,9 @@ abstract class TextLeafNode<V> extends TextNode implements Value<V> {
     }
 
     final TextLeafNode<V> replaceValue(final V value) {
-        return this.replace1(this.index, value)
-                .replaceChild(this.parent())
+        final int index = this.index;
+        return this.replace1(index, value)
+                .replaceChild(this.parent(), index)
                 .cast();
     }
 
@@ -88,8 +89,8 @@ abstract class TextLeafNode<V> extends TextNode implements Value<V> {
     }
 
     @Override
-    final TextNode setChild(final TextNode newChild) {
-        return NeverError.unexpectedMethodCall(this, "setChild", newChild);
+    final TextNode setChild(final TextNode newChild, final int index) {
+        return NeverError.unexpectedMethodCall(this, "setChild", newChild, index);
     }
 
     // attributes.......................................................................................................
@@ -105,7 +106,7 @@ abstract class TextLeafNode<V> extends TextNode implements Value<V> {
     }
 
     @Override
-    final TextPropertiesNode setAttributesNonEmptyTextPropertiesMap(final TextPropertiesMap textPropertiesMap) {
+    final TextNode setAttributesNonEmptyTextPropertiesMap(final TextPropertiesMap textPropertiesMap) {
         return this.setAttributesNonEmptyTextPropertiesMap0(textPropertiesMap);
     }
 

--- a/src/main/java/walkingkooka/tree/text/TextNode.java
+++ b/src/main/java/walkingkooka/tree/text/TextNode.java
@@ -134,18 +134,19 @@ public abstract class TextNode implements Node<TextNode, TextNodeName, TextPrope
      * Sub classes must create a new copy of the parent and replace the identified child using its index or similar,
      * and also sets its parent after creation, returning the equivalent child at the same index.
      */
-    abstract TextNode setChild(final TextNode newChild);
+    abstract TextNode setChild(final TextNode newChild, final int index);
 
     /**
      * Only ever called after during the completion of a setChildren, basically used to recreate the parent graph
      * containing this child.
      */
-    final TextNode replaceChild(final Optional<TextNode> previousParent) {
+    final TextNode replaceChild(final Optional<TextNode> previousParent,
+                                final int childIndex) {
         return previousParent.isPresent() ?
                 previousParent.get()
-                        .setChild(this)
+                        .setChild(this, childIndex)
                         .children()
-                        .get(this.index()) :
+                        .get(childIndex) :
                 this;
     }
 
@@ -185,13 +186,15 @@ public abstract class TextNode implements Node<TextNode, TextNodeName, TextPrope
     /**
      * Factory that accepts a non empty {@link TextPropertiesNode} either wrapping or replacing (for {@link TextPropertiesNode}.
      */
-    abstract TextPropertiesNode setAttributesNonEmptyTextPropertiesMap(final TextPropertiesMap textPropertiesMap);
+    abstract TextNode setAttributesNonEmptyTextPropertiesMap(final TextPropertiesMap textPropertiesMap);
 
     /**
      * Default for all sub classes except for {@link TextPropertiesNode}.
      */
-    final TextPropertiesNode setAttributesNonEmptyTextPropertiesMap0(final TextPropertiesMap textPropertiesMap) {
-        return TextPropertiesNode.with(Lists.of(this), textPropertiesMap);
+    final TextNode setAttributesNonEmptyTextPropertiesMap0(final TextPropertiesMap textPropertiesMap) {
+        return TextPropertiesNode.with(Lists.of(this), textPropertiesMap)
+                .replaceChild(this.parent(), this.index)
+                .children().get(0);
     }
 
     // is...............................................................................................................

--- a/src/main/java/walkingkooka/tree/text/TextParentNode.java
+++ b/src/main/java/walkingkooka/tree/text/TextParentNode.java
@@ -83,15 +83,15 @@ abstract class TextParentNode extends TextNode {
     }
 
     @Override
-    final TextNode setChild(final TextNode newChild) {
-        final int index = newChild.index();
+    final TextNode setChild(final TextNode newChild, final int index) {
+        //int index = newChild.index();
         final TextNode previous = this.children().get(index);
         return previous.equalsIgnoringParentAndChildren(newChild) && previous.equalsDescendants(newChild) ?
                 this :
                 this.replaceChild0(newChild, index);
     }
 
-    private TextNode replaceChild0(final TextNode newChild, final int index) {
+    final TextNode replaceChild0(final TextNode newChild, final int index) {
         final List<TextNode> newChildren = Lists.array();
         newChildren.addAll(this.children());
         newChildren.set(index, newChild);
@@ -100,8 +100,9 @@ abstract class TextParentNode extends TextNode {
     }
 
     private TextParentNode replaceChildren(final List<TextNode> children) {
-        return this.replace0(this.index, children)
-                .replaceChild(this.parent())
+        final int index = this.index;
+        return this.replace0(index, children)
+                .replaceChild(this.parent(), index)
                 .cast();
     }
 

--- a/src/main/java/walkingkooka/tree/text/TextProperties.java
+++ b/src/main/java/walkingkooka/tree/text/TextProperties.java
@@ -42,7 +42,7 @@ public abstract class TextProperties implements HashCodeEqualsDefined,
     /**
      * A {@link TextProperties} with no properties.
      */
-    public static TextProperties EMPTY = EmptyTextProperties.INSTANCE;
+    public final static TextProperties EMPTY = EmptyTextProperties.instance();
 
     /**
      * Factory that creates a {@link TextProperties} from a {@link Map}.

--- a/src/main/java/walkingkooka/tree/text/TextPropertiesNode.java
+++ b/src/main/java/walkingkooka/tree/text/TextPropertiesNode.java
@@ -226,7 +226,8 @@ public final class TextPropertiesNode extends TextParentNode {
 
     @Override
     boolean equalsIgnoringParentAndChildren(final TextNode other) {
-        return this.equalsIgnoringParentAndChildren0(Cast.to(other));
+        return other instanceof TextPropertiesNode &&
+                this.equalsIgnoringParentAndChildren0(Cast.to(other));
     }
 
     private boolean equalsIgnoringParentAndChildren0(final TextPropertiesNode other) {

--- a/src/main/java/walkingkooka/tree/text/TextStyledNode.java
+++ b/src/main/java/walkingkooka/tree/text/TextStyledNode.java
@@ -118,7 +118,7 @@ public final class TextStyledNode extends TextParentNode {
     }
 
     @Override
-    final TextPropertiesNode setAttributesNonEmptyTextPropertiesMap(final TextPropertiesMap textPropertiesMap) {
+    final TextNode setAttributesNonEmptyTextPropertiesMap(final TextPropertiesMap textPropertiesMap) {
         return this.setAttributesNonEmptyTextPropertiesMap0(textPropertiesMap);
     }
 
@@ -220,7 +220,8 @@ public final class TextStyledNode extends TextParentNode {
 
     @Override
     boolean equalsIgnoringParentAndChildren(final TextNode other) {
-        return this.equalsIgnoringParentAndChildren0(Cast.to(other));
+        return other instanceof TextStyledNode &&
+                this.equalsIgnoringParentAndChildren0(Cast.to(other));
     }
 
     private boolean equalsIgnoringParentAndChildren0(final TextStyledNode other) {

--- a/src/test/java/walkingkooka/tree/text/EmptyTextPropertiesTest.java
+++ b/src/test/java/walkingkooka/tree/text/EmptyTextPropertiesTest.java
@@ -19,11 +19,9 @@
 package walkingkooka.tree.text;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.collect.list.Lists;
+import walkingkooka.Cast;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.tree.json.JsonNode;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -31,15 +29,25 @@ public final class EmptyTextPropertiesTest extends TextPropertiesTestCase<EmptyT
 
     @Test
     public void testEmpty() {
-        assertSame(EmptyTextProperties.INSTANCE, TextProperties.with(Maps.empty()));
+        assertSame(TextProperties.EMPTY, TextProperties.with(Maps.empty()));
     }
 
     @Test
     public void testValue() {
-        assertSame(EmptyTextProperties.INSTANCE.value(), EmptyTextProperties.INSTANCE.value());
+        assertSame(TextProperties.EMPTY.value(), TextProperties.EMPTY.value());
     }
 
     // replace...........................................................................................................
+
+    @Test
+    public void testReplaceTextPlaceholderNode() {
+        this.replaceAndCheck2(this.placeholder("place1"));
+    }
+
+    @Test
+    public void testReplaceTextPlaceholderNodeWithParent() {
+        this.replaceAndCheck2(setStyledParent(this.placeholder("child-place1")));
+    }
 
     @Test
     public void testReplaceTextProperties() {
@@ -50,13 +58,18 @@ public final class EmptyTextPropertiesTest extends TextPropertiesTestCase<EmptyT
     public void testReplaceTextProperties2() {
         final TextPropertiesNode node = TextNode.properties(children());
 
-        this.replaceAndCheck(EmptyTextProperties.INSTANCE,
+        this.replaceAndCheck(TextProperties.EMPTY,
                 node.setAttributes(Maps.of(TextPropertyName.FONT_STYLE, FontStyle.ITALIC)),
                 node);
     }
 
-    private List<TextNode> children() {
-        return Lists.of(TextNode.text("a1"), TextNode.text("b2"));
+    @Test
+    public void testReplaceTextPropertiesNodeWithParent() {
+        final TextPropertiesNode textPropertiesNode = TextNode.properties(this.children());
+
+        this.replaceAndCheck(TextProperties.EMPTY,
+                setStyledParent(textPropertiesNode.setAttributes(Maps.of(TextPropertyName.FONT_STYLE, FontStyle.ITALIC))),
+                setStyledParent(textPropertiesNode));
     }
 
     @Test
@@ -65,17 +78,24 @@ public final class EmptyTextPropertiesTest extends TextPropertiesTestCase<EmptyT
     }
 
     @Test
+    public void testReplaceTextStyleWithParent() {
+        final TextStyledNode styled = setStyledParent(this.styled("child-style-456"));
+
+        this.replaceAndCheck2(styled);
+    }
+
+    @Test
     public void testReplaceText() {
         this.replaceAndCheck2(TextNode.text("abc123"));
     }
 
     @Test
-    public void testReplaceTextPlaceholder() {
-        this.replaceAndCheck2(TextNode.placeholder(TextPlaceholderName.with("placeholder123")));
+    public void testReplaceTextWithParent() {
+        this.replaceAndCheck2(setStyledParent(TextNode.text("child-abc123")));
     }
 
     private void replaceAndCheck2(final TextNode textNode) {
-        this.replaceAndCheck(EmptyTextProperties.INSTANCE, textNode);
+        this.replaceAndCheck(TextProperties.EMPTY, textNode);
     }
 
     // set..............................................................................................................
@@ -85,7 +105,7 @@ public final class EmptyTextPropertiesTest extends TextPropertiesTestCase<EmptyT
         final TextPropertyName<FontFamilyName> propertyName = TextPropertyName.FONT_FAMILY_NAME;
         final FontFamilyName familyName = FontFamilyName.with("Antiqua");
 
-        this.setAndCheck(EmptyTextProperties.INSTANCE,
+        this.setAndCheck(TextProperties.EMPTY,
                 propertyName,
                 familyName,
                 TextProperties.with(Maps.of(propertyName, familyName)));
@@ -93,7 +113,7 @@ public final class EmptyTextPropertiesTest extends TextPropertiesTestCase<EmptyT
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(EmptyTextProperties.INSTANCE, "{}");
+        this.toStringAndCheck(TextProperties.EMPTY, "{}");
     }
 
     @Test
@@ -103,7 +123,7 @@ public final class EmptyTextPropertiesTest extends TextPropertiesTestCase<EmptyT
 
     @Override
     public EmptyTextProperties createObject() {
-        return EmptyTextProperties.INSTANCE;
+        return Cast.to(TextProperties.EMPTY);
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/text/NonEmptyTextPropertiesTest.java
+++ b/src/test/java/walkingkooka/tree/text/NonEmptyTextPropertiesTest.java
@@ -98,13 +98,41 @@ public final class NonEmptyTextPropertiesTest extends TextPropertiesTestCase<Non
                 TextNode.properties(children));
     }
 
-    private List<TextNode> children() {
-        return Lists.of(TextNode.text("a1"), TextNode.text("b2"));
+    @Test
+    public void testReplaceTextPropertiesWithParent() {
+        final TextPropertiesNode textPropertiesNode = TextNode.properties(this.children());
+
+        final TextProperties textProperties = this.createTextProperties(this.property2(), this.value2());
+
+        this.replaceAndCheck(textProperties,
+                this.setStyledParent(textPropertiesNode),
+                this.setStyledParent(textPropertiesNode.setAttributes(textProperties.value())));
+    }
+
+    @Test
+    public void testReplaceTextPropertiesWithParent2() {
+        final TextPropertiesNode textPropertiesNode = TextNode.properties(this.children());
+
+        final TextProperties textProperties = this.createTextProperties(this.property2(), this.value2());
+
+        this.replaceAndCheck(textProperties,
+                this.setStyledParent(textPropertiesNode.setAttributes(Maps.of(this.property1(), this.value1()))),
+                this.setStyledParent(textPropertiesNode.setAttributes(textProperties.value())));
     }
 
     @Test
     public void testReplaceTextStyled() {
-        this.replaceAndCheck2(TextNode.styled(TextStyleName.with("style123")));
+        this.replaceAndCheck2(this.styled("style123"));
+    }
+
+    @Test
+    public void testReplaceTextStyledWithParent() {
+        final TextStyledNode styledNode = this.styled("child-style123");
+        final TextProperties  textProperties = this.createTextProperties();
+
+        this.replaceAndCheck(textProperties,
+                this.setStyledParent(styledNode),
+                this.setStyledParent(TextNode.properties(Lists.of(styledNode)).setAttributes(textProperties.value())).children().get(0));
     }
 
     @Test
@@ -113,8 +141,26 @@ public final class NonEmptyTextPropertiesTest extends TextPropertiesTestCase<Non
     }
 
     @Test
+    public void testReplaceTextWithParent() {
+        this.replaceAndCheck3(TextNode.text("child-abc123"));
+    }
+
+    @Test
     public void testReplaceTextPlaceholder() {
-        this.replaceAndCheck2(TextNode.placeholder(TextPlaceholderName.with("placeholder123")));
+        this.replaceAndCheck2(this.placeholder("placeholder123"));
+    }
+
+    @Test
+    public void testReplaceTextPlaceholderWithParent() {
+        this.replaceAndCheck3(this.placeholder("child-placeholder123"));
+    }
+
+    private void replaceAndCheck3(final TextNode textNode) {
+        final TextProperties textProperties = this.createTextProperties();
+
+        this.replaceAndCheck(textProperties,
+                this.setStyledParent(textNode),
+                this.setStyledParent(TextNode.properties(Lists.of(textNode)).setAttributes(textProperties.value())).children().get(0));
     }
 
     private void replaceAndCheck2(final TextNode textNode) {
@@ -122,7 +168,7 @@ public final class NonEmptyTextPropertiesTest extends TextPropertiesTestCase<Non
 
         this.replaceAndCheck(textProperties,
                 textNode,
-                TextNode.properties(Lists.of(textNode)).setAttributes(textProperties.value()));
+                TextNode.properties(Lists.of(textNode)).setAttributes(textProperties.value()).children().get(0));
     }
 
     // get..............................................................................................................

--- a/src/test/java/walkingkooka/tree/text/TextNodeTestCase2.java
+++ b/src/test/java/walkingkooka/tree/text/TextNodeTestCase2.java
@@ -58,14 +58,14 @@ public abstract class TextNodeTestCase2<N extends TextNode> extends TextNodeTest
     }
 
     final void setAttributeNotEmptyAndCheck() {
-        final N child = this.createTextNode();
+        final N before = this.createTextNode();
         final Map<TextPropertyName<?>, Object> attributes = Maps.of(TextPropertyName.FONT_STYLE, FontStyle.ITALIC);
-        final TextNode parent = child.setAttributes(attributes);
-        assertNotSame(parent, child);
+        final TextNode after = before.setAttributes(attributes);
+        assertNotSame(after, before);
 
-        final TextPropertiesNode textPropertiesNode = Cast.to(parent);
-        this.childCountCheck(parent, child);
-        assertEquals(attributes, textPropertiesNode.attributes(), "attributes");
+        final TextPropertiesNode parent = after.parentOrFail().cast();
+        this.childCountCheck(parent, before);
+        assertEquals(attributes, parent.attributes(), "attributes");
     }
 
     // HasTextOffset .....................................................................................................

--- a/src/test/java/walkingkooka/tree/text/TextPropertiesTestCase.java
+++ b/src/test/java/walkingkooka/tree/text/TextPropertiesTestCase.java
@@ -20,6 +20,7 @@ package walkingkooka.tree.text;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.test.ClassTesting2;
 import walkingkooka.test.HashCodeEqualsDefinedTesting;
 import walkingkooka.test.ToStringTesting;
@@ -28,6 +29,7 @@ import walkingkooka.tree.json.HasJsonNodeTesting;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.type.MemberVisibility;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -149,6 +151,28 @@ public abstract class TextPropertiesTestCase<T extends TextProperties> implement
                 removed,
                 () -> properties + " remove " + propertyName);
         return removed;
+    }
+
+    // helpers .........................................................................................................
+
+    final <T extends TextNode> T setStyledParent(final T child) {
+        return this.styled("parent-style-123")
+                .setChildren(Lists.of(child))
+                .children()
+                .get(0)
+                .cast();
+    }
+
+    final TextPlaceholderNode placeholder(final String placeholderName) {
+        return TextNode.placeholder(TextPlaceholderName.with(placeholderName));
+    }
+
+    final TextStyledNode styled(final String styleName) {
+        return TextNode.styled(TextStyleName.with(styleName));
+    }
+
+    final List<TextNode> children() {
+        return Lists.of(TextNode.text("a1"), TextNode.text("b2"));
     }
 
     // ClassTesting.....................................................................................................


### PR DESCRIPTION
- Added instanceof guard to each TextNode.equalsIgnoringParentAndChildren
- EmptyTextProperties.instance() lazy getter replace field, solves race causing nulls.

Closes #1598 