### PR TITLE
FailedConversionException includes value and targetType

### DIFF
--- a/src/main/java/walkingkooka/convert/Converter.java
+++ b/src/main/java/walkingkooka/convert/Converter.java
@@ -17,8 +17,6 @@
 
 package walkingkooka.convert;
 
-import walkingkooka.text.CharSequences;
-
 /**
  * Converts object instances to a requested target {@link Class type}.
  */
@@ -41,11 +39,11 @@ public interface Converter {
     }
 
     default <TT> TT failConversion(final Object value, final Class<TT> target) {
-        throw new ConversionException("Failed to convert " + value.getClass().getName() + "=" + CharSequences.quoteIfChars(value) + " to " + target.getName());
+        throw new FailedConversionException(value, target);
     }
 
     default <TT> TT failConversion(final Object value, final Class<TT> target, final Throwable cause) {
-        throw new ConversionException("Failed to convert " + value.getClass().getName() + "=" + CharSequences.quoteIfChars(value) + " to " + target.getName() + ", message: " + cause.getMessage(), cause);
+        throw new FailedConversionException(value, target, cause);
     }
 
     default Converter setToString(final String toString) {

--- a/src/main/java/walkingkooka/convert/ConverterTesting.java
+++ b/src/main/java/walkingkooka/convert/ConverterTesting.java
@@ -62,6 +62,10 @@ public interface ConverterTesting<C extends Converter> {
         try {
             final Object result = converter.convert(value, type, context);
             fail("Expected " + converter + " with " + CharSequences.quoteIfChars(value) + " to " + type.getName() + " to fail but got " + CharSequences.quoteIfChars(result));
+
+        } catch (final FailedConversionException failed) {
+            assertEquals(value, failed.value(), () -> failed.getMessage());
+            assertEquals(type, failed.targetType(), () -> failed.getMessage());
         } catch (final ConversionException ignored) {
         }
     }

--- a/src/main/java/walkingkooka/convert/FailedConversionException.java
+++ b/src/main/java/walkingkooka/convert/FailedConversionException.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.convert;
+
+import walkingkooka.text.CharSequences;
+
+import java.util.Objects;
+
+/**
+ * A {@link ConversionException} that also includes the source {@link Object value} and {@link Class target type} as properties.
+ */
+public class FailedConversionException extends ConversionException {
+
+    private static final long serialVersionUID = 1;
+
+    public FailedConversionException(final Object value,
+                                     final Class<?> targetType) {
+        super(buildMessage(value, targetType));
+
+        this.value = value;
+        this.targetType = targetType;
+    }
+
+    public FailedConversionException(final Object value,
+                                     final Class<?> targetType,
+                                     final Throwable cause) {
+        super(buildMessage(value, targetType), cause);
+
+        this.value = value;
+        this.targetType = targetType;
+    }
+
+    private static String buildMessage(final Object value,
+                                       final Class<?> targetType) {
+        Objects.requireNonNull(targetType, "targetType");
+
+        return "Failed to convert " + CharSequences.quoteIfChars(value) +
+                (null == value ? "" : " (" + value.getClass().getName() + ")") +
+                " to " + targetType.getName();
+    }
+
+    public Object value() {
+        return this.value;
+    }
+
+    private final Object value;
+
+    public Class<?> targetType() {
+        return this.targetType;
+    }
+
+    private final Class<?> targetType;
+}

--- a/src/test/java/walkingkooka/convert/FailedConversionExceptionTest.java
+++ b/src/test/java/walkingkooka/convert/FailedConversionExceptionTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.convert;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.test.ThrowableTesting2;
+import walkingkooka.type.JavaVisibility;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public final class FailedConversionExceptionTest implements ThrowableTesting2<FailedConversionException> {
+
+    @Test
+    public void testWithNullTargetTypeFails() {
+        assertThrows(NullPointerException.class, () -> {
+            new FailedConversionException("value", null);
+        });
+    }
+
+    @Test
+    public void testWithNullTargetTypeAndThrowableFails() {
+        assertThrows(NullPointerException.class, () -> {
+            new FailedConversionException("value", null, new Exception("cause"));
+        });
+    }
+
+    @Test
+    public void testWithNullThrowableFails() {
+        assertThrows(NullPointerException.class, () -> {
+            new FailedConversionException("value", Void.class, null);
+        });
+    }
+
+    @Test
+    public void testMessage() {
+        this.checkMessage(new FailedConversionException("abc123", BigDecimal.class),
+                "Failed to convert \"abc123\" (java.lang.String) to java.math.BigDecimal");
+    }
+
+    @Test
+    public void testMessage2() {
+        this.checkMessage(new FailedConversionException(1234.5, Byte.class),
+                "Failed to convert 1234.5 (java.lang.Double) to java.lang.Byte");
+    }
+
+    @Test
+    public void testMessageWithCause() {
+        this.checkMessage(new FailedConversionException("abc123", BigDecimal.class, new Exception("cause")),
+                "Failed to convert \"abc123\" (java.lang.String) to java.math.BigDecimal");
+    }
+
+    @Override
+    public Class<FailedConversionException> type() {
+        return FailedConversionException.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+}


### PR DESCRIPTION
- sub class of ConversionException.
- includes failed value and targettype as properties.
- Converter.failConversion helpers now throw FailedConversionException.

- Closes #1949 