### PR TITLE
Arrays.copyOf replace array clone calls

### DIFF
--- a/src/main/java/walkingkooka/Binary.java
+++ b/src/main/java/walkingkooka/Binary.java
@@ -40,7 +40,7 @@ public final class Binary implements Value<byte[]> {
     public static Binary with(final byte[] value) {
         Objects.requireNonNull(value, "value");
 
-        return value.length == 0 ? EMPTY : new Binary(value.clone());
+        return value.length == 0 ? EMPTY : new Binary(Arrays.copyOf(value, value.length));
     }
 
     private Binary(final byte[] value) {
@@ -50,7 +50,7 @@ public final class Binary implements Value<byte[]> {
 
     @Override
     public byte[] value() {
-        return value.clone();
+        return Arrays.copyOf(this.value, this.value.length);
     }
 
     // BinaryRangeVisitor

--- a/src/main/java/walkingkooka/collect/iterator/ArrayIterator.java
+++ b/src/main/java/walkingkooka/collect/iterator/ArrayIterator.java
@@ -33,7 +33,7 @@ final class ArrayIterator<T> implements Iterator<T> {
     static <T> ArrayIterator<T> with(final T... items) {
         Objects.requireNonNull(items, "items");
 
-        return new ArrayIterator<>(items.clone());
+        return new ArrayIterator<>(Arrays.copyOf(items, items.length));
     }
 
     /**

--- a/src/main/java/walkingkooka/collect/iterator/ChainIterator.java
+++ b/src/main/java/walkingkooka/collect/iterator/ChainIterator.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.collect.iterator;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -38,7 +39,7 @@ final class ChainIterator<E> implements Iterator<E> {
 
         return iterators.length == 0 ?
                 first :
-                new ChainIterator<>(first, iterators.clone());
+                new ChainIterator<>(first, Arrays.copyOf(iterators, iterators.length));
     }
 
     /**

--- a/src/main/java/walkingkooka/collect/list/Lists.java
+++ b/src/main/java/walkingkooka/collect/list/Lists.java
@@ -94,7 +94,7 @@ final public class Lists implements PublicStaticHelper {
      */
     @SafeVarargs
     public static <T> List<T> of(final T... items) {
-        return ImmutableList.select(Arrays.asList(items.clone()));
+        return ImmutableList.select(Arrays.asList(Arrays.copyOf(items, items.length)));
     }
 
     /**


### PR DESCRIPTION
- Necessary because array.clone() is not supported by j2cl jre.