### PR TITLE
AmericanDecimalNumberContext.locale() -> Locale.US

### DIFF
--- a/src/main/java/walkingkooka/math/AmericanDecimalNumberContext.java
+++ b/src/main/java/walkingkooka/math/AmericanDecimalNumberContext.java
@@ -97,7 +97,7 @@ final class AmericanDecimalNumberContext implements DecimalNumberContext {
 
     @Override
     public Locale locale() {
-        throw new UnsupportedOperationException();
+        return Locale.US;
     }
 
     @Override

--- a/src/test/java/walkingkooka/math/AmericanDecimalNumberContextTest.java
+++ b/src/test/java/walkingkooka/math/AmericanDecimalNumberContextTest.java
@@ -22,6 +22,7 @@ import walkingkooka.test.ClassTesting2;
 import walkingkooka.type.JavaVisibility;
 
 import java.math.MathContext;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -86,10 +87,8 @@ public final class AmericanDecimalNumberContextTest implements ClassTesting2<Ame
     }
 
     @Test
-    public void testLocaleFails() {
-        assertThrows(UnsupportedOperationException.class, () -> {
-            this.createContext().locale();
-        });
+    public void testLocale() {
+        this.hasLocaleAndCheck(this.createContext(), Locale.US);
     }
 
     @Test


### PR DESCRIPTION
- previously threw UnsupportedOperationException.