### PR TITLE
CaseSensitivity private method @GwtIncompatible

### DIFF
--- a/src/main/java/walkingkooka/text/CaseSensitivity.java
+++ b/src/main/java/walkingkooka/text/CaseSensitivity.java
@@ -449,6 +449,7 @@ public enum CaseSensitivity {
                 .orElse(null);
     }
 
+    @GwtIncompatible
     private static CaseSensitivity fromSystemProperty0(final String systemPropertyValue) {
         return Boolean.parseBoolean(systemPropertyValue) ?
                 SENSITIVE :


### PR DESCRIPTION
- Not sure why but walkingkooka-spreadsheet/it-test/gwt-jar-test is failing with a NoClassDef SystemProperty, trying to really ignore all refs.