### PR TITLE
FileExtension.parse hierarchical support

### DIFF
--- a/src/main/java/walkingkooka/io/FileExtension.java
+++ b/src/main/java/walkingkooka/io/FileExtension.java
@@ -20,7 +20,6 @@ package walkingkooka.io;
 import walkingkooka.CanBeEmpty;
 import walkingkooka.Cast;
 import walkingkooka.HasValue;
-import walkingkooka.InvalidCharacterException;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.text.CaseSensitivity;
 
@@ -128,17 +127,39 @@ public final class FileExtension implements
     public static FileExtension parse(final String value) {
         Objects.requireNonNull(value, "value");
 
+        return parseWithParent(
+            value,
+            NO_PARENT
+        );
+    }
+
+    private static FileExtension parseWithParent(final String value,
+                                                 final Optional<FileExtension> parent) {
+        Objects.requireNonNull(value, "value");
+
         FileExtension fileExtension = CONSTANTS.get(value);
         if (null == fileExtension) {
             final int dot = value.indexOf(SEPARATOR);
             if (dot != -1) {
-                throw new InvalidCharacterException(value, dot);
+                fileExtension = parseWithParent(
+                    value.substring(
+                        0,
+                        dot
+                    ),
+                    Optional.of(
+                        parse(
+                            value.substring(
+                                dot + 1
+                            )
+                        )
+                    )
+                );
+            } else {
+                fileExtension = new FileExtension(
+                    value,
+                    parent
+                );
             }
-
-            fileExtension = new FileExtension(
-                value,
-                NO_PARENT
-            );
         }
 
         return fileExtension;

--- a/src/test/java/walkingkooka/io/FileExtensionTest.java
+++ b/src/test/java/walkingkooka/io/FileExtensionTest.java
@@ -20,7 +20,6 @@ package walkingkooka.io;
 import org.junit.jupiter.api.Test;
 import walkingkooka.CanBeEmptyTesting;
 import walkingkooka.HasValueTesting;
-import walkingkooka.InvalidCharacterException;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.compare.ComparableTesting2;
@@ -151,14 +150,6 @@ public final class FileExtensionTest implements ComparableTesting2<FileExtension
 
     // parse............................................................................................................
 
-    @Test
-    public void testParseContainsDotFails() {
-        assertThrows(
-            InvalidCharacterException.class,
-            () -> FileExtension.parse("a.b")
-        );
-    }
-
     @Override
     public void testParseStringEmptyFails() {
         throw new UnsupportedOperationException();
@@ -214,6 +205,42 @@ public final class FileExtensionTest implements ComparableTesting2<FileExtension
         );
 
         this.parentAndCheck(fileExtension);
+    }
+
+    @Test
+    public void testParseWithDot() {
+        final String value = "bin1.bin2";
+        final FileExtension fileExtension = FileExtension.parse(value);
+        this.valueAndCheck(
+            fileExtension,
+            value
+        );
+
+        this.parentAndCheck(
+            fileExtension,
+            FileExtension.parse("bin2")
+        );
+    }
+
+    @Test
+    public void testParseWithDoubleDot() {
+        final String value = "bin1.bin2.bin3";
+        final FileExtension fileExtension = FileExtension.parse(value);
+        this.valueAndCheck(
+            fileExtension,
+            value
+        );
+
+        this.parentAndCheck(
+            fileExtension,
+            FileExtension.parse("bin2.bin3")
+        );
+
+        this.parentAndCheck(
+            fileExtension.parent()
+                .get(),
+            FileExtension.parse("bin3")
+        );
     }
 
     @Override


### PR DESCRIPTION
- Previously values with a dot that was not a constant would fail.