### PR TITLE
Revert "NameTesting redundant Comparable type parameter removed"

### DIFF
--- a/src/main/java/walkingkooka/naming/NameTesting.java
+++ b/src/main/java/walkingkooka/naming/NameTesting.java
@@ -19,6 +19,7 @@ package walkingkooka.naming;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.CanBeEmptyTesting;
+import walkingkooka.Cast;
 import walkingkooka.HasValueTesting;
 import walkingkooka.ToStringTesting;
 import walkingkooka.compare.ComparableTesting2;
@@ -34,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Base class for testing a {@link Name} with mostly helpers to check construction failure.
  */
-public interface NameTesting<N extends Name & Comparable<N>> extends ComparableTesting2<N>,
+public interface NameTesting<N extends Name, C extends Comparable<C>> extends ComparableTesting2<C>,
     HasTextTesting,
     HasFileExtensionTesting,
     HasValueTesting,
@@ -83,8 +84,8 @@ public interface NameTesting<N extends Name & Comparable<N>> extends ComparableT
 
     N createName(final String name);
 
-    default N createComparable(final String name) {
-        return this.createName(name);
+    default C createComparable(final String name) {
+        return Cast.to(this.createName(name));
     }
 
     CaseSensitivity caseSensitivity();
@@ -119,8 +120,8 @@ public interface NameTesting<N extends Name & Comparable<N>> extends ComparableT
     default void testCompareDifferentCase() {
         final String value = this.nameText();
 
-        final N lower = this.createComparable(value.toLowerCase());
-        final N upper = this.createComparable(value.toUpperCase());
+        final C lower = this.createComparable(value.toLowerCase());
+        final C upper = this.createComparable(value.toUpperCase());
 
         if (this.caseSensitivity() == CaseSensitivity.INSENSITIVE) {
             this.compareToAndCheckEquals(
@@ -150,10 +151,8 @@ public interface NameTesting<N extends Name & Comparable<N>> extends ComparableT
     }
 
     @Override
-    default N createComparable() {
-        return this.createName(
-            this.nameText()
-        );
+    default C createComparable() {
+        return Cast.to(this.createName(this.nameText()));
     }
 
     // class............................................................................................................

--- a/src/main/java/walkingkooka/naming/NameTesting2.java
+++ b/src/main/java/walkingkooka/naming/NameTesting2.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Base class for testing a {@link Name} with mostly helpers to check construction failure.
  */
-public interface NameTesting2<N extends Name & Comparable<N>> extends NameTesting<N> {
+public interface NameTesting2<N extends Name, C extends Comparable<C>> extends NameTesting<N, C> {
 
     /**
      * All upper case ascii letters

--- a/src/main/java/walkingkooka/naming/ValueNameTesting.java
+++ b/src/main/java/walkingkooka/naming/ValueNameTesting.java
@@ -20,7 +20,7 @@ package walkingkooka.naming;
 /**
  * Base class for testing a {@link Name} with mostly helpers to check construction failure.
  */
-public interface ValueNameTesting<N extends ValueName<V> & Comparable<N>, V> extends NameTesting<N> {
+public interface ValueNameTesting<N extends ValueName<V>, C extends Comparable<C>, V> extends NameTesting<N, C> {
 
     default void typeAndCheck(final N name,
                               final V expected) {

--- a/src/test/java/walkingkooka/naming/StringNameTest.java
+++ b/src/test/java/walkingkooka/naming/StringNameTest.java
@@ -25,7 +25,7 @@ import walkingkooka.text.CaseSensitivity;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class StringNameTest implements ClassTesting2<StringName>,
-    NameTesting<StringName> {
+    NameTesting<StringName, StringName> {
 
     private final static String TEXT = "bcd123";
 

--- a/src/test/java/walkingkooka/reflect/JavaNameTestCase.java
+++ b/src/test/java/walkingkooka/reflect/JavaNameTestCase.java
@@ -24,7 +24,7 @@ import walkingkooka.text.CaseSensitivity;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-public abstract class JavaNameTestCase<N extends JavaName<N>> implements NameTesting2<N> {
+public abstract class JavaNameTestCase<N extends JavaName<N>> implements NameTesting2<N, N> {
 
     JavaNameTestCase() {
         super();


### PR DESCRIPTION
This reverts commit e33393d7d08c306d65151cb432a046f2ef0a225f.

- revert https://github.com/mP1/walkingkooka/pull/3076
- NameTesting redundant Comparable type parameter removed