### PR TITLE
ToStringBuilderAppenderLongScalarTest test naming fix

### DIFF
--- a/src/test/java/walkingkooka/ToStringBuilderAppenderLongScalarTest.java
+++ b/src/test/java/walkingkooka/ToStringBuilderAppenderLongScalarTest.java
@@ -42,7 +42,7 @@ public final class ToStringBuilderAppenderLongScalarTest extends ToStringBuilder
     }
 
     @Test
-    public void testLongPrimitiveexWholeNumberWithAtoFLetters() {
+    public void testLongPrimitiveHexWholeNumberWithAtoFLetters() {
         final ToStringBuilder b = this.builder();
         b.enable(ToStringBuilderOption.HEX_WHOLE_NUMBERS);
 


### PR DESCRIPTION
- No logic changes, just a method rename.