### PR TITLE
Range.and compare rather than equals bounds

### DIFF
--- a/src/main/java/walkingkooka/collect/Range.java
+++ b/src/main/java/walkingkooka/collect/Range.java
@@ -187,11 +187,12 @@ public final class Range<C extends Comparable<C>> implements Predicate<C>,
 
         final RangeBound<C> lower = this.lower.max(other.lower);
         final RangeBound<C> upper = this.upper.min(other.upper);
-        return this.equals1(lower, upper) ?
+
+        return this.compareToEquals(lower, upper) ?
                 this :
-                other.equals1(lower, upper) ?
+                other.compareToEquals(lower, upper) ?
                         other :
-                        lower.equals(upper) ?
+                        lower.compareToEquals(upper) ?
                                 this.replace(lower, other) :
                                 this.replace0(lower, upper);
     }
@@ -297,6 +298,12 @@ public final class Range<C extends Comparable<C>> implements Predicate<C>,
     private boolean equals1(final RangeBound<?> lower, final RangeBound<?> upper) {
         return this.lower.equals(lower) &&
                 this.upper.equals(upper);
+    }
+
+    private boolean compareToEquals(final RangeBound<?> lower,
+                                    final RangeBound<?> upper) {
+        return this.lower.compareToEquals(lower) &&
+                this.upper.compareToEquals(upper);
     }
 
     @Override

--- a/src/main/java/walkingkooka/collect/RangeBound.java
+++ b/src/main/java/walkingkooka/collect/RangeBound.java
@@ -173,4 +173,10 @@ abstract public class RangeBound<C extends Comparable<C>> implements Value<Optio
 
     @Override
     public abstract boolean equals(final Object other);
+
+    /**
+     * Similar to {@link #equals(Object)} except the value is compared using {{@link Comparable#compareTo(Object)}} rather
+     * than equals.
+     */
+    abstract boolean compareToEquals(final RangeBound<?> other);
 }

--- a/src/main/java/walkingkooka/collect/RangeBoundAll.java
+++ b/src/main/java/walkingkooka/collect/RangeBoundAll.java
@@ -151,7 +151,14 @@ final class RangeBoundAll<C extends Comparable<C>> extends RangeBound<C> {
         return ">=" + upper.value;
     }
 
-    // Object.................................................................................................
+    // compareToEquals..................................................................................................
+
+    @Override
+    boolean compareToEquals(final RangeBound<?> other) {
+        return other instanceof RangeBoundAll;
+    }
+
+    // Object...........................................................................................................
 
     @Override
     public int hashCode() {

--- a/src/main/java/walkingkooka/collect/RangeBoundExclusive.java
+++ b/src/main/java/walkingkooka/collect/RangeBoundExclusive.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.collect;
 
+import walkingkooka.Cast;
+
 /**
  * Represents a exclusive value within a {@link Range}
  */
@@ -140,7 +142,7 @@ final class RangeBoundExclusive<C extends Comparable<C>> extends RangeBoundExclu
         return INCLUSIVE_OPEN + lower.value + BETWEEN + this.value + EXCLUSIVE_CLOSE;
     }
 
-    // Object....................................................................
+    // Object...........................................................................................................
 
     @Override
     boolean canBeEquals(final Object other) {

--- a/src/main/java/walkingkooka/collect/RangeBoundExclusiveInclusive.java
+++ b/src/main/java/walkingkooka/collect/RangeBoundExclusiveInclusive.java
@@ -42,6 +42,19 @@ abstract class RangeBoundExclusiveInclusive<C extends Comparable<C>> extends Ran
         return Optional.of(this.value);
     }
 
+    // compareToEquals..................................................................................................
+
+    @Override
+    final boolean compareToEquals(final RangeBound<?> other) {
+        return this == other ||
+                this.canBeEquals(other) &&
+                        this.compareToEquals0(Cast.to(other));
+    }
+
+    private boolean compareToEquals0(final RangeBoundExclusiveInclusive<C> other) {
+        return this.value.compareTo(other.value) == 0;
+    }
+
     // Object...........................................................................................................
 
     @Override

--- a/src/test/java/walkingkooka/collect/RangeTest.java
+++ b/src/test/java/walkingkooka/collect/RangeTest.java
@@ -73,10 +73,62 @@ public final class RangeTest implements ClassTesting2<Range<CaseInsensitiveStrin
 
     @Test
     public void testAndNullFails() {
-        assertThrows(NullPointerException.class, () -> this.createPredicate().and(null));
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createPredicate().and(null)
+        );
     }
 
-    // all ..............................................................................................
+    @Test
+    public void testAndSame() {
+        this.andAndCheck(
+                "a",
+                "a",
+                "a:a"
+        );
+    }
+
+    @Test
+    public void testAndSame2() {
+        this.andAndCheck(
+                "Z",
+                "Z",
+                "Z:Z"
+        );
+    }
+
+    @Test
+    public void testAndEquivalent() {
+        this.andAndCheck(
+                "a",
+                "A",
+                "a"
+        );
+    }
+
+    @Test
+    public void testAndEquivalent2() {
+        this.andAndCheck(
+                "A",
+                "a",
+                "A"
+        );
+    }
+
+    private void andAndCheck(final String left,
+                             final String and,
+                             final String expected) {
+        this.checkEquals(
+                this.parseString(expected),
+                this.parseString(left)
+                        .and(
+                                this.parseString(and)
+                        ),
+                () -> left + " and " + and
+        );
+    }
+
+    // all .............................................................................................................
 
     @Test
     public void testAll() {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka/issues/2532
- Range.and should use compare not equals of bounds.

- Closes https://github.com/mP1/walkingkooka/issues/2533
- Replace.replace should use compare rather than equals for bounds.