### PR TITLE
ParseStringTesting.parseString Function<String, T> overload

### DIFF
--- a/src/main/java/walkingkooka/HashCodeEqualsDefinedTesting.java
+++ b/src/main/java/walkingkooka/HashCodeEqualsDefinedTesting.java
@@ -27,11 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  */
 public interface HashCodeEqualsDefinedTesting extends Testing {
 
-    default void checkEquals(final Object expected, final Object actual) {
-        assertEquals(expected, actual);
-        assertEquals(actual, expected);
-    }
-
     default void checkEqualsAndHashCode(final Object expected, final Object actual) {
         checkEquals(expected, actual);
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka/issues/2757
- HashCodeEqualsDefinedTesting.checkEquals TreePrintableTesting TreePrintable support problems.