### PR TITLE
StringLocalDateDateTimeFormatterConverterTest DateTimeFormatter fix

### DIFF
--- a/src/main/java/walkingkooka/convert/StringLocalDateDateTimeFormatterConverter.java
+++ b/src/main/java/walkingkooka/convert/StringLocalDateDateTimeFormatterConverter.java
@@ -49,6 +49,6 @@ final class StringLocalDateDateTimeFormatterConverter extends DateTimeFormatterC
 
     @Override
     LocalDate convert3(final String value) throws DateTimeParseException {
-        return LocalDate.parse(value);
+        return LocalDate.parse(value, this.formatter);
     }
 }

--- a/src/test/java/walkingkooka/convert/StringLocalDateDateTimeFormatterConverterTest.java
+++ b/src/test/java/walkingkooka/convert/StringLocalDateDateTimeFormatterConverterTest.java
@@ -26,7 +26,15 @@ public final class StringLocalDateDateTimeFormatterConverterTest extends DateTim
 
     @Test
     public void testConvert() {
-        this.convertAndCheck("2000-01-31", LocalDate.of(2000, 1, 31));
+        this.convertAndCheck("01 2000 31", LocalDate.of(2000, 1, 31));
+    }
+
+    @Test
+    public void testConvert2() {
+        this.convertAndCheck(StringLocalDateDateTimeFormatterConverter.with(DateTimeFormatter.ofPattern("yyyy dd MM")),
+                "2000 31 01",
+                LocalDate.class,
+                LocalDate.of(2000, 1, 31));
     }
 
     @Override
@@ -36,7 +44,7 @@ public final class StringLocalDateDateTimeFormatterConverterTest extends DateTim
 
     @Override
     DateTimeFormatter formatter() {
-        return DateTimeFormatter.ISO_LOCAL_DATE;
+        return DateTimeFormatter.ofPattern("MM yyyy dd");
     }
 
     @Override


### PR DESCRIPTION
- previously ignoring DateTimeFormatter, assuming default LocalDate.parse(String)