### PR TITLE
Raw parameter types SuppressWarnings

### DIFF
--- a/src/main/java/walkingkooka/collect/list/Lists.java
+++ b/src/main/java/walkingkooka/collect/list/Lists.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Vector;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiPredicate;
@@ -34,7 +35,10 @@ final public class Lists implements PublicStaticHelper {
     /**
      * Registers a {@link List} type as immutable.
      */
-    public static void registerImmutableType(final Class<? extends List<?>> type) {
+    @SuppressWarnings("rawtypes")
+    public static void registerImmutableType(final Class<? extends List> type) {
+        Objects.requireNonNull(type, "type");
+
         synchronized (ImmutableList.TYPES) {
             ImmutableList.TYPES.add(type);
         }

--- a/src/main/java/walkingkooka/collect/map/Maps.java
+++ b/src/main/java/walkingkooka/collect/map/Maps.java
@@ -42,7 +42,10 @@ final public class Maps implements PublicStaticHelper {
     /**
      * Registers a {@link Map} type as immutable.
      */
-    public static void registerImmutableType(final Class<? extends Map<?, ?>> type) {
+    @SuppressWarnings("rawtypes")
+    public static void registerImmutableType(final Class<Map> type) {
+        Objects.requireNonNull(type, "type");
+
         synchronized (ImmutableMap.TYPES) {
             ImmutableMap.TYPES.add(type);
         }

--- a/src/main/java/walkingkooka/collect/set/Sets.java
+++ b/src/main/java/walkingkooka/collect/set/Sets.java
@@ -35,7 +35,10 @@ final public class Sets implements PublicStaticHelper {
     /**
      * Registers a {@link Set} type as immutable.
      */
-    public static void registerImmutableType(final Class<? extends Set<?>> type) {
+    @SuppressWarnings("rawtypes")
+    public static void registerImmutableType(final Class<? extends Set> type) {
+        Objects.requireNonNull(type, "type");
+
         synchronized (ImmutableSet.TYPES) {
             ImmutableSet.TYPES.add(type);
         }

--- a/src/test/java/walkingkooka/collect/list/ListsTest.java
+++ b/src/test/java/walkingkooka/collect/list/ListsTest.java
@@ -28,7 +28,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -36,6 +35,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 final public class ListsTest implements PublicStaticHelperTesting<Lists>,
         IteratorTesting {
 
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void testRegisterImmutableTypeNullFails() {
+        final Class<List> type = null;
+
+        assertThrows(
+                NullPointerException.class,
+                () -> Lists.registerImmutableType(type)
+        );
+    }
+    
     @Test
     public void testArray() {
         final List<String> list = Lists.array();

--- a/src/test/java/walkingkooka/collect/map/MapsTest.java
+++ b/src/test/java/walkingkooka/collect/map/MapsTest.java
@@ -26,13 +26,24 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class MapsTest implements PublicStaticHelperTesting<Maps>,
         IteratorTesting {
 
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void testRegisterImmutableTypeNullFails() {
+        final Class<Map> type = null;
+
+        assertThrows(
+                NullPointerException.class,
+                () -> Maps.registerImmutableType(type)
+        );
+    }
+    
     final static String KEY1 = "a1";
     final static Integer VALUE1 = 111;
 

--- a/src/test/java/walkingkooka/collect/set/SetsTest.java
+++ b/src/test/java/walkingkooka/collect/set/SetsTest.java
@@ -25,13 +25,24 @@ import walkingkooka.reflect.PublicStaticHelperTesting;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class SetsTest implements PublicStaticHelperTesting<Sets> {
 
     // tests
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void testRegisterImmutableTypeNullFails() {
+        final Class<Set> type = null;
+
+        assertThrows(
+                NullPointerException.class,
+                () -> Sets.registerImmutableType(type)
+        );
+    }
 
     @Test
     public void testOfNullFails() {


### PR DESCRIPTION
- Previous type parameter declaration caused failures when invoked with raw types.