### PR TITLE
ImmutableSortedSetImpl.with copy comparator FIX

### DIFF
--- a/src/main/java/walkingkooka/collect/set/ImmutableSortedSetImpl.java
+++ b/src/main/java/walkingkooka/collect/set/ImmutableSortedSetImpl.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.collect.set;
 
-import walkingkooka.Cast;
 import walkingkooka.collect.iterator.Iterators;
 
 import java.util.AbstractSet;
@@ -37,11 +36,16 @@ final class ImmutableSortedSetImpl<E> extends AbstractSet<E> implements Immutabl
      * Returns a {@link ImmutableSortedSet} which is immutable including copying elements if necessary.
      */
     static <E> ImmutableSortedSet<E> with(final SortedSet<E> sortedSet) {
-        return sortedSet instanceof ImmutableSortedSet ?
-            Cast.to(sortedSet) :
-            new ImmutableSortedSetImpl<>(
-                new TreeSet<>(sortedSet)
-            );
+        ImmutableSortedSet<E> immutableSortedSet;
+
+        if (sortedSet instanceof ImmutableSortedSet) {
+            immutableSortedSet = (ImmutableSortedSet<E>) sortedSet;
+        } else {
+            final TreeSet<E> treeSet = new TreeSet<>(sortedSet.comparator());
+            treeSet.addAll(sortedSet);
+            immutableSortedSet = new ImmutableSortedSetImpl<>(treeSet);
+        }
+        return immutableSortedSet;
     }
 
     /**

--- a/src/test/java/walkingkooka/collect/set/ImmutableSortedSetImplTest.java
+++ b/src/test/java/walkingkooka/collect/set/ImmutableSortedSetImplTest.java
@@ -21,10 +21,46 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.iterator.IteratorTesting;
 
+import java.util.SortedSet;
 import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public final class ImmutableSortedSetImplTest implements ImmutableSortedSetTesting<ImmutableSortedSetImpl<String>, String>,
     IteratorTesting {
+
+    @Test
+    public void testWithNoComparator() {
+        final SortedSet<String> sortedSet = new TreeSet<>();
+        sortedSet.add("a1");
+        sortedSet.add("b2");
+
+        final ImmutableSortedSet<String> immutableSortedSet = ImmutableSortedSetImpl.with(sortedSet);
+        assertSame(
+            sortedSet.comparator(),
+            immutableSortedSet.comparator(),
+            "comparator"
+        );
+    }
+
+    @Test
+    public void testWithComparator() {
+        final SortedSet<String> sortedSet = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        sortedSet.add("a1");
+        sortedSet.add("b2");
+
+        final ImmutableSortedSet<String> immutableSortedSet = ImmutableSortedSetImpl.with(sortedSet);
+        assertSame(
+            sortedSet.comparator(),
+            immutableSortedSet.comparator(),
+            "comparator"
+        );
+
+        this.containsAndCheck(
+            immutableSortedSet,
+            "A1"
+        );
+    }
 
     @Test
     public void testConcat() {


### PR DESCRIPTION
- Previously when taking a defensive copy, the comparator from the source SortedSet was NOT copied.