### PR TITLE
j2cl-uber replaces google N vertispan equvialent dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,24 +88,22 @@
     </repositories>
 
     <dependencies>
-        <!-- j2cl compile dependencies -->
         <dependency>
-            <groupId>com.google.jsinterop</groupId>
-            <artifactId>jsinterop-annotations</artifactId>
-            <version>2.0.0</version>
+            <groupId>walkingkooka</groupId>
+            <artifactId>j2cl-uber</artifactId>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.vertispan.jsinterop</groupId>
-            <artifactId>base</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
-        </dependency>
-
-        <!-- junit dependencies, excluded for j2cl transpile-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.4.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opentest4j</groupId>
+            <artifactId>opentest4j</artifactId>
+            <version>1.1.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
 Closes #2435 